### PR TITLE
Prepare app for GitHub Pages deployment (Supabase auth options + HTTPS guard + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# 行政書士 案件・売上・経費管理アプリ
+
+GitHub Pages でそのまま配信できる、`HTML / CSS / JavaScript` のみで構成されたシングルページアプリです。
+データ保存・認証は Supabase を利用しています。
+
+## 現在の公開構成（GitHub Pages 対応）
+
+- `index.html`
+- `app.js`
+- `styles.css`
+
+上記 3 ファイルはすべて**相対パス**で参照しています。
+
+- `index.html` -> `styles.css`
+- `index.html` -> `app.js`
+
+そのため、リポジトリ直下を GitHub Pages の公開ルートにすれば追加ビルドなしで動作します。
+
+## 重要な前提（`file://` ではなく `https://`）
+
+- 本アプリは Supabase Auth を使うため、**`https://` での配信前提**です。
+- `file://` 直開きではログインセッション保持や認証コールバックが不安定になるため、アプリ側でも `file://` 起動時は案内を表示して停止します。
+
+## GitHub Pages 公開手順
+
+### 1. GitHub に push
+
+このリポジトリを GitHub に push します。
+
+### 2. Pages を有効化
+
+1. GitHub リポジトリを開く
+2. `Settings` -> `Pages`
+3. `Build and deployment` で以下を設定
+   - `Source`: `Deploy from a branch`
+   - `Branch`: `main`（または公開したいブランチ）
+   - `Folder`: `/ (root)`
+4. `Save`
+
+数分後、以下のような URL で公開されます。
+
+- `https://<GitHubユーザー名>.github.io/<リポジトリ名>/`
+
+### 3. Supabase Auth の URL 設定（必須）
+
+Supabase ダッシュボードで、GitHub Pages の URL を許可してください。
+
+1. Supabase プロジェクトを開く
+2. `Authentication` -> `URL Configuration`
+3. 以下を設定
+   - `Site URL`: `https://<GitHubユーザー名>.github.io/<リポジトリ名>/`
+   - `Redirect URLs`: 上記 URL を追加
+
+> 末尾スラッシュ付きで登録しておくと安全です。
+
+## Supabase 接続情報について
+
+`app.js` 内の Supabase URL / publishable key は既存値をそのまま使用しています。
+
+- URL: `https://ueelzyftlbnvjvpsmpyt.supabase.co`
+- Key: `sb_publishable_...`
+
+## 複数端末で同じデータを閲覧する条件
+
+同じ公開 URL（GitHub Pages）を複数端末で開き、**同じ Supabase アカウントでログイン**すれば、同じ Supabase テーブル上のデータを参照するため同一データが表示されます。
+
+- 本アプリは `user_id` でデータを保存・取得しています。
+- 端末ローカル保存ではなく Supabase 永続データを読み込むため、端末間で同期されます。
+
+## ローカル確認方法（`https://` 推奨）
+
+簡易サーバーを使って確認してください（`file://` ではなく HTTP/HTTPS 経由）。
+
+例:
+
+```bash
+python -m http.server 8000
+```
+
+その後 `http://localhost:8000` を開いて動作確認します。
+

--- a/app.js
+++ b/app.js
@@ -2,7 +2,14 @@ const SUPABASE_URL = "https://ueelzyftlbnvjvpsmpyt.supabase.co";
 const SUPABASE_KEY = "sb_publishable_0DrKsieUcCyEZN_HRg8LhQ_QqFTPMtp";
 const STATUS_ORDER = ["未着手", "進行中", "完了"];
 
-const sbClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+const sbClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    storageKey: "gyosei-app-auth",
+  },
+});
 
 const state = {
   cases: [],
@@ -69,6 +76,18 @@ let loadingCount = 0;
 let isResuming = false;
 
 initialize();
+
+if (window.location.protocol === "file:") {
+  document.body.innerHTML = `
+    <main class="auth-container">
+      <section class="panel auth-panel">
+        <h1>このアプリは https:// で開いてください</h1>
+        <p class="auth-caption">GitHub Pages などの HTTPS 環境でのみ、Supabase Auth のログイン状態を正しく保持できます。</p>
+      </section>
+    </main>
+  `;
+  throw new Error("file:// では Supabase Auth を利用できません。HTTPS で配信してください。");
+}
 
 async function initialize() {
   setLoading(true);


### PR DESCRIPTION
### Motivation
- Make the single-file static app runnable as-is on GitHub Pages and ensure Supabase Auth behaves correctly when hosted over HTTPS. 
- Ensure session persistence, token refresh and URL-based auth callback handling work on hosted pages without changing the existing Supabase project credentials. 
- Prevent users from opening the app via `file://` where Supabase Auth and session handling are unreliable. 

### Description
- Enabled Supabase client auth options by creating the client with `{ auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true, storageKey: "gyosei-app-auth" } }` while keeping the existing `SUPABASE_URL` and publishable `SUPABASE_KEY`. 
- Added a runtime guard that detects `window.location.protocol === "file:"`, replaces the page with an explanatory message, and aborts execution to require `https://` delivery. 
- Added `README.md` with concrete GitHub Pages publishing steps, Supabase `Site URL`/`Redirect URLs` configuration guidance, note about HTTPS-only operation, and a local HTTP testing tip (`python -m http.server`). 
- Verified that `index.html` references `styles.css` and `app.js` with relative paths so the repository root can be used as the Pages publishing root. 

### Testing
- Ran a syntax check with `node --check app.js` which completed successfully. 
- Used automated search (`rg`) to verify presence of updated client options, the `file://` guard, relative asset references, and README entries, which returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadd1ba4348333ac63cdba50a29aa8)