### PR TITLE
ダッシュボードに未入金アラートカードと未入金一覧（編集導線付き）を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,15 @@ const yearFilter = document.getElementById("year-filter");
 const aggregationRadios = Array.from(document.querySelectorAll('input[name="aggregation-unit"]'));
 const yearlyBreakdown = document.getElementById("yearly-breakdown");
 const yearlyBreakdownBody = document.getElementById("yearly-breakdown-body");
+const unpaidAlertCard = document.getElementById("unpaid-alert-card");
+const unpaidAlertSummary = document.getElementById("unpaid-alert-summary");
+const unpaidAlertPeriod = document.getElementById("unpaid-alert-period");
+const unpaidAlertBody = document.getElementById("unpaid-alert-body");
+const unpaidAlertEmpty = document.getElementById("unpaid-alert-empty");
+const unpaidAlertListWrap = document.getElementById("unpaid-alert-list-wrap");
+const unpaidListBody = document.getElementById("unpaid-list-body");
+const unpaidListEmpty = document.getElementById("unpaid-list-empty");
+const unpaidListWrap = document.getElementById("unpaid-list-wrap");
 
 const caseForm = document.getElementById("case-form");
 const caseList = document.getElementById("case-list");
@@ -155,6 +164,7 @@ function bindEvents() {
   salesList.addEventListener("click", handleSalesListAction);
   expensesList.addEventListener("click", handleExpensesListAction);
   fixedExpensesList.addEventListener("click", handleFixedExpensesListAction);
+  unpaidListBody?.addEventListener("click", handleUnpaidListAction);
   targetMonthInput?.addEventListener("input", handleTargetMonthChange);
   targetYearInput?.addEventListener("input", handleTargetYearChange);
   aggregationRadios.forEach((radio) => radio.addEventListener("change", handleAggregationChange));
@@ -523,15 +533,7 @@ async function handleSalesListAction(event) {
   const id = item.dataset.id;
 
   if (btn.classList.contains("edit-btn")) {
-    const target = state.sales.find((entry) => entry.id === id);
-    if (!target) return;
-    editState.saleId = target.id;
-    saleCaseSelect.value = target.caseId;
-    saleForm.elements.invoiceAmount.value = target.invoiceAmount;
-    saleForm.elements.paidAmount.value = target.paidAmount ?? "";
-    saleForm.elements.paidDate.value = target.paidDate || "";
-    saleForm.elements.isUnpaid.checked = Boolean(target.isUnpaid);
-    saleSubmitBtn.textContent = "売上を更新";
+    startSaleEdit(id);
     return;
   }
 
@@ -574,6 +576,30 @@ async function handleExpensesListAction(event) {
       await refreshAfterMutation("経費を削除しました。");
     }, "経費の削除に失敗しました。");
   }
