### PR TITLE
Supabase対応: Auth追加と案件/売上/経費のDB CRUD化

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,18 +1,22 @@
-const DATA_STORAGE_KEY = "gyosei-app-data-v3";
-const LEGACY_STORAGE_KEYS = ["gyosei-app-data-v2", "gyosei-cases"];
+const SUPABASE_URL = "https://ueelzyftlbnvjvpsmpyt.supabase.co";
+const SUPABASE_KEY = "sb_publishable_0DrKsieUcCyEZN_HRg8LhQ_QqFTPMtp";
 const STATUS_ORDER = ["未着手", "進行中", "完了"];
 
-const state = {
-  cases: [],
-  sales: [],
-  expenses: [],
-};
+const { createClient } = window.supabase;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
-const editState = {
-  caseId: null,
-  saleId: null,
-  expenseId: null,
-};
+const state = { cases: [], sales: [], expenses: [] };
+const editState = { caseId: null, saleId: null, expenseId: null };
+
+const authView = document.getElementById("auth-view");
+const appView = document.getElementById("app-view");
+const loadingOverlay = document.getElementById("loading-overlay");
+const authForm = document.getElementById("auth-form");
+const authMessage = document.getElementById("auth-message");
+const signupBtn = document.getElementById("signup-btn");
+const logoutBtn = document.getElementById("logout-btn");
+const userLabel = document.getElementById("user-label");
+const appMessage = document.getElementById("app-message");
 
 const tabs = Array.from(document.querySelectorAll(".tab-btn"));
 const panels = {
@@ -45,167 +49,233 @@ const caseItemTemplate = document.getElementById("case-item-template");
 const saleItemTemplate = document.getElementById("sale-item-template");
 const expenseItemTemplate = document.getElementById("expense-item-template");
 
+let currentUser = null;
+
 initialize();
 
-function initialize() {
-  const loaded = loadData();
-  state.cases = loaded.cases;
-  state.sales = loaded.sales;
-  state.expenses = loaded.expenses;
-
+async function initialize() {
   bindEvents();
-  renderCaseOptions();
-  renderCases();
-  renderSales();
-  renderExpenses();
-  renderDashboard();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  currentUser = session?.user ?? null;
+  await applyAuthState();
+
+  supabase.auth.onAuthStateChange(async (_event, sessionState) => {
+    currentUser = sessionState?.user ?? null;
+    await applyAuthState();
+  });
 }
 
 function bindEvents() {
-  tabs.forEach((btn) => {
-    btn.addEventListener("click", () => activateTab(btn.dataset.tab));
-  });
+  tabs.forEach((btn) => btn.addEventListener("click", () => activateTab(btn.dataset.tab)));
+  authForm.addEventListener("submit", handleLogin);
+  signupBtn.addEventListener("click", handleSignup);
+  logoutBtn.addEventListener("click", handleLogout);
 
   caseForm.addEventListener("submit", handleCaseSubmit);
   saleForm.addEventListener("submit", handleSaleSubmit);
   expenseForm.addEventListener("submit", handleExpenseSubmit);
 
-  clearBtn.addEventListener("click", () => {
-    if (!window.confirm("案件・売上・経費の全データを削除します。よろしいですか？")) return;
-    state.cases = [];
-    state.sales = [];
-    state.expenses = [];
-    resetEditMode("case");
-    resetEditMode("sale");
-    resetEditMode("expense");
-    saveData();
-    renderAfterDataChanged();
-  });
-
+  clearBtn.addEventListener("click", handleClearAll);
   caseList.addEventListener("click", handleCaseListAction);
   salesList.addEventListener("click", handleSalesListAction);
   expensesList.addEventListener("click", handleExpensesListAction);
 }
 
-function handleCaseSubmit(event) {
+async function applyAuthState() {
+  if (!currentUser) {
+    authView.hidden = false;
+    appView.hidden = true;
+    userLabel.textContent = "";
+    clearAppMessage();
+    return;
+  }
+
+  authView.hidden = true;
+  appView.hidden = false;
+  userLabel.textContent = currentUser.email || "ログイン中";
+
+  await withLoading(async () => {
+    await loadAllData();
+    resetCaseForm();
+    resetSaleForm();
+    resetExpenseForm();
+    renderAfterDataChanged();
+  }, "データの読み込みに失敗しました。テーブル設定を確認してください。");
+}
+
+async function handleLogin(event) {
   event.preventDefault();
+  const email = authForm.elements.email.value.trim();
+  const password = authForm.elements.password.value;
+  if (!email || !password) return;
+
+  await withLoading(async () => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+    showAuthMessage("ログインしました。", false);
+  }, "ログインに失敗しました。メールアドレスまたはパスワードを確認してください。", true);
+}
+
+async function handleSignup() {
+  const email = authForm.elements.email.value.trim();
+  const password = authForm.elements.password.value;
+  if (!email || !password) {
+    showAuthMessage("メールアドレスとパスワードを入力してください。", true);
+    return;
+  }
+
+  await withLoading(async () => {
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (error) throw error;
+    showAuthMessage("新規登録が完了しました。確認メールを確認してください。", false);
+  }, "新規登録に失敗しました。入力内容を確認してください。", true);
+}
+
+async function handleLogout() {
+  await withLoading(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) throw error;
+    showAuthMessage("ログアウトしました。", false);
+    authForm.reset();
+  }, "ログアウトに失敗しました。", true);
+}
+
+async function loadAllData() {
+  if (!currentUser) return;
+
+  const [casesRes, salesRes, expensesRes] = await Promise.all([
+    supabase.from("cases").select("*").eq("user_id", currentUser.id),
+    supabase.from("sales").select("*").eq("user_id", currentUser.id),
+    supabase.from("expenses").select("*").eq("user_id", currentUser.id),
+  ]);
+
+  if (casesRes.error) throw casesRes.error;
+  if (salesRes.error) throw salesRes.error;
+  if (expensesRes.error) throw expensesRes.error;
+
+  state.cases = (casesRes.data || []).map(mapCaseFromDb);
+  state.sales = (salesRes.data || []).map(mapSaleFromDb);
+  state.expenses = (expensesRes.data || []).map(mapExpenseFromDb);
+}
+
+async function refreshAfterMutation(successMessage) {
+  await loadAllData();
+  renderAfterDataChanged();
+  if (successMessage) showAppMessage(successMessage, false);
+}
+
+async function handleCaseSubmit(event) {
+  event.preventDefault();
+  if (!currentUser) return;
 
   const customerName = caseForm.elements.customerName.value.trim();
   const caseName = caseForm.elements.caseName.value.trim();
   if (!customerName || !caseName) return;
 
   const payload = {
-    customerName,
-    caseName,
-    estimateAmount: normalizeAmount(caseForm.elements.amount.value),
-    receivedDate: caseForm.elements.receivedDate.value || "",
-    dueDate: caseForm.elements.dueDate.value || "",
+    user_id: currentUser.id,
+    customer_name: customerName,
+    case_name: caseName,
+    estimate_amount: normalizeAmount(caseForm.elements.amount.value),
+    received_date: caseForm.elements.receivedDate.value || null,
+    due_date: caseForm.elements.dueDate.value || null,
     status: normalizeStatus(caseForm.elements.status.value),
-    updatedAt: Date.now(),
   };
 
-  if (editState.caseId) {
-    const index = state.cases.findIndex((item) => item.id === editState.caseId);
-    if (index !== -1) {
-      state.cases[index] = { ...state.cases[index], ...payload };
+  await withLoading(async () => {
+    if (editState.caseId) {
+      const { error } = await supabase.from("cases").update(payload).eq("id", editState.caseId).eq("user_id", currentUser.id);
+      if (error) throw error;
+      resetCaseForm();
+      await refreshAfterMutation("案件を更新しました。");
+      return;
     }
-  } else {
-    state.cases.push({
-      id: crypto.randomUUID(),
-      ...payload,
-      createdAt: Date.now(),
-    });
-  }
 
-  resetCaseForm();
-  saveData();
-  renderAfterDataChanged();
+    const { error } = await supabase.from("cases").insert(payload);
+    if (error) throw error;
+    resetCaseForm();
+    await refreshAfterMutation("案件を登録しました。");
+  }, "案件の保存に失敗しました。入力内容を確認してください。");
 }
 
-function handleSaleSubmit(event) {
+async function handleSaleSubmit(event) {
   event.preventDefault();
-  if (!state.cases.length) return;
+  if (!currentUser || !state.cases.length) return;
 
   const invoiceAmount = normalizeAmount(saleForm.elements.invoiceAmount.value);
   if (invoiceAmount === null) return;
 
   const paidAmount = normalizeAmount(saleForm.elements.paidAmount.value);
+  const caseId = saleCaseSelect.value;
+  if (!caseId) return;
 
   const payload = {
-    caseId: saleCaseSelect.value,
-    invoiceAmount,
-    paidAmount,
-    paidDate: saleForm.elements.paidDate.value || "",
-    isUnpaid: saleForm.elements.isUnpaid.checked || (paidAmount ?? 0) < invoiceAmount,
+    user_id: currentUser.id,
+    case_id: caseId,
+    invoice_amount: invoiceAmount,
+    paid_amount: paidAmount,
+    paid_date: saleForm.elements.paidDate.value || null,
+    is_unpaid: saleForm.elements.isUnpaid.checked || (paidAmount ?? 0) < invoiceAmount,
   };
 
-  if (!payload.caseId) return;
-
-  if (editState.saleId) {
-    const index = state.sales.findIndex((item) => item.id === editState.saleId);
-    if (index !== -1) {
-      state.sales[index] = {
-        ...state.sales[index],
-        ...payload,
-        updatedAt: Date.now(),
-      };
+  await withLoading(async () => {
+    if (editState.saleId) {
+      const { error } = await supabase.from("sales").update(payload).eq("id", editState.saleId).eq("user_id", currentUser.id);
+      if (error) throw error;
+      resetSaleForm();
+      await refreshAfterMutation("売上を更新しました。");
+      return;
     }
-  } else {
-    state.sales.push({
-      id: crypto.randomUUID(),
-      ...payload,
-      createdAt: Date.now(),
-    });
-  }
 
-  resetSaleForm();
-  saveData();
-  renderAfterDataChanged();
+    const { error } = await supabase.from("sales").insert(payload);
+    if (error) throw error;
+    resetSaleForm();
+    await refreshAfterMutation("売上を登録しました。");
+  }, "売上の保存に失敗しました。入力内容を確認してください。");
 }
 
-function handleExpenseSubmit(event) {
+async function handleExpenseSubmit(event) {
   event.preventDefault();
+  if (!currentUser) return;
 
   const date = expenseForm.elements.expenseDate.value;
   const content = expenseForm.elements.expenseContent.value.trim();
   const amount = normalizeAmount(expenseForm.elements.expenseAmount.value);
-
   if (!date || !content || amount === null) return;
 
   const payload = {
+    user_id: currentUser.id,
     date,
     content,
     amount,
-    caseId: expenseCaseSelect.value || null,
+    case_id: expenseCaseSelect.value || null,
   };
 
-  if (editState.expenseId) {
-    const index = state.expenses.findIndex((item) => item.id === editState.expenseId);
-    if (index !== -1) {
-      state.expenses[index] = {
-        ...state.expenses[index],
-        ...payload,
-        updatedAt: Date.now(),
-      };
+  await withLoading(async () => {
+    if (editState.expenseId) {
+      const { error } = await supabase.from("expenses").update(payload).eq("id", editState.expenseId).eq("user_id", currentUser.id);
+      if (error) throw error;
+      resetExpenseForm();
+      await refreshAfterMutation("経費を更新しました。");
+      return;
     }
-  } else {
-    state.expenses.push({
-      id: crypto.randomUUID(),
-      ...payload,
-      createdAt: Date.now(),
-    });
-  }
 
-  resetExpenseForm();
-  saveData();
-  renderAfterDataChanged();
+    const { error } = await supabase.from("expenses").insert(payload);
+    if (error) throw error;
+    resetExpenseForm();
+    await refreshAfterMutation("経費を登録しました。");
+  }, "経費の保存に失敗しました。入力内容を確認してください。");
 }
 
-function handleCaseListAction(event) {
+async function handleCaseListAction(event) {
   const btn = event.target;
   if (!(btn instanceof HTMLButtonElement)) return;
   const item = btn.closest(".item");
-  if (!item) return;
+  if (!item || !currentUser) return;
   const id = item.dataset.id;
 
   if (btn.classList.contains("edit-btn")) {
@@ -224,20 +294,21 @@ function handleCaseListAction(event) {
 
   if (btn.classList.contains("delete-btn")) {
     if (!window.confirm("この案件を削除しますか？関連する売上・経費も削除されます。")) return;
-    state.cases = state.cases.filter((entry) => entry.id !== id);
-    state.sales = state.sales.filter((entry) => entry.caseId !== id);
-    state.expenses = state.expenses.filter((entry) => entry.caseId !== id);
-    if (editState.caseId === id) resetCaseForm();
-    saveData();
-    renderAfterDataChanged();
+
+    await withLoading(async () => {
+      const { error } = await supabase.from("cases").delete().eq("id", id).eq("user_id", currentUser.id);
+      if (error) throw error;
+      if (editState.caseId === id) resetCaseForm();
+      await refreshAfterMutation("案件を削除しました。");
+    }, "案件の削除に失敗しました。");
   }
 }
 
-function handleSalesListAction(event) {
+async function handleSalesListAction(event) {
   const btn = event.target;
   if (!(btn instanceof HTMLButtonElement)) return;
   const item = btn.closest(".item");
-  if (!item) return;
+  if (!item || !currentUser) return;
   const id = item.dataset.id;
 
   if (btn.classList.contains("edit-btn")) {
@@ -255,18 +326,20 @@ function handleSalesListAction(event) {
 
   if (btn.classList.contains("delete-btn")) {
     if (!window.confirm("この売上を削除しますか？")) return;
-    state.sales = state.sales.filter((entry) => entry.id !== id);
-    if (editState.saleId === id) resetSaleForm();
-    saveData();
-    renderAfterDataChanged();
+    await withLoading(async () => {
+      const { error } = await supabase.from("sales").delete().eq("id", id).eq("user_id", currentUser.id);
+      if (error) throw error;
+      if (editState.saleId === id) resetSaleForm();
+      await refreshAfterMutation("売上を削除しました。");
+    }, "売上の削除に失敗しました。");
   }
 }
 
-function handleExpensesListAction(event) {
+async function handleExpensesListAction(event) {
   const btn = event.target;
   if (!(btn instanceof HTMLButtonElement)) return;
   const item = btn.closest(".item");
-  if (!item) return;
+  if (!item || !currentUser) return;
   const id = item.dataset.id;
 
   if (btn.classList.contains("edit-btn")) {
@@ -283,11 +356,35 @@ function handleExpensesListAction(event) {
 
   if (btn.classList.contains("delete-btn")) {
     if (!window.confirm("この経費を削除しますか？")) return;
-    state.expenses = state.expenses.filter((entry) => entry.id !== id);
-    if (editState.expenseId === id) resetExpenseForm();
-    saveData();
-    renderAfterDataChanged();
+    await withLoading(async () => {
+      const { error } = await supabase.from("expenses").delete().eq("id", id).eq("user_id", currentUser.id);
+      if (error) throw error;
+      if (editState.expenseId === id) resetExpenseForm();
+      await refreshAfterMutation("経費を削除しました。");
+    }, "経費の削除に失敗しました。");
   }
+}
+
+async function handleClearAll() {
+  if (!currentUser) return;
+  if (!window.confirm("案件・売上・経費の全データを削除します。よろしいですか？")) return;
+
+  await withLoading(async () => {
+    const [salesRes, expensesRes, casesRes] = await Promise.all([
+      supabase.from("sales").delete().eq("user_id", currentUser.id),
+      supabase.from("expenses").delete().eq("user_id", currentUser.id),
+      supabase.from("cases").delete().eq("user_id", currentUser.id),
+    ]);
+
+    if (salesRes.error) throw salesRes.error;
+    if (expensesRes.error) throw expensesRes.error;
+    if (casesRes.error) throw casesRes.error;
+
+    resetCaseForm();
+    resetSaleForm();
+    resetExpenseForm();
+    await refreshAfterMutation("全データを削除しました。");
+  }, "全件削除に失敗しました。");
 }
 
 function renderAfterDataChanged() {
@@ -300,16 +397,13 @@ function renderAfterDataChanged() {
 
 function activateTab(tabKey) {
   tabs.forEach((btn) => btn.classList.toggle("active", btn.dataset.tab === tabKey));
-  Object.entries(panels).forEach(([key, panel]) => {
-    panel.classList.toggle("active", key === tabKey);
-  });
+  Object.entries(panels).forEach(([key, panel]) => panel.classList.toggle("active", key === tabKey));
 }
 
 function renderDashboard() {
-  const salesByMonth = aggregateByMonth(state.sales, (s) => s.createdAt, (s) => s.invoiceAmount);
+  const salesByMonth = aggregateByMonth(state.sales, (s) => s.paidDate || s.createdAt, (s) => s.invoiceAmount);
   const expenseByMonth = aggregateByMonth(state.expenses, (e) => e.date, (e) => e.amount);
   const monthKeys = [...new Set([...Object.keys(salesByMonth), ...Object.keys(expenseByMonth)])].sort().reverse();
-
   const currentMonth = monthKeys[0] || toMonthKey(new Date());
   const sales = salesByMonth[currentMonth] || 0;
   const expenses = expenseByMonth[currentMonth] || 0;
@@ -338,12 +432,10 @@ function renderCaseOptions() {
 
   saleCaseSelect.innerHTML = state.cases.length ? options : '<option value="">案件を先に登録してください</option>';
   saleCaseSelect.disabled = !state.cases.length;
-
   expenseCaseSelect.innerHTML = `<option value="">案件に紐付けしない</option>${options}`;
 }
 
 function renderCases() {
-  if (!caseList || !caseEmpty || !caseItemTemplate) return;
   caseList.innerHTML = "";
   const sorted = state.cases.slice().sort(sortCases);
 
@@ -363,7 +455,6 @@ function renderCases() {
 }
 
 function renderSales() {
-  if (!salesList || !salesEmpty || !saleItemTemplate) return;
   salesList.innerHTML = "";
   const sorted = state.sales.slice().sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt));
 
@@ -383,11 +474,8 @@ function renderSales() {
 }
 
 function renderExpenses() {
-  if (!expensesList || !expensesEmpty || !expenseItemTemplate) return;
   expensesList.innerHTML = "";
-  const sorted = state.expenses
-    .slice()
-    .sort((a, b) => toSortTimestamp(b.date) - toSortTimestamp(a.date));
+  const sorted = state.expenses.slice().sort((a, b) => toSortTimestamp(b.date) - toSortTimestamp(a.date));
 
   sorted.forEach((expense) => {
     const node = expenseItemTemplate.content.cloneNode(true);
@@ -406,8 +494,7 @@ function renderExpenses() {
 
 function resolveCaseName(caseId) {
   const found = state.cases.find((c) => c.id === caseId);
-  if (!found) return "（削除済み案件）";
-  return `${found.customerName}｜${found.caseName}`;
+  return found ? `${found.customerName}｜${found.caseName}` : "（削除済み案件）";
 }
 
 function resetCaseForm() {
@@ -506,84 +593,79 @@ function escapeHtml(text) {
     .replaceAll("'", "&#039;");
 }
 
-function saveData() {
-  localStorage.setItem(DATA_STORAGE_KEY, JSON.stringify(state));
-}
-
-function loadData() {
-  try {
-    const raw = localStorage.getItem(DATA_STORAGE_KEY);
-    if (raw) return sanitizeData(JSON.parse(raw));
-
-    const oldV2Raw = localStorage.getItem(LEGACY_STORAGE_KEYS[0]);
-    if (oldV2Raw) {
-      const migrated = sanitizeData(JSON.parse(oldV2Raw));
-      localStorage.setItem(DATA_STORAGE_KEY, JSON.stringify(migrated));
-      return migrated;
-    }
-
-    const legacyCasesRaw = localStorage.getItem(LEGACY_STORAGE_KEYS[1]);
-    if (legacyCasesRaw) {
-      const migrated = sanitizeData({ cases: JSON.parse(legacyCasesRaw), sales: [], expenses: [] });
-      localStorage.setItem(DATA_STORAGE_KEY, JSON.stringify(migrated));
-      return migrated;
-    }
-  } catch {
-    return { cases: [], sales: [], expenses: [] };
-  }
-
-  return { cases: [], sales: [], expenses: [] };
-}
-
-function sanitizeData(input) {
-  const safe = input && typeof input === "object" ? input : {};
-  const cases = Array.isArray(safe.cases) ? safe.cases : [];
-  const sales = Array.isArray(safe.sales) ? safe.sales : [];
-  const expenses = Array.isArray(safe.expenses) ? safe.expenses : [];
-
+function mapCaseFromDb(row) {
   return {
-    cases: cases
-      .filter((c) => c && typeof c === "object")
-      .map((c) => ({
-        id: c.id || crypto.randomUUID(),
-        customerName: String(c.customerName || "").trim(),
-        caseName: String(c.caseName || "").trim(),
-        estimateAmount: normalizeAmount(c.estimateAmount ?? c.amount),
-        receivedDate: String(c.receivedDate || ""),
-        dueDate: String(c.dueDate || ""),
-        status: normalizeStatus(c.status),
-        createdAt: Number.isFinite(c.createdAt) ? c.createdAt : Date.now(),
-        updatedAt: Number.isFinite(c.updatedAt) ? c.updatedAt : Date.now(),
-      }))
-      .filter((c) => c.customerName && c.caseName),
-    sales: sales
-      .filter((s) => s && typeof s === "object")
-      .map((s) => {
-        const invoiceAmount = normalizeAmount(s.invoiceAmount);
-        const paidAmount = normalizeAmount(s.paidAmount);
-        return {
-          id: s.id || crypto.randomUUID(),
-          caseId: String(s.caseId || ""),
-          invoiceAmount: invoiceAmount ?? 0,
-          paidAmount,
-          paidDate: String(s.paidDate || ""),
-          isUnpaid: Boolean(s.isUnpaid) || (paidAmount ?? 0) < (invoiceAmount ?? 0),
-          createdAt: Number.isFinite(s.createdAt) ? s.createdAt : Date.now(),
-          updatedAt: Number.isFinite(s.updatedAt) ? s.updatedAt : Date.now(),
-        };
-      })
-      .filter((s) => s.caseId),
-    expenses: expenses
-      .filter((e) => e && typeof e === "object")
-      .map((e) => ({
-        id: e.id || crypto.randomUUID(),
-        date: String(e.date || ""),
-        content: String(e.content || "").trim(),
-        amount: normalizeAmount(e.amount) ?? 0,
-        caseId: e.caseId ? String(e.caseId) : null,
-        createdAt: Number.isFinite(e.createdAt) ? e.createdAt : Date.now(),
-        updatedAt: Number.isFinite(e.updatedAt) ? e.updatedAt : Date.now(),
-      }))
-      .filter((e) => e.date && e.content),
+    id: row.id,
+    customerName: row.customer_name || "",
+    caseName: row.case_name || "",
+    estimateAmount: normalizeAmount(row.estimate_amount),
+    receivedDate: row.received_date || "",
+    dueDate: row.due_date || "",
+    status: normalizeStatus(row.status),
+    createdAt: Date.parse(row.created_at) || Date.now(),
+    updatedAt: Date.parse(row.updated_at) || Date.now(),
   };
+}
+
+function mapSaleFromDb(row) {
+  const invoiceAmount = normalizeAmount(row.invoice_amount) ?? 0;
+  const paidAmount = normalizeAmount(row.paid_amount);
+  return {
+    id: row.id,
+    caseId: row.case_id,
+    invoiceAmount,
+    paidAmount,
+    paidDate: row.paid_date || "",
+    isUnpaid: Boolean(row.is_unpaid) || (paidAmount ?? 0) < invoiceAmount,
+    createdAt: Date.parse(row.created_at) || Date.now(),
+    updatedAt: Date.parse(row.updated_at) || Date.now(),
+  };
+}
+
+function mapExpenseFromDb(row) {
+  return {
+    id: row.id,
+    date: row.date || "",
+    content: row.content || "",
+    amount: normalizeAmount(row.amount) ?? 0,
+    caseId: row.case_id || null,
+    createdAt: Date.parse(row.created_at) || Date.now(),
+    updatedAt: Date.parse(row.updated_at) || Date.now(),
+  };
+}
+
+async function withLoading(task, fallbackMessage, authArea = false) {
+  setLoading(true);
+  try {
+    clearAppMessage();
+    if (authArea) showAuthMessage("", false);
+    await task();
+  } catch (error) {
+    const message = error?.message ? String(error.message) : fallbackMessage;
+    if (authArea) {
+      showAuthMessage(`${fallbackMessage}\n詳細: ${message}`, true);
+    } else {
+      showAppMessage(`${fallbackMessage}\n詳細: ${message}`, true);
+    }
+  } finally {
+    setLoading(false);
+  }
+}
+
+function setLoading(isLoading) {
+  loadingOverlay.hidden = !isLoading;
+}
+
+function showAuthMessage(text, isError) {
+  authMessage.textContent = text;
+  authMessage.classList.toggle("error", isError);
+}
+
+function showAppMessage(text, isError) {
+  appMessage.textContent = text;
+  appMessage.classList.toggle("error", isError);
+}
+
+function clearAppMessage() {
+  showAppMessage("", false);
 }

--- a/index.html
+++ b/index.html
@@ -5,147 +5,185 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>行政書士 案件・売上・経費管理</title>
     <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="app.js" defer></script>
   </head>
   <body>
-    <header class="top-bar">
-      <h1>行政書士 案件・売上・経費管理</h1>
-      <p>案件管理＋売上/経費管理（localStorage保存）</p>
-    </header>
+    <div id="loading-overlay" class="loading-overlay" hidden>
+      <div class="loading-box">読み込み中です...</div>
+    </div>
 
-    <main class="container">
-      <nav class="tabs" aria-label="メイン機能">
-        <button type="button" class="tab-btn active" data-tab="cases">案件</button>
-        <button type="button" class="tab-btn" data-tab="sales">売上</button>
-        <button type="button" class="tab-btn" data-tab="expenses">経費</button>
-      </nav>
-
-      <section class="dashboard panel">
-        <h2>月次ダッシュボード</h2>
-        <div class="summary-grid" id="summary-grid"></div>
-      </section>
-
-      <section id="tab-cases" class="tab-panel active">
-        <div class="layout two-col">
-          <section class="panel">
-            <h2>新規案件登録</h2>
-            <form id="case-form" class="form">
-              <label>
-                顧客名 <span class="required">必須</span>
-                <input id="customer-name" name="customerName" type="text" required maxlength="80" />
-              </label>
-              <label>
-                案件名 <span class="required">必須</span>
-                <input id="case-name" name="caseName" type="text" required maxlength="120" />
-              </label>
-              <label>
-                見積金額（円）
-                <input id="amount" name="amount" type="number" min="0" step="1" />
-              </label>
-              <div class="date-grid">
-                <label>
-                  受付日
-                  <input id="received-date" name="receivedDate" type="date" />
-                </label>
-                <label>
-                  期限日
-                  <input id="due-date" name="dueDate" type="date" />
-                </label>
-              </div>
-              <label>
-                ステータス
-                <select id="status" name="status">
-                  <option value="未着手">未着手</option>
-                  <option value="進行中">進行中</option>
-                  <option value="完了">完了</option>
-                </select>
-              </label>
-              <button type="submit">案件を追加</button>
-            </form>
-          </section>
-
-          <section class="panel">
-            <div class="panel-title-row">
-              <h2>案件一覧（期限順）</h2>
-              <button id="clear-btn" type="button" class="danger-btn">全件削除</button>
-            </div>
-            <div id="case-empty" class="empty">案件はまだ登録されていません。</div>
-            <ul id="case-list" class="item-list"></ul>
-          </section>
-        </div>
-      </section>
-
-      <section id="tab-sales" class="tab-panel">
-        <div class="layout two-col">
-          <section class="panel">
-            <h2>売上登録</h2>
-            <form id="sale-form" class="form">
-              <label>
-                対象案件 <span class="required">必須</span>
-                <select id="sale-case-id" name="saleCaseId" required></select>
-              </label>
-              <label>
-                請求額（円） <span class="required">必須</span>
-                <input id="invoice-amount" name="invoiceAmount" type="number" min="0" step="1" required />
-              </label>
-              <label>
-                入金額（円）
-                <input id="paid-amount" name="paidAmount" type="number" min="0" step="1" />
-              </label>
-              <label>
-                入金日
-                <input id="paid-date" name="paidDate" type="date" />
-              </label>
-              <label class="checkbox">
-                <input id="is-unpaid" name="isUnpaid" type="checkbox" />
-                未入金フラグを立てる
-              </label>
-              <button type="submit">売上を登録</button>
-            </form>
-          </section>
-
-          <section class="panel">
-            <h2>売上一覧</h2>
-            <div id="sales-empty" class="empty">売上データはまだありません。</div>
-            <ul id="sales-list" class="item-list"></ul>
-          </section>
-        </div>
-      </section>
-
-      <section id="tab-expenses" class="tab-panel">
-        <div class="layout two-col">
-          <section class="panel">
-            <h2>経費登録</h2>
-            <form id="expense-form" class="form">
-              <div class="date-grid">
-                <label>
-                  日付 <span class="required">必須</span>
-                  <input id="expense-date" name="expenseDate" type="date" required />
-                </label>
-                <label>
-                  案件（任意）
-                  <select id="expense-case-id" name="expenseCaseId"></select>
-                </label>
-              </div>
-              <label>
-                内容 <span class="required">必須</span>
-                <input id="expense-content" name="expenseContent" type="text" maxlength="120" placeholder="例：交通費、印紙代" required />
-              </label>
-              <label>
-                金額（円） <span class="required">必須</span>
-                <input id="expense-amount" name="expenseAmount" type="number" min="0" step="1" required />
-              </label>
-              <button type="submit">経費を登録</button>
-            </form>
-          </section>
-
-          <section class="panel">
-            <h2>経費一覧</h2>
-            <div id="expenses-empty" class="empty">経費データはまだありません。</div>
-            <ul id="expenses-list" class="item-list"></ul>
-          </section>
-        </div>
+    <main class="auth-container" id="auth-view">
+      <section class="panel auth-panel">
+        <h1>ログイン</h1>
+        <p class="auth-caption">メールアドレスとパスワードでログインしてください。</p>
+        <form id="auth-form" class="form">
+          <label>
+            メールアドレス
+            <input id="auth-email" name="email" type="email" required />
+          </label>
+          <label>
+            パスワード
+            <input id="auth-password" name="password" type="password" minlength="6" required />
+          </label>
+          <div class="auth-actions">
+            <button id="login-btn" type="submit">ログイン</button>
+            <button id="signup-btn" type="button" class="secondary-btn">新規登録</button>
+          </div>
+        </form>
+        <p id="auth-message" class="message" aria-live="polite"></p>
       </section>
     </main>
+
+    <div id="app-view" hidden>
+      <header class="top-bar">
+        <div>
+          <h1>行政書士 案件・売上・経費管理</h1>
+          <p>案件管理＋売上/経費管理（Supabase保存）</p>
+        </div>
+        <div class="top-actions">
+          <span id="user-label" class="user-label"></span>
+          <button id="logout-btn" type="button" class="secondary-btn">ログアウト</button>
+        </div>
+      </header>
+
+      <main class="container">
+        <p id="app-message" class="message" aria-live="polite"></p>
+
+        <nav class="tabs" aria-label="メイン機能">
+          <button type="button" class="tab-btn active" data-tab="cases">案件</button>
+          <button type="button" class="tab-btn" data-tab="sales">売上</button>
+          <button type="button" class="tab-btn" data-tab="expenses">経費</button>
+        </nav>
+
+        <section class="dashboard panel">
+          <h2>月次ダッシュボード</h2>
+          <div class="summary-grid" id="summary-grid"></div>
+        </section>
+
+        <section id="tab-cases" class="tab-panel active">
+          <div class="layout two-col">
+            <section class="panel">
+              <h2>新規案件登録</h2>
+              <form id="case-form" class="form">
+                <label>
+                  顧客名 <span class="required">必須</span>
+                  <input id="customer-name" name="customerName" type="text" required maxlength="80" />
+                </label>
+                <label>
+                  案件名 <span class="required">必須</span>
+                  <input id="case-name" name="caseName" type="text" required maxlength="120" />
+                </label>
+                <label>
+                  見積金額（円）
+                  <input id="amount" name="amount" type="number" min="0" step="1" />
+                </label>
+                <div class="date-grid">
+                  <label>
+                    受付日
+                    <input id="received-date" name="receivedDate" type="date" />
+                  </label>
+                  <label>
+                    期限日
+                    <input id="due-date" name="dueDate" type="date" />
+                  </label>
+                </div>
+                <label>
+                  ステータス
+                  <select id="status" name="status">
+                    <option value="未着手">未着手</option>
+                    <option value="進行中">進行中</option>
+                    <option value="完了">完了</option>
+                  </select>
+                </label>
+                <button type="submit">案件を追加</button>
+              </form>
+            </section>
+
+            <section class="panel">
+              <div class="panel-title-row">
+                <h2>案件一覧（期限順）</h2>
+                <button id="clear-btn" type="button" class="danger-btn">全件削除</button>
+              </div>
+              <div id="case-empty" class="empty">案件はまだ登録されていません。</div>
+              <ul id="case-list" class="item-list"></ul>
+            </section>
+          </div>
+        </section>
+
+        <section id="tab-sales" class="tab-panel">
+          <div class="layout two-col">
+            <section class="panel">
+              <h2>売上登録</h2>
+              <form id="sale-form" class="form">
+                <label>
+                  対象案件 <span class="required">必須</span>
+                  <select id="sale-case-id" name="saleCaseId" required></select>
+                </label>
+                <label>
+                  請求額（円） <span class="required">必須</span>
+                  <input id="invoice-amount" name="invoiceAmount" type="number" min="0" step="1" required />
+                </label>
+                <label>
+                  入金額（円）
+                  <input id="paid-amount" name="paidAmount" type="number" min="0" step="1" />
+                </label>
+                <label>
+                  入金日
+                  <input id="paid-date" name="paidDate" type="date" />
+                </label>
+                <label class="checkbox">
+                  <input id="is-unpaid" name="isUnpaid" type="checkbox" />
+                  未入金フラグを立てる
+                </label>
+                <button type="submit">売上を登録</button>
+              </form>
+            </section>
+
+            <section class="panel">
+              <h2>売上一覧</h2>
+              <div id="sales-empty" class="empty">売上データはまだありません。</div>
+              <ul id="sales-list" class="item-list"></ul>
+            </section>
+          </div>
+        </section>
+
+        <section id="tab-expenses" class="tab-panel">
+          <div class="layout two-col">
+            <section class="panel">
+              <h2>経費登録</h2>
+              <form id="expense-form" class="form">
+                <div class="date-grid">
+                  <label>
+                    日付 <span class="required">必須</span>
+                    <input id="expense-date" name="expenseDate" type="date" required />
+                  </label>
+                  <label>
+                    案件（任意）
+                    <select id="expense-case-id" name="expenseCaseId"></select>
+                  </label>
+                </div>
+                <label>
+                  内容 <span class="required">必須</span>
+                  <input id="expense-content" name="expenseContent" type="text" maxlength="120" placeholder="例：交通費、印紙代" required />
+                </label>
+                <label>
+                  金額（円） <span class="required">必須</span>
+                  <input id="expense-amount" name="expenseAmount" type="number" min="0" step="1" required />
+                </label>
+                <button type="submit">経費を登録</button>
+              </form>
+            </section>
+
+            <section class="panel">
+              <h2>経費一覧</h2>
+              <div id="expenses-empty" class="empty">経費データはまだありません。</div>
+              <ul id="expenses-list" class="item-list"></ul>
+            </section>
+          </div>
+        </section>
+      </main>
+    </div>
 
     <template id="case-item-template">
       <li class="item">
@@ -176,7 +214,5 @@
         <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
       </li>
     </template>
-
-    <script src="app.js" defer></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -21,14 +21,51 @@ body {
   color: var(--text);
 }
 
+.auth-container {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.auth-panel {
+  width: min(100%, 440px);
+}
+
+.auth-caption {
+  margin-top: 0;
+  color: var(--muted);
+}
+
+.auth-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .top-bar {
   padding: 1rem;
   background: var(--card);
   border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .top-bar h1 { margin: 0; font-size: 1.45rem; }
 .top-bar p { margin: 0.35rem 0 0; color: var(--muted); }
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.user-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
 
 .container { max-width: 1160px; margin: 1rem auto; padding: 0 1rem 1.2rem; }
 
@@ -157,11 +194,6 @@ button:hover { background: var(--primary-dark); }
 
 .panel-title-row { display: flex; justify-content: space-between; align-items: center; gap: 0.6rem; }
 
-@media (max-width: 640px) {
-  .date-grid { grid-template-columns: 1fr; }
-  .item { flex-direction: column; }
-}
-
 .secondary-btn {
   background: #4b5563;
 }
@@ -177,4 +209,38 @@ button:hover { background: var(--primary-dark); }
 
 .row-actions button {
   white-space: nowrap;
+}
+
+.message {
+  min-height: 1.2rem;
+  margin: 0.4rem 0 0;
+  color: #0f766e;
+  white-space: pre-line;
+}
+
+.message.error {
+  color: #b42318;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(17, 24, 39, 0.25);
+  z-index: 1000;
+}
+
+.loading-box {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.8rem 1rem;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .date-grid { grid-template-columns: 1fr; }
+  .item { flex-direction: column; }
+  .top-bar { flex-direction: column; align-items: flex-start; }
 }


### PR DESCRIPTION
### Motivation
- localStorage依存を廃止し、ユーザー別データをSupabaseで一元管理するためにSupabase AuthとDB連携を導入しました。
- 未ログイン時はログイン画面のみ表示し、ログイン後に既存UIを維持したメイン画面を表示するフローが必要でした。

### Description
- `supabase-js` をCDNで読み込みし、`app.js` に `supabase` クライアントを作成して `cases / sales / expenses` テーブルを `user_id` で読み書きするCRUD処理を実装しました。
- メール＋パスワードのログイン・新規登録・ログアウト画面と認証状態監視を追加し、未ログイン時は認証画面のみ表示、ログイン後にデータを取得して画面へ反映するようにしました。
- 登録/更新/削除はDB操作後に再取得して即一覧とダッシュボードに反映させる `refreshAfterMutation` ロジックと、読み込み中オーバーレイ・日本語エラーメッセージを追加しました。
- UIをできるだけ維持しつつ認証用スタイルとローディング/メッセージ領域を `index.html` / `styles.css` / `app.js` に追加・修正しました。

### Testing
- `node --check app.js` による構文チェックを実行し、エラーは発生しませんでした（成功）。
- ブラウザ向けのスクリプト読み込みとDOM参照に合わせて `index.html` と `styles.css` を修正し、アプリ起動時の基本的な表示切替（認証画面 ⇄ メイン画面）の動作を想定して検証しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab58de8a48333b2b066e020924539)