### PR TITLE
Fix loading overlay stuck on tab/window resume

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,6 +50,7 @@ const expenseItemTemplate = document.getElementById("expense-item-template");
 
 let currentUser = null;
 let loadingCount = 0;
+let isResuming = false;
 
 initialize();
 
@@ -104,21 +105,33 @@ function bindEvents() {
   salesList.addEventListener("click", handleSalesListAction);
   expensesList.addEventListener("click", handleExpensesListAction);
   document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("focus", handleWindowFocus);
 }
 
-async function handleVisibilityChange() {
-  if (document.hidden || !currentUser) return;
 
+async function handleVisibilityChange() {
+  if (document.hidden) return;
+  await handleResumeRefresh("visibilitychange");
+}
+
+async function handleWindowFocus() {
+  await handleResumeRefresh("focus");
+}
+
+async function handleResumeRefresh(trigger) {
+  if (!currentUser || isResuming) return;
+
+  isResuming = true;
   setLoading(true);
   try {
     await loadAllData();
     renderAfterDataChanged();
   } catch (error) {
-    console.error("画面復帰時の再読み込みに失敗しました。", error);
+    console.error(`画面復帰時の再読み込みに失敗しました。(${trigger})`, error);
     showAppMessage("画面復帰時のデータ更新に失敗しました。", true);
   } finally {
+    isResuming = false;
     setLoading(false);
-    clearLoadingState();
   }
 }
 
@@ -698,8 +711,9 @@ function setLoading(isLoading) {
     loadingOverlay.hidden = false;
     return;
   }
+
   loadingCount = Math.max(0, loadingCount - 1);
-  if (loadingCount === 0) loadingOverlay.hidden = true;
+  loadingOverlay.hidden = true;
 }
 
 function clearLoadingState() {


### PR DESCRIPTION
### Motivation
- Prevent the loading overlay from remaining visible when the user switches tabs/windows or when auth state changes and the app returns to the foreground. 
- Ensure all foreground reloading paths use robust `try/catch/finally` semantics so `setLoading(false)` always runs.
- Keep the existing CSS rule ` .loading-overlay[hidden] { display: none !important; }` so hiding the overlay remains reliable.

### Description
- Added a re-entry guard variable `isResuming` and a new centralized foreground refresh function `handleResumeRefresh(trigger)` to run data reloads triggered by `visibilitychange` and `focus` events. 
- Hooked `window.focus` to call `handleWindowFocus` and changed `handleVisibilityChange` to delegate to `handleResumeRefresh` so both events share the same guarded flow. 
- Ensured resume logic is wrapped with `try/catch/finally` and always calls `setLoading(false)` in `finally`. 
- Modified `setLoading(false)` to always set `loadingOverlay.hidden = true` when clearing loading so the overlay cannot remain visible unexpectedly.

### Testing
- Ran `node --check app.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaca6f508c833389daaa35a936b65b)