+}
+
+function handleUnpaidListAction(event) {
+  const btn = event.target;
+  if (!(btn instanceof HTMLButtonElement)) return;
+  const saleId = btn.dataset.saleId;
+  if (!saleId) return;
+  if (btn.classList.contains("edit-sale-btn")) {
+    startSaleEdit(saleId);
+  }
+}
+
+function startSaleEdit(saleId) {
+  const target = state.sales.find((entry) => entry.id === saleId);
+  if (!target) return;
+  activateTab("sales");
+  editState.saleId = target.id;
+  saleCaseSelect.value = target.caseId;
+  saleForm.elements.invoiceAmount.value = target.invoiceAmount;
+  saleForm.elements.paidAmount.value = target.paidAmount ?? "";
+  saleForm.elements.paidDate.value = target.paidDate || "";
+  saleForm.elements.isUnpaid.checked = Boolean(target.isUnpaid);
+  saleSubmitBtn.textContent = "売上を更新";
+  saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 async function handleFixedExpensesListAction(event) {
@@ -919,12 +945,93 @@ function renderDashboard() {
     summaryGrid.appendChild(div);
   });
 
+  renderUnpaidAlert({
+    mode: state.selectedAggregation,
+    monthKey: state.selectedMonth,
+    year: state.selectedYear,
+  });
   renderYearlyBreakdown(salesByMonth, expenseByMonth);
   renderCaseProfitList({
     mode: state.selectedAggregation,
     monthKey: state.selectedMonth,
     year: state.selectedYear,
   });
+  renderUnpaidList();
+}
+
+function renderUnpaidAlert(filter = {}) {
+  const unpaidSales = getUnpaidSales();
+  const count = unpaidSales.length;
+  const totalUnpaidAmount = unpaidSales.reduce((sum, sale) => sum + getUnpaidAmount(sale), 0);
+  const filteredUnpaid = unpaidSales.filter((sale) => isWithinFilterDate(sale.paidDate || sale.createdAt, filter));
+  const periodCount = filteredUnpaid.length;
+  const periodAmount = filteredUnpaid.reduce((sum, sale) => sum + getUnpaidAmount(sale), 0);
+
+  if (unpaidAlertCard) unpaidAlertCard.classList.toggle("has-unpaid", count > 0);
+  if (unpaidAlertSummary) {
+    unpaidAlertSummary.textContent = count > 0
+      ? `未入金 ${count}件 / 未入金合計 ${formatCurrency(totalUnpaidAmount)}`
+      : "未入金はありません。";
+  }
+  if (unpaidAlertPeriod) {
+    unpaidAlertPeriod.textContent = filter.mode === "year"
+      ? `対象年(${filter.year}年): ${periodCount}件 / ${formatCurrency(periodAmount)}`
+      : `対象月(${monthLabel(filter.monthKey || state.selectedMonth)}): ${periodCount}件 / ${formatCurrency(periodAmount)}`;
+  }
+  if (unpaidAlertEmpty) unpaidAlertEmpty.hidden = count > 0;
+  if (unpaidAlertListWrap) unpaidAlertListWrap.hidden = count === 0;
+  if (!unpaidAlertBody) return;
+  unpaidAlertBody.innerHTML = "";
+
+  unpaidSales
+    .slice()
+    .sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt))
+    .forEach((sale) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${escapeHtml(resolveCaseName(sale.caseId))}</td>
+        <td>${formatCurrency(sale.invoiceAmount)}</td>
+        <td>${formatCurrency(sale.paidAmount)}</td>
+        <td>${formatCurrency(getUnpaidAmount(sale))}</td>
+        <td>${formatDate(sale.paidDate || toDateString(sale.createdAt))}</td>
+      `;
+      unpaidAlertBody.appendChild(tr);
+    });
+}
+
+function renderUnpaidList() {
+  const unpaidSales = getUnpaidSales().slice().sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt));
+  if (!unpaidListBody || !unpaidListEmpty || !unpaidListWrap) return;
+  unpaidListBody.innerHTML = "";
+  unpaidListEmpty.hidden = unpaidSales.length > 0;
+  unpaidListWrap.hidden = unpaidSales.length === 0;
+
+  unpaidSales.forEach((sale) => {
+    const linkedCase = state.cases.find((entry) => entry.id === sale.caseId);
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${escapeHtml(linkedCase?.customerName || "（削除済み顧客）")}</td>
+      <td>${escapeHtml(linkedCase?.caseName || "（削除済み案件）")}</td>
+      <td>${formatCurrency(sale.invoiceAmount)}</td>
+      <td>${formatCurrency(sale.paidAmount)}</td>
+      <td>${formatCurrency(getUnpaidAmount(sale))}</td>
+      <td>${formatDate(sale.paidDate)}</td>
+      <td><button type="button" class="secondary-btn edit-sale-btn" data-sale-id="${sale.id}">編集</button></td>
+    `;
+    unpaidListBody.appendChild(tr);
+  });
+}
+
+function getUnpaidSales() {
+  return state.sales.filter((sale) => {
+    const invoiceAmount = sale.invoiceAmount ?? 0;
+    const paidAmount = sale.paidAmount ?? 0;
+    return Boolean(sale.isUnpaid) || paidAmount < invoiceAmount || !sale.paidDate;
+  });
+}
+
+function getUnpaidAmount(sale) {
+  return Math.max((sale.invoiceAmount ?? 0) - (sale.paidAmount ?? 0), 0);
 }
 
 function renderCaseOptions() {
@@ -1234,6 +1341,12 @@ function formatDate(dateText) {
   const date = new Date(dateText);
   if (Number.isNaN(date.getTime())) return "未設定";
   return new Intl.DateTimeFormat("ja-JP").format(date);
+}
+
+function toDateString(dateSource) {
+  const date = dateSource instanceof Date ? dateSource : new Date(dateSource);
+  if (Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
 function normalizeAmount(raw) {

--- a/index.html
+++ b/index.html
@@ -111,6 +111,28 @@
 
         <section class="dashboard panel">
           <h2>ダッシュボード</h2>
+          <section id="unpaid-alert-card" class="unpaid-alert-card" aria-live="polite">
+            <div class="unpaid-alert-header">
+              <h3>未入金アラート</h3>
+              <p id="unpaid-alert-period" class="unpaid-alert-period"></p>
+            </div>
+            <p id="unpaid-alert-summary" class="unpaid-alert-summary"></p>
+            <div id="unpaid-alert-empty" class="empty" hidden>未入金はありません。</div>
+            <div id="unpaid-alert-list-wrap" class="table-wrap" hidden>
+              <table class="unpaid-alert-table">
+                <thead>
+                  <tr>
+                    <th>対象案件</th>
+                    <th>請求額</th>
+                    <th>入金額</th>
+                    <th>未入金額</th>
+                    <th>入金予定日/請求日</th>
+                  </tr>
+                </thead>
+                <tbody id="unpaid-alert-body"></tbody>
+              </table>
+            </div>
+          </section>
           <div class="dashboard-filter-group">
             <fieldset class="aggregation-switch" aria-label="集計単位の切替">
               <legend>集計単位</legend>
@@ -145,6 +167,24 @@
           <h3 class="subheading">案件別利益一覧</h3>
           <div id="case-profit-empty" class="empty">案件データがありません。</div>
           <ul id="case-profit-list" class="item-list compact-list"></ul>
+          <h3 class="subheading">未入金一覧（全期間）</h3>
+          <div id="unpaid-list-empty" class="empty">未入金はありません。</div>
+          <div id="unpaid-list-wrap" class="table-wrap" hidden>
+            <table>
+              <thead>
+                <tr>
+                  <th>顧客名</th>
+                  <th>案件名</th>
+                  <th>請求額</th>
+                  <th>入金額</th>
+                  <th>未入金額</th>
+                  <th>入金日</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody id="unpaid-list-body"></tbody>
+            </table>
+          </div>
         </section>
 
         <section id="tab-cases" class="tab-panel active">

--- a/styles.css
+++ b/styles.css
@@ -230,6 +230,47 @@ button:hover { background: var(--primary-dark); }
   margin-top: 0.8rem;
 }
 
+.unpaid-alert-card {
+  border: 1px solid #f3d2d2;
+  background: #fff7f7;
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.unpaid-alert-card.has-unpaid {
+  border-color: #c51616;
+  background: #fff0f0;
+}
+
+.unpaid-alert-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.unpaid-alert-header h3 {
+  margin: 0;
+  color: #9f1239;
+}
+
+.unpaid-alert-period {
+  margin: 0;
+  color: #7f1d1d;
+  font-size: 0.9rem;
+}
+
+.unpaid-alert-summary {
+  margin: 0.45rem 0 0.5rem;
+  font-weight: 700;
+}
+
+.unpaid-alert-table thead th {
+  background: #fde8e8;
+}
+
 .table-wrap {
   overflow-x: auto;
 }


### PR DESCRIPTION
### Motivation
- ダッシュボード上で請求済みだが入金が完了していない売上を見落とさないよう、全期間の未入金を目立たせて編集にすぐつなげられるようにする。

### Description
- ダッシュボード上部に「未入金アラート」カードを追加し、未入金件数・未入金合計を表示し、対象案件名・請求額/入金額/未入金額/入金予定日（または請求日）を一覧表示するUIを実装した（`index.html`, `styles.css`）。
- 全期間の「未入金一覧（全期間）」テーブルをダッシュボードに追加し、各行に顧客名・案件名・請求額・入金額・未入金額・入金日・編集ボタンを表示するUIを実装した（`index.html`）。
- 未入金判定ロジックを `getUnpaidSales()` に実装し、判定条件は `is_unpaid === true` または `paid_amount < invoice_amount` または `paid_date` が空のいずれかであるようにした（`app.js`）。
- アラートは全期間を集計して表示しつつ、ダッシュボードの対象月/対象年フィルタに合わせて該当期間の小計を補助表示する `renderUnpaidAlert()` を追加した（`app.js`）。
- 未入金一覧の各行「編集」ボタンから既存の売上編集フォームへ遷移して値をセットする導線を追加し、共通関数 `startSaleEdit()` を作成して既存の売上一覧編集処理と統合した（`app.js`）。
- 未入金あり時は赤系で強調表示するスタイルを追加し、未入金0件時は「未入金はありません。」を表示する挙動を実装した（`styles.css`, `index.html`, `app.js`）。
- 既存の Supabase 連携や既存の CSV/Excel/集計機能はそのまま動作するようにし、フロントエンドのみの変更に止めている（`index.html`, `app.js`, `styles.css`）。

### Testing
- 自動構文チェックとして `node --check app.js` を実行してエラーがないことを確認した（成功）。
- 変更はフロントエンドの HTML/CSS/JavaScript のみで行っており、既存の Supabase API 呼び出しやデータロード処理はそのまま使用しているため、既存の自動化テストは影響を受けない想定である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb07905f208333b2e3a920eedaa96d)