### PR TITLE
Fix 日報タブ切替でダッシュボードが残る不具合

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,6 +55,7 @@ const panels = {
   expenses: document.getElementById("tab-expenses"),
   "daily-reports": document.getElementById("tab-daily-reports"),
 };
+const dashboardSection = document.querySelector(".dashboard");
 
 const summaryGrid = document.getElementById("summary-grid");
 const worktimeSummaryGrid = document.getElementById("worktime-summary-grid");
@@ -1171,8 +1172,24 @@ function renderAfterDataChanged() {
 }
 
 function activateTab(tabKey) {
-  tabs.forEach((btn) => btn.classList.toggle("active", btn.dataset.tab === tabKey));
-  Object.entries(panels).forEach(([key, panel]) => panel.classList.toggle("active", key === tabKey));
+  const normalizedTabKey = normalizeTabKey(tabKey);
+
+  tabs.forEach((btn) => btn.classList.toggle("active", normalizeTabKey(btn.dataset.tab) === normalizedTabKey));
+  Object.entries(panels).forEach(([key, panel]) => panel.classList.toggle("active", key === normalizedTabKey));
+
+  if (dashboardSection) {
+    dashboardSection.hidden = normalizedTabKey === "daily-reports";
+  }
+}
+
+function normalizeTabKey(tabKey) {
+  const key = String(tabKey || "").trim();
+  if (!key) return "cases";
+  if (["daily-reports", "dailyReports", "report", "reports", "日報"].includes(key)) return "daily-reports";
+  if (["cases", "案件"].includes(key)) return "cases";
+  if (["sales", "売上"].includes(key)) return "sales";
+  if (["expenses", "経費"].includes(key)) return "expenses";
+  return "cases";
 }
 
 function renderDashboard() {


### PR DESCRIPTION
### Motivation
- 日報タブを選択してもダッシュボードが表示されたままになり、日報専用パネル（登録フォーム/一覧/集計）が表示されない不具合を修正するため。

### Description
- タブキーの別名（`dailyReports` / `report` / `日報` など）を吸収する `normalizeTabKey` を追加し、タブ判定を正規化するようにした。 
- `activateTab` を更新してタブボタンの `active` と各タブパネルの表示切替を正規化キーで行うようにした。 
- 日報タブ選択時にダッシュボードセクション（`.dashboard`）へ `hidden` を付与して非表示にし、案件/売上/経費タブでは従来どおりダッシュボードを表示するようにした。 
- 既存の `daily_reports` の読み込み・登録・編集・削除や Supabase 連携などのデータ処理ロジックは変更していないため、既存機能に影響を与えない設計にしている。 

### Testing
- `node --check app.js` を実行して構文チェックは成功した（`node --check app.js`：成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2a6c41588333ac06001959507958)