### PR TITLE
案件の作業メモ・次回対応管理とダッシュボード次回対応アラートを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ python -m http.server 8000
 ```
 
 その後 `http://localhost:8000` を開いて動作確認します。
+
+
+## 案件メモ・次回対応管理のための追加SQL
+
+`cases` テーブルに以下カラムが未追加の場合は実行してください。
+
+```sql
+alter table cases add column if not exists work_memo text;
+alter table cases add column if not exists next_action_date date;
+alter table cases add column if not exists next_action text;
+```

--- a/app.js
+++ b/app.js
@@ -86,6 +86,11 @@ const deadlineAlertSummary = document.getElementById("deadline-alert-summary");
 const deadlineAlertBody = document.getElementById("deadline-alert-body");
 const deadlineAlertEmpty = document.getElementById("deadline-alert-empty");
 const deadlineAlertListWrap = document.getElementById("deadline-alert-list-wrap");
+const nextActionAlertCard = document.getElementById("next-action-alert-card");
+const nextActionAlertSummary = document.getElementById("next-action-alert-summary");
+const nextActionAlertBody = document.getElementById("next-action-alert-body");
+const nextActionAlertEmpty = document.getElementById("next-action-alert-empty");
+const nextActionAlertListWrap = document.getElementById("next-action-alert-list-wrap");
 
 const caseForm = document.getElementById("case-form");
 const caseList = document.getElementById("case-list");
@@ -204,6 +209,7 @@ function bindEvents() {
   statusFilterClearBtn?.addEventListener("click", () => applyCaseStatusFilter("all"));
   deadlineAlertSummary?.addEventListener("click", handleDeadlineAlertClick);
   deadlineAlertBody?.addEventListener("click", handleDeadlineAlertClick);
+  nextActionAlertBody?.addEventListener("click", handleNextActionAlertClick);
   caseSearchInput?.addEventListener("input", handleCaseSearchInput);
   caseStatusFilterSelect?.addEventListener("change", handleCaseStatusFilterChange);
   caseDeadlineFilterSelect?.addEventListener("change", handleCaseDeadlineFilterChange);
@@ -288,6 +294,13 @@ function handleDeadlineAlertClick(event) {
     applyCaseDeadlineFilter(filter, { activateCases: true });
     return;
   }
+  const caseId = button.dataset.caseId;
+  if (caseId) startCaseEdit(caseId);
+}
+
+function handleNextActionAlertClick(event) {
+  const button = event.target.closest("button");
+  if (!(button instanceof HTMLButtonElement)) return;
   const caseId = button.dataset.caseId;
   if (caseId) startCaseEdit(caseId);
 }
@@ -466,6 +479,9 @@ async function handleCaseSubmit(event) {
     estimate_amount: normalizeAmount(caseForm.elements.amount.value),
     received_date: caseForm.elements.receivedDate.value || null,
     due_date: caseForm.elements.dueDate.value || null,
+    work_memo: asTrimmedText(caseForm.elements.workMemo.value) || null,
+    next_action_date: caseForm.elements.nextActionDate.value || null,
+    next_action: asTrimmedText(caseForm.elements.nextAction.value) || null,
     status: normalizeStatus(caseForm.elements.status.value),
   };
 
@@ -649,6 +665,9 @@ function startCaseEdit(caseId) {
   caseForm.elements.amount.value = target.estimateAmount ?? "";
   caseForm.elements.receivedDate.value = target.receivedDate || "";
   caseForm.elements.dueDate.value = target.dueDate || "";
+  caseForm.elements.workMemo.value = target.workMemo || "";
+  caseForm.elements.nextActionDate.value = target.nextActionDate || "";
+  caseForm.elements.nextAction.value = target.nextAction || "";
   caseForm.elements.status.value = normalizeStatus(target.status);
   caseSubmitBtn.textContent = "案件を更新";
   caseForm.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -834,8 +853,11 @@ function handleExportCasesCsv() {
     received_date: entry.receivedDate || "",
     due_date: entry.dueDate || "",
     status: normalizeStoredStatus(entry.status),
+    work_memo: entry.workMemo || "",
+    next_action_date: entry.nextActionDate || "",
+    next_action: entry.nextAction || "",
   }));
-  downloadCsvFile("cases.csv", ["customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status"], rows);
+  downloadCsvFile("cases.csv", ["customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status", "work_memo", "next_action_date", "next_action"], rows);
 }
 
 function handleExportSalesCsv() {
@@ -879,7 +901,7 @@ function handleExportFixedExpensesCsv() {
 function handleExportAllCsv() {
   const headers = [
     "data_type",
-    "customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status",
+    "customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status", "work_memo", "next_action_date", "next_action",
     "invoice_amount", "paid_amount", "paid_date", "is_unpaid",
     "date", "content", "amount",
     "day_of_month", "start_date", "active",
@@ -895,6 +917,9 @@ function handleExportAllCsv() {
       received_date: entry.receivedDate || "",
       due_date: entry.dueDate || "",
       status: normalizeStoredStatus(entry.status),
+      work_memo: entry.workMemo || "",
+      next_action_date: entry.nextActionDate || "",
+      next_action: entry.nextAction || "",
     });
   });
   state.sales.forEach((entry) => {
@@ -962,7 +987,7 @@ function exportExcel() {
 
   try {
     const workbook = XLSX.utils.book_new();
-    const caseHeaders = ["customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status"];
+    const caseHeaders = ["customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status", "work_memo", "next_action_date", "next_action"];
     const saleHeaders = ["case_name", "invoice_amount", "paid_amount", "paid_date", "is_unpaid"];
     const expenseHeaders = ["case_name", "date", "content", "amount"];
     const fixedExpenseHeaders = ["content", "amount", "day_of_month", "start_date", "active"];
@@ -973,6 +998,9 @@ function exportExcel() {
       received_date: entry.receivedDate || "",
       due_date: entry.dueDate || "",
       status: normalizeStoredStatus(entry.status),
+      work_memo: entry.workMemo || "",
+      next_action_date: entry.nextActionDate || "",
+      next_action: entry.nextAction || "",
     }));
     const saleRows = state.sales.map((entry) => {
       const foundCase = state.cases.find((c) => c.id === entry.caseId);
@@ -1096,6 +1124,7 @@ function renderDashboard() {
     div.innerHTML = `<p class="label">${card.label}</p><p class="value">${card.value}</p>`;
     summaryGrid.appendChild(div);
   });
+  renderNextActionAlertCard();
   renderDeadlineAlertCard();
   renderStatusSummaryCard();
 
@@ -1189,6 +1218,63 @@ function getCaseDeadlineInfo(entry) {
   if (remainingDays <= 7) return { deadlineStatus: "within7", remainingDays };
   if (remainingDays <= 30) return { deadlineStatus: "within30", remainingDays };
   return null;
+}
+
+
+function renderNextActionAlertCard() {
+  if (!nextActionAlertCard || !nextActionAlertSummary || !nextActionAlertBody || !nextActionAlertEmpty || !nextActionAlertListWrap) return;
+  const targets = getNextActionAlertTargets();
+  nextActionAlertCard.classList.toggle("has-alert", targets.length > 0);
+  nextActionAlertSummary.textContent = `対象 ${targets.length}件`;
+  nextActionAlertBody.innerHTML = "";
+  nextActionAlertEmpty.hidden = targets.length > 0;
+  nextActionAlertListWrap.hidden = targets.length === 0;
+  if (!targets.length) return;
+
+  targets
+    .slice()
+    .sort((a, b) => {
+      if (a.remainingDays !== b.remainingDays) return a.remainingDays - b.remainingDays;
+      return sortCases(a, b);
+    })
+    .forEach((entry) => {
+      const tr = document.createElement("tr");
+      tr.className = entry.urgencyClass;
+      tr.innerHTML = `
+        <td>${escapeHtml(entry.customerName)}</td>
+        <td>${escapeHtml(entry.caseName)}</td>
+        <td>${formatDate(entry.nextActionDate)}</td>
+        <td>${escapeHtml(entry.nextAction || "未設定")}</td>
+        <td><button type="button" class="secondary-btn" data-case-id="${entry.id}">編集</button></td>
+      `;
+      nextActionAlertBody.appendChild(tr);
+    });
+}
+
+function getNextActionAlertTargets() {
+  return state.cases
+    .map((entry) => {
+      const info = getNextActionInfo(entry);
+      if (!info) return null;
+      return { ...entry, ...info };
+    })
+    .filter((entry) => entry && entry.remainingDays <= 0 && getStatusCategory(entry.status) !== "完了");
+}
+
+function getNextActionInfo(entry) {
+  if (!entry?.nextActionDate) return null;
+  const nextActionTimestamp = toDateOnlyTimestamp(entry.nextActionDate);
+  const todayTimestamp = getTodayTimestamp();
+  if (!Number.isFinite(nextActionTimestamp) || !Number.isFinite(todayTimestamp)) return null;
+  const remainingDays = Math.floor((nextActionTimestamp - todayTimestamp) / 86400000);
+  const urgencyClass = remainingDays <= 0 ? "next-action-overdue" : remainingDays <= 3 ? "next-action-within3" : remainingDays <= 7 ? "next-action-within7" : "";
+  return { remainingDays, urgencyClass };
+}
+
+function truncateText(value, maxLength = 80) {
+  const text = String(value || "").trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}…`;
 }
 
 function renderStatusSummaryCard() {
@@ -1353,12 +1439,19 @@ function renderCases() {
     const item = node.querySelector(".item");
     const title = node.querySelector(".title");
     const meta = node.querySelector(".meta");
+    const caseWorkMeta = node.querySelector(".case-work-meta");
     const profitMeta = node.querySelector(".profit-meta");
     const totals = profitsByCaseId[entry.id] || { sales: 0, expenses: 0, profit: 0 };
+    const nextActionInfo = getNextActionInfo(entry);
 
     item.dataset.id = entry.id;
     title.textContent = `${entry.customerName}｜${entry.caseName}`;
-    meta.textContent = `見積: ${formatCurrency(entry.estimateAmount)} / ステータス: ${entry.status} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)}`;
+    meta.textContent = `見積: ${formatCurrency(entry.estimateAmount)} / ステータス: ${entry.status} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)} / 次回対応日: ${formatDate(entry.nextActionDate)} / 次回対応内容: ${entry.nextAction || "未設定"}`;
+    if (caseWorkMeta) {
+      caseWorkMeta.textContent = `作業メモ: ${truncateText(entry.workMemo || "未設定", 60)}`;
+      caseWorkMeta.classList.remove("next-action-overdue", "next-action-within3", "next-action-within7");
+      if (nextActionInfo) caseWorkMeta.classList.add(nextActionInfo.urgencyClass);
+    }
     profitMeta.textContent = `売上合計: ${formatCurrency(totals.sales)} / 経費合計: ${formatCurrency(totals.expenses)} / 利益: ${formatCurrency(totals.profit)}`;
     profitMeta.classList.toggle("loss-text", totals.profit < 0);
     caseList.appendChild(node);
@@ -1712,6 +1805,9 @@ function matchesCaseSearch(entry, query) {
     entry.customerName,
     entry.caseName,
     entry.status,
+    entry.nextAction,
+    entry.nextActionDate,
+    entry.workMemo,
   ]
     .map((value) => String(value || "").toLowerCase())
     .join(" ");
@@ -2078,6 +2174,9 @@ async function importRowsByType(importType, tableData) {
           received_date: parseFlexibleDate(row.received_date),
           due_date: parseFlexibleDate(row.due_date),
           status: normalizeStoredStatus(row.status),
+          work_memo: asTrimmedText(row.work_memo) || null,
+          next_action_date: parseFlexibleDate(row.next_action_date),
+          next_action: asTrimmedText(row.next_action) || null,
         });
       } catch (_error) {
         result.errorCount += 1;
@@ -2226,6 +2325,9 @@ function mapCaseFromDb(row) {
     receivedDate: row.received_date || "",
     dueDate: row.due_date || "",
     status: normalizeStoredStatus(row.status),
+    workMemo: row.work_memo || "",
+    nextActionDate: row.next_action_date || "",
+    nextAction: row.next_action || "",
     createdAt: Date.parse(row.created_at) || Date.now(),
     updatedAt: Date.parse(row.updated_at) || Date.now(),
   };

--- a/index.html
+++ b/index.html
@@ -111,6 +111,27 @@
 
         <section class="dashboard panel">
           <h2>ダッシュボード</h2>
+          <section id="next-action-alert-card" class="next-action-alert-card" aria-live="polite">
+            <div class="next-action-alert-header">
+              <h3>次回対応アラート</h3>
+              <p id="next-action-alert-summary" class="next-action-alert-summary">対象 0件</p>
+            </div>
+            <div id="next-action-alert-empty" class="empty">次回対応が必要な案件はありません。</div>
+            <div id="next-action-alert-list-wrap" class="table-wrap" hidden>
+              <table class="next-action-alert-table">
+                <thead>
+                  <tr>
+                    <th>顧客名</th>
+                    <th>案件名</th>
+                    <th>次回対応日</th>
+                    <th>次回対応内容</th>
+                    <th>編集</th>
+                  </tr>
+                </thead>
+                <tbody id="next-action-alert-body"></tbody>
+              </table>
+            </div>
+          </section>
           <section id="deadline-alert-card" class="deadline-alert-card" aria-live="polite">
             <div class="deadline-alert-header">
               <h3>期限アラート</h3>
@@ -263,6 +284,20 @@
                   <label>
                     期限日
                     <input id="due-date" name="dueDate" type="date" />
+                  </label>
+                </div>
+                <label>
+                  作業メモ
+                  <textarea id="work-memo" name="workMemo" rows="4" maxlength="2000" placeholder="対応履歴・注意点などを記録"></textarea>
+                </label>
+                <div class="date-grid">
+                  <label>
+                    次回対応日
+                    <input id="next-action-date" name="nextActionDate" type="date" />
+                  </label>
+                  <label>
+                    次回対応内容
+                    <input id="next-action" name="nextAction" type="text" maxlength="200" placeholder="次回やること" />
                   </label>
                 </div>
                 <label>
@@ -445,6 +480,7 @@
         <div>
           <p class="title"></p>
           <p class="meta"></p>
+          <p class="meta case-work-meta"></p>
           <p class="meta profit-meta"></p>
         </div>
         <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>

--- a/styles.css
+++ b/styles.css
@@ -135,7 +135,7 @@ label { display: grid; gap: 0.32rem; font-size: 0.92rem; }
 
 input, select, button { font: inherit; }
 
-input, select {
+input, select, textarea {
   width: 100%;
   padding: 0.58rem 0.65rem;
   border: 1px solid var(--border);
@@ -151,7 +151,7 @@ input, select {
 
 .checkbox input { width: auto; }
 
-input:focus, select:focus, button:focus {
+input:focus, select:focus, textarea:focus, button:focus {
   outline: 2px solid var(--focus);
   outline-offset: 1px;
 }
@@ -248,6 +248,56 @@ button:hover { background: var(--primary-dark); }
   margin-top: 0.8rem;
 }
 
+
+.next-action-alert-card {
+  border: 1px solid #fecaca;
+  background: #fff5f5;
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.next-action-alert-card.has-alert {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.12);
+}
+
+.next-action-alert-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.next-action-alert-header h3,
+.next-action-alert-summary {
+  margin: 0;
+}
+
+.next-action-alert-table tr.next-action-overdue td {
+  background: #fef2f2;
+}
+
+.next-action-alert-table tr.next-action-within3 td {
+  background: #fff7ed;
+}
+
+.next-action-alert-table tr.next-action-within7 td {
+  background: #fefce8;
+}
+
+.case-work-meta.next-action-overdue {
+  color: #b91c1c;
+}
+
+.case-work-meta.next-action-within3 {
+  color: #c2410c;
+}
+
+.case-work-meta.next-action-within7 {
+  color: #a16207;
+}
 .deadline-alert-card {
   border: 1px solid #fde68a;
   background: #fffbeb;


### PR DESCRIPTION
### Motivation
- 案件ごとに「作業メモ」「次回対応日」「次回対応内容」を保存して対応履歴を残し、対応漏れを防止するためのUIとアラートが必要だった。
- ダッシュボードで期限だけでなく「次回対応日」に基づくアラートを表示して、優先度の高い対応を可視化するため。 

### Description
- 案件フォームに `workMemo`（textarea）、`nextActionDate`（date）、`nextAction`（text）を追加して新規登録・編集で保存できるようにした（`index.html` / `app.js`）。
- ダッシュボード上部に `next-action-alert-card` を追加し、判定条件は「`next_action_date` が今日以前 かつ `status` が完了ではない」こととし、件数一覧・顧客名・案件名・次回対応日・次回対応内容・編集ボタンを表示するよう実装した（色分け：今日以前=赤、3日以内=オレンジ、7日以内=黄）。
- 案件一覧カードに次回対応日・次回対応内容・作業メモの抜粋表示を追加し、次回対応の緊急度に応じて作業メモの表示色を変える処理を追加した（`case-item-template` / `renderCases` の修正）。
- Supabase 連携と入出力を拡張し、`cases` の読み書き・CSV/Excel 出力・CSV/Excel取込で `work_memo` / `next_action_date` / `next_action` を扱うようにした（`app.js` のマッピング、`handleExport*`/`exportExcel`/`importRowsByType` 等を更新）。
- スタイルを `styles.css` に追加してアラートカードや色分けクラスを定義し、フォームで `textarea` を扱うためのフォーカススタイルを調整した。 
- `README.md` に `cases` テーブルへ必要なカラムが未作成の場合の追加SQLを追記した: `alter table cases add column if not exists work_memo text;`, `alter table cases add column if not exists next_action_date date;`, `alter table cases add column if not exists next_action text;`。

### Testing
- `node --check app.js` を実行して構文エラーがないことを確認済み（成功）。
- 既存の機能（期限アラート、検索・フィルター、請求漏れ/未入金アラート、CSV/Excel入出力、Supabase連携）は互換性を保つ実装となっており、アプリ全体のレンダリング関数から新機能を呼び出す形で統合済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1d30e7608333b3f684975b5fb0d4)