### PR TITLE
案件別の売上・経費・利益表示を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ const panels = {
 };
 
 const summaryGrid = document.getElementById("summary-grid");
+const caseProfitList = document.getElementById("case-profit-list");
+const caseProfitEmpty = document.getElementById("case-profit-empty");
 
 const caseForm = document.getElementById("case-form");
 const caseList = document.getElementById("case-list");
@@ -464,13 +466,15 @@ function renderDashboard() {
     { label: "対象月", value: monthLabel(currentMonth), cls: "" },
     { label: "月別売上合計", value: formatCurrency(sales), cls: "" },
     { label: "月別経費合計", value: formatCurrency(expenses), cls: "" },
-    { label: "利益（売上−経費）", value: formatCurrency(profit), cls: "profit" },
+    { label: "利益（売上−経費）", value: formatCurrency(profit), cls: `profit ${profit < 0 ? "loss" : ""}`.trim() },
   ].forEach((card) => {
     const div = document.createElement("div");
     div.className = `summary-card ${card.cls}`.trim();
     div.innerHTML = `<p class="label">${card.label}</p><p class="value">${card.value}</p>`;
     summaryGrid.appendChild(div);
   });
+
+  renderCaseProfitList();
 }
 
 function renderCaseOptions() {
@@ -488,20 +492,70 @@ function renderCaseOptions() {
 function renderCases() {
   caseList.innerHTML = "";
   const sorted = state.cases.slice().sort(sortCases);
+  const profitsByCaseId = buildCaseProfitMap();
 
   sorted.forEach((entry) => {
     const node = caseItemTemplate.content.cloneNode(true);
     const item = node.querySelector(".item");
     const title = node.querySelector(".title");
     const meta = node.querySelector(".meta");
+    const profitMeta = node.querySelector(".profit-meta");
+    const totals = profitsByCaseId[entry.id] || { sales: 0, expenses: 0, profit: 0 };
 
     item.dataset.id = entry.id;
     title.textContent = `${entry.customerName}｜${entry.caseName}`;
-    meta.textContent = `見積: ${formatCurrency(entry.estimateAmount)} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)} / ${entry.status}`;
+    meta.textContent = `見積: ${formatCurrency(entry.estimateAmount)} / ステータス: ${entry.status} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)}`;
+    profitMeta.textContent = `売上合計: ${formatCurrency(totals.sales)} / 経費合計: ${formatCurrency(totals.expenses)} / 利益: ${formatCurrency(totals.profit)}`;
+    profitMeta.classList.toggle("loss-text", totals.profit < 0);
     caseList.appendChild(node);
   });
 
   caseEmpty.hidden = sorted.length > 0;
+}
+
+function renderCaseProfitList() {
+  if (!caseProfitList || !caseProfitEmpty) return;
+  const profitsByCaseId = buildCaseProfitMap();
+  const sortedCases = state.cases.slice().sort(sortCases);
+  caseProfitList.innerHTML = "";
+
+  sortedCases.forEach((entry) => {
+    const totals = profitsByCaseId[entry.id] || { sales: 0, expenses: 0, profit: 0 };
+    const li = document.createElement("li");
+    li.className = "item";
+    li.innerHTML = `
+      <div>
+        <p class="title">${escapeHtml(entry.customerName)}｜${escapeHtml(entry.caseName)}</p>
+        <p class="meta">売上合計: ${formatCurrency(totals.sales)} / 経費合計: ${formatCurrency(totals.expenses)} / <span class="${totals.profit < 0 ? "loss-text" : ""}">利益: ${formatCurrency(totals.profit)}</span></p>
+      </div>
+    `;
+    caseProfitList.appendChild(li);
+  });
+
+  caseProfitEmpty.hidden = sortedCases.length > 0;
+}
+
+function buildCaseProfitMap() {
+  const map = {};
+  state.cases.forEach((entry) => {
+    map[entry.id] = { sales: 0, expenses: 0, profit: 0 };
+  });
+
+  state.sales.forEach((sale) => {
+    if (!sale.caseId || !map[sale.caseId]) return;
+    map[sale.caseId].sales += sale.invoiceAmount || 0;
+  });
+
+  state.expenses.forEach((expense) => {
+    if (!expense.caseId || !map[expense.caseId]) return;
+    map[expense.caseId].expenses += expense.amount || 0;
+  });
+
+  Object.values(map).forEach((item) => {
+    item.profit = item.sales - item.expenses;
+  });
+
+  return map;
 }
 
 function renderSales() {

--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
         <section class="dashboard panel">
           <h2>月次ダッシュボード</h2>
           <div class="summary-grid" id="summary-grid"></div>
+          <h3 class="subheading">案件別利益一覧</h3>
+          <div id="case-profit-empty" class="empty">案件データがありません。</div>
+          <ul id="case-profit-list" class="item-list compact-list"></ul>
         </section>
 
         <section id="tab-cases" class="tab-panel active">
@@ -190,6 +193,7 @@
         <div>
           <p class="title"></p>
           <p class="meta"></p>
+          <p class="meta profit-meta"></p>
         </div>
         <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
       </li>

--- a/styles.css
+++ b/styles.css
@@ -191,6 +191,25 @@ button:hover { background: var(--primary-dark); }
 .summary-card .label { margin: 0 0 0.3rem; color: var(--muted); }
 .summary-card .value { margin: 0; font-size: 1.15rem; font-weight: 700; }
 .summary-card.profit .value { color: var(--ok); }
+.summary-card.loss .value { color: var(--danger); }
+
+.subheading {
+  margin-top: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.compact-list {
+  margin-top: 0.2rem;
+}
+
+.profit-meta {
+  margin-top: 0.32rem;
+}
+
+.loss-text {
+  color: var(--danger);
+  font-weight: 700;
+}
 
 .panel-title-row { display: flex; justify-content: space-between; align-items: center; gap: 0.6rem; }
 


### PR DESCRIPTION
### Motivation
- 案件ごとの利益を一覧で把握できるように、既存UIを維持しつつダッシュボードと案件一覧に案件単位の売上/経費/利益表示を追加するため。 
- 売上と経費はそれぞれ `sales.invoice_amount` / `expenses.amount` を集計し、`case_id` で `cases.id` と紐付ける仕様に準拠するため。

### Description
- `index.html` にダッシュボード内の「案件別利益一覧」領域と案件テンプレート内の利益表示行（`profit-meta`）を追加し表示領域を用意しました。 
- `app.js` に以下を追加・変更しました：`case-profit-list`/`case-profit-empty` の DOM 参照、`buildCaseProfitMap` による案件別集計ロジック、`renderCaseProfitList` によるダッシュボード表示、`renderCases` と `renderDashboard` に集計結果の埋め込みと赤字（利益<0）の強調処理を追加しました。 
- 集計は `sales.case_id` → `cases.id`、`expenses.case_id` → `cases.id` を参照し、売上は `invoice_amount`、経費は `amount` を合算し、`case_id` がない経費は案件集計から除外します。 
- `styles.css` に見出し・コンパクトリスト・赤字強調（`.loss-text`）などの最小限のスタイルを追加して既存デザインとの整合を保ちました。 
- 実装は HTML/CSS/JavaScript のみで行い、既存の Supabase 認証・RLS 前提のデータ取得フローや UI 構成は変更していません。 

### Testing
- 自動構文チェックとして `node --check app.js` を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead00025288333ac8d3a40848f4ef2)