### PR TITLE
案件削除時に関連売上・経費を順次削除するよう修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -464,11 +464,30 @@ async function handleCaseListAction(event) {
     if (!window.confirm("この案件を削除しますか？関連する売上・経費も削除されます。")) return;
 
     await withLoading(async () => {
-      const { error } = await sbClient.from("cases").delete().eq("id", id).eq("user_id", currentUser.id);
-      if (error) throw error;
+      const salesDeleteRes = await sbClient
+        .from("sales")
+        .delete()
+        .eq("case_id", id)
+        .eq("user_id", currentUser.id);
+      if (salesDeleteRes.error) throw salesDeleteRes.error;
+
+      const expensesDeleteRes = await sbClient
+        .from("expenses")
+        .delete()
+        .eq("case_id", id)
+        .eq("user_id", currentUser.id);
+      if (expensesDeleteRes.error) throw expensesDeleteRes.error;
+
+      const caseDeleteRes = await sbClient
+        .from("cases")
+        .delete()
+        .eq("id", id)
+        .eq("user_id", currentUser.id);
+      if (caseDeleteRes.error) throw caseDeleteRes.error;
+
       if (editState.caseId === id) resetCaseForm();
       await refreshAfterMutation("案件を削除しました。");
-    }, "案件の削除に失敗しました。");
+    }, "案件と関連データの削除に失敗しました。");
   }
 }
 


### PR DESCRIPTION
### Motivation
- 現状では `cases` を削除しても `sales.case_id` と `expenses.case_id` に紐づくデータが残り孤児データが発生していたため修正する必要がありました。 
- 削除時に関連データも同時に削除し、一覧・ダッシュボード等の再描画が確実に行われるようにする目的です。 
- 削除はユーザ単位で絞り込み、途中エラー発生時には処理を止める要件に対応します。 

### Description
- `app.js` の `handleCaseListAction` の削除分岐を変更し、削除順序を `sales`（`case_id` + `user_id`）→ `expenses`（`case_id` + `user_id`）→ `cases`（`id` + `user_id`）で逐次実行するよう実装しました。 
- 各削除ステップでレスポンスの `error` をチェックして `throw` し、エラー時に後続処理を中断するようにしました。 
- 確認ダイアログ文言は要件通りの文言（既存の `window.confirm` 文言）を使用し、そのまま維持しています。 
- 削除成功時は既存の `refreshAfterMutation("案件を削除しました。")` を呼び出して、内部で `loadAllData()` による一覧／ダッシュボード／案件別利益／月別・年別集計の再描画を行う設計は維持しています。 

### Testing
- `node --check app.js` を実行して構文チェックを行い、エラーなしで成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf4b2cd3c833393c2460c60bcf899)