### PR TITLE
Ensure loading overlay hides when hidden and always cleared after ops

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ let currentUser = null;
 initialize();
 
 async function initialize() {
-  setLoading(true);
+  showLoading();
   setAuthControlsDisabled(true);
   try {
     bindEvents();
@@ -75,7 +75,7 @@ async function initialize() {
     authView.hidden = false;
     appView.hidden = true;
   } finally {
-    setLoading(false);
+    hideLoading();
     setAuthControlsDisabled(false);
   }
 }
@@ -646,7 +646,7 @@ function mapExpenseFromDb(row) {
 }
 
 async function withLoading(task, fallbackMessage, authArea = false) {
-  setLoading(true);
+  showLoading();
   try {
     clearAppMessage();
     if (authArea) showAuthMessage("", false);
@@ -660,12 +660,26 @@ async function withLoading(task, fallbackMessage, authArea = false) {
       showAppMessage(`${fallbackMessage}\n詳細: ${message}`, true);
     }
   } finally {
-    setLoading(false);
+    hideLoading();
   }
 }
 
 function setLoading(isLoading) {
-  loadingOverlay.hidden = !isLoading;
+  if (isLoading) {
+    showLoading();
+    return;
+  }
+  hideLoading();
+}
+
+function showLoading() {
+  if (!loadingOverlay) return;
+  loadingOverlay.hidden = false;
+}
+
+function hideLoading() {
+  if (!loadingOverlay) return;
+  loadingOverlay.hidden = true;
 }
 
 function setAuthControlsDisabled(disabled) {

--- a/styles.css
+++ b/styles.css
@@ -231,6 +231,10 @@ button:hover { background: var(--primary-dark); }
   z-index: 1000;
 }
 
+.loading-overlay[hidden] {
+  display: none !important;
+}
+
 .loading-box {
   background: #fff;
   border: 1px solid var(--border);


### PR DESCRIPTION
### Motivation

- The loading overlay could remain visible because `.loading-overlay { display: grid; }` overrides visual hiding even when the `hidden` attribute is present.
- Initialization or async failures could leave the overlay visible and keep login inputs/buttons disabled.
- The goal is to guarantee that an overlay with `hidden` is always non‑visible and that JS always hides the overlay after async flows so controls become operable.

### Description

- Added a CSS rule `.loading-overlay[hidden] { display: none !important; }` to force hidden overlays to be non‑visible (`styles.css`).
- Introduced `showLoading()` and `hideLoading()` helpers and updated `setLoading()` to delegate to them for compatibility (`app.js`).
- Replaced `setLoading(true/false)` calls at initialization and in the async wrapper with `showLoading()` / `hideLoading()` and ensured `hideLoading()` is always called in `finally` blocks so the overlay is cleared even on errors (`initialize()` and `withLoading()` in `app.js`).
- Ensured auth controls are re-enabled in `finally` so the login form and buttons become usable after failures (`app.js`).

### Testing

- Ran `node --check app.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac0e5a968833388f7cb0e1dafe6f0)