### PR TITLE
ダッシュボードに請求漏れアラートと売上登録導線を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,11 @@ const unpaidAlertPeriod = document.getElementById("unpaid-alert-period");
 const unpaidAlertBody = document.getElementById("unpaid-alert-body");
 const unpaidAlertEmpty = document.getElementById("unpaid-alert-empty");
 const unpaidAlertListWrap = document.getElementById("unpaid-alert-list-wrap");
+const billingLeakAlertCard = document.getElementById("billing-leak-alert-card");
+const billingLeakAlertSummary = document.getElementById("billing-leak-alert-summary");
+const billingLeakAlertBody = document.getElementById("billing-leak-alert-body");
+const billingLeakAlertEmpty = document.getElementById("billing-leak-alert-empty");
+const billingLeakAlertListWrap = document.getElementById("billing-leak-alert-list-wrap");
 const unpaidListBody = document.getElementById("unpaid-list-body");
 const unpaidListEmpty = document.getElementById("unpaid-list-empty");
 const unpaidListWrap = document.getElementById("unpaid-list-wrap");
@@ -170,6 +175,7 @@ function bindEvents() {
   expensesList.addEventListener("click", handleExpensesListAction);
   fixedExpensesList.addEventListener("click", handleFixedExpensesListAction);
   unpaidListBody?.addEventListener("click", handleUnpaidListAction);
+  billingLeakAlertBody?.addEventListener("click", handleBillingLeakAlertAction);
   targetMonthInput?.addEventListener("input", handleTargetMonthChange);
   targetYearInput?.addEventListener("input", handleTargetYearChange);
   aggregationRadios.forEach((radio) => radio.addEventListener("change", handleAggregationChange));
@@ -609,6 +615,16 @@ function handleUnpaidListAction(event) {
   }
 }
 
+function handleBillingLeakAlertAction(event) {
+  const btn = event.target;
+  if (!(btn instanceof HTMLButtonElement)) return;
+  const caseId = btn.dataset.caseId;
+  if (!caseId) return;
+  if (btn.classList.contains("register-sale-btn")) {
+    openSaleFormForCase(caseId);
+  }
+}
+
 function startSaleEdit(saleId) {
   const target = state.sales.find((entry) => entry.id === saleId);
   if (!target) return;
@@ -620,6 +636,19 @@ function startSaleEdit(saleId) {
   saleForm.elements.paidDate.value = target.paidDate || "";
   saleForm.elements.isUnpaid.checked = Boolean(target.isUnpaid);
   saleSubmitBtn.textContent = "売上を更新";
+  saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function openSaleFormForCase(caseId) {
+  const targetCase = state.cases.find((entry) => entry.id === caseId);
+  if (!targetCase || !saleCaseSelect) return;
+  activateTab("sales");
+  resetSaleForm();
+  saleCaseSelect.value = targetCase.id;
+  saleForm.elements.invoiceAmount.value = targetCase.estimateAmount ?? "";
+  saleForm.elements.paidAmount.value = "";
+  saleForm.elements.paidDate.value = "";
+  saleForm.elements.isUnpaid.checked = true;
   saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
@@ -972,6 +1001,7 @@ function renderDashboard() {
     monthKey: state.selectedMonth,
     year: state.selectedYear,
   });
+  renderBillingLeakAlert();
   renderYearlyBreakdown(salesByMonth, expenseByMonth);
   renderCaseProfitList({
     mode: state.selectedAggregation,
@@ -1061,6 +1091,43 @@ function renderUnpaidList() {
       <td><button type="button" class="secondary-btn edit-sale-btn" data-sale-id="${sale.id}">編集</button></td>
     `;
     unpaidListBody.appendChild(tr);
+  });
+}
+
+function renderBillingLeakAlert() {
+  const billingLeakCases = getBillingLeakCandidates()
+    .slice()
+    .sort(sortCases);
+  const count = billingLeakCases.length;
+
+  if (billingLeakAlertCard) billingLeakAlertCard.classList.toggle("has-leak", count > 0);
+  if (billingLeakAlertSummary) {
+    billingLeakAlertSummary.textContent = count > 0
+      ? `請求漏れ候補 ${count}件`
+      : "請求漏れ候補はありません。";
+  }
+  if (billingLeakAlertEmpty) billingLeakAlertEmpty.hidden = count > 0;
+  if (billingLeakAlertListWrap) billingLeakAlertListWrap.hidden = count === 0;
+  if (!billingLeakAlertBody) return;
+  billingLeakAlertBody.innerHTML = "";
+
+  billingLeakCases.forEach((entry) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${escapeHtml(entry.customerName)}</td>
+      <td>${escapeHtml(entry.caseName)}</td>
+      <td>${formatCurrency(entry.estimateAmount)}</td>
+      <td>${escapeHtml(entry.status || "完了")}</td>
+      <td><button type="button" class="secondary-btn register-sale-btn" data-case-id="${entry.id}">売上登録</button></td>
+    `;
+    billingLeakAlertBody.appendChild(tr);
+  });
+}
+
+function getBillingLeakCandidates() {
+  return state.cases.filter((entry) => {
+    if (getStatusCategory(entry.status) !== "完了") return false;
+    return !state.sales.some((sale) => sale.caseId === entry.id);
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -141,6 +141,27 @@
               </table>
             </div>
           </section>
+          <section id="billing-leak-alert-card" class="billing-leak-alert-card" aria-live="polite">
+            <div class="billing-leak-alert-header">
+              <h3>請求漏れアラート</h3>
+            </div>
+            <p id="billing-leak-alert-summary" class="billing-leak-alert-summary"></p>
+            <div id="billing-leak-alert-empty" class="empty">請求漏れ候補はありません。</div>
+            <div id="billing-leak-alert-list-wrap" class="table-wrap" hidden>
+              <table class="billing-leak-alert-table">
+                <thead>
+                  <tr>
+                    <th>顧客名</th>
+                    <th>案件名</th>
+                    <th>見積金額</th>
+                    <th>完了ステータス</th>
+                    <th>操作</th>
+                  </tr>
+                </thead>
+                <tbody id="billing-leak-alert-body"></tbody>
+              </table>
+            </div>
+          </section>
           <div class="dashboard-filter-group">
             <fieldset class="aggregation-switch" aria-label="集計単位の切替">
               <legend>集計単位</legend>

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,14 @@ button:hover { background: var(--primary-dark); }
   margin-bottom: 0.75rem;
 }
 
+.billing-leak-alert-card {
+  border: 1px solid #fed7aa;
+  background: #fffaf3;
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
 .status-summary-card {
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -316,6 +324,11 @@ button:hover { background: var(--primary-dark); }
   background: #fff0f0;
 }
 
+.billing-leak-alert-card.has-leak {
+  border-color: #ea580c;
+  background: #fff4ed;
+}
+
 .unpaid-alert-header {
   display: flex;
   justify-content: space-between;
@@ -329,6 +342,11 @@ button:hover { background: var(--primary-dark); }
   color: #9f1239;
 }
 
+.billing-leak-alert-header h3 {
+  margin: 0;
+  color: #c2410c;
+}
+
 .unpaid-alert-period {
   margin: 0;
   color: #7f1d1d;
@@ -340,8 +358,17 @@ button:hover { background: var(--primary-dark); }
   font-weight: 700;
 }
 
+.billing-leak-alert-summary {
+  margin: 0.45rem 0 0.5rem;
+  font-weight: 700;
+}
+
 .unpaid-alert-table thead th {
   background: #fde8e8;
+}
+
+.billing-leak-alert-table thead th {
+  background: #ffedd5;
 }
 
 .table-wrap {


### PR DESCRIPTION
### Motivation
- 案件が「完了」なのに売上データがないケースを検出して請求漏れを防ぐため、ダッシュボード上に視認性の高いアラートを追加する。判定条件は `cases.status === "完了"` かつ 該当 `case_id` に紐づく `sales` が存在しないこととする。

### Description
- UI: 未入金アラートの近くに「請求漏れアラート」カードを追加し、件数サマリとテーブル（顧客名/案件名/見積金額/完了ステータス/売上登録ボタン）を表示する HTML を追加した（`index.html`）。
- スタイル: 候補あり時はオレンジ〜赤系で強調するカード用の CSS を追加した（`styles.css`）。
- ロジック: 完了案件で売上が未登録の案件を抽出する `getBillingLeakCandidates`、一覧描画のための `renderBillingLeakAlert`、およびアラート内操作を受ける `handleBillingLeakAlertAction` を追加しダッシュボード描画フローに組み込んだ（`app.js`）。
- 操作導線: アラート行の「売上登録」ボタンで `openSaleFormForCase` を呼び出して売上タブへ遷移し、対象案件を `sale` フォームの案件選択に自動セットし、請求額に案件の見積金額を自動入力する（未入金フラグを ON に設定）。
- 既存機能は上書きせず追加実装のみで行い、未入金アラートや集計ロジック、Supabase 連携等の既存挙動は維持している（変更ファイル: `index.html`, `app.js`, `styles.css`）。

### Testing
- `node --check app.js` による構文チェックは成功しエラーはありませんでした。
- 変更はフロントエンド（HTML/CSS/JS）実装のみのため、動作確認はブラウザでの手動検証が必要です（自動 UI テストは未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1229108c833383d0223625ade64d)