### PR TITLE
日報一覧をカード表示に変更し検索・日付フィルターを追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,8 @@ const state = {
   caseDeadlineFilter: "all",
   salesSearchQuery: "",
   expensesSearchQuery: "",
+  dailyReportSearchQuery: "",
+  dailyReportDateFilter: "all",
 };
 const editState = { caseId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null };
 
@@ -135,6 +137,10 @@ const dailyReportsBody = document.getElementById("daily-reports-body");
 const dailyReportsEmpty = document.getElementById("daily-reports-empty");
 const dailyReportsListWrap = document.getElementById("daily-reports-list-wrap");
 const dailyReportSummaryList = document.getElementById("daily-report-summary-list");
+const dailyReportSearchInput = document.getElementById("daily-report-search-input");
+const dailyReportDateFilterSelect = document.getElementById("daily-report-date-filter");
+const dailyReportFilterClearBtn = document.getElementById("daily-report-filter-clear-btn");
+const dailyReportFilterCount = document.getElementById("daily-report-filter-count");
 
 const caseItemTemplate = document.getElementById("case-item-template");
 const saleItemTemplate = document.getElementById("sale-item-template");
@@ -231,6 +237,9 @@ function bindEvents() {
   salesFilterClearBtn?.addEventListener("click", clearSalesSearch);
   expensesSearchInput?.addEventListener("input", handleExpensesSearchInput);
   expensesFilterClearBtn?.addEventListener("click", clearExpensesSearch);
+  dailyReportSearchInput?.addEventListener("input", handleDailyReportSearchInput);
+  dailyReportDateFilterSelect?.addEventListener("change", handleDailyReportDateFilterChange);
+  dailyReportFilterClearBtn?.addEventListener("click", clearDailyReportFilters);
   document.addEventListener("visibilitychange", handleVisibilityChange);
   window.addEventListener("focus", handleWindowFocus);
   window.addEventListener("pageshow", handlePageShow);
@@ -346,6 +355,28 @@ function clearExpensesSearch() {
   state.expensesSearchQuery = "";
   if (expensesSearchInput) expensesSearchInput.value = "";
   renderExpenses();
+}
+
+function handleDailyReportSearchInput(event) {
+  state.dailyReportSearchQuery = String(event?.target?.value ?? "").trim().toLowerCase();
+  renderDailyReports();
+}
+
+function handleDailyReportDateFilterChange(event) {
+  applyDailyReportDateFilter(event?.target?.value || "all");
+}
+
+function applyDailyReportDateFilter(nextFilter) {
+  const normalized = ["all", "today", "month"].includes(nextFilter) ? nextFilter : "all";
+  state.dailyReportDateFilter = normalized;
+  if (dailyReportDateFilterSelect) dailyReportDateFilterSelect.value = normalized;
+  renderDailyReports();
+}
+
+function clearDailyReportFilters() {
+  state.dailyReportSearchQuery = "";
+  applyDailyReportDateFilter("all");
+  if (dailyReportSearchInput) dailyReportSearchInput.value = "";
 }
 
 
@@ -1532,25 +1563,59 @@ function renderCaseOptions() {
 function renderDailyReports() {
   if (!dailyReportsBody || !dailyReportsEmpty || !dailyReportsListWrap || !dailyReportSummaryList) return;
   const sorted = state.dailyReports.slice().sort((a, b) => toSortTimestamp(b.reportDate) - toSortTimestamp(a.reportDate));
-  dailyReportsBody.innerHTML = "";
-
-  sorted.forEach((entry) => {
-    const tr = document.createElement("tr");
-    tr.innerHTML = `
-      <td>${formatDate(entry.reportDate)}</td>
-      <td>${escapeHtml(resolveDailyReportCaseName(entry.caseId))}</td>
-      <td>${escapeHtml(truncateText(entry.workContent || "", 120))}</td>
-      <td>${formatMinutes(entry.workMinutes)}</td>
-      <td>${escapeHtml(truncateText(entry.nextAction || "未設定", 80))}</td>
-      <td>${escapeHtml(truncateText(entry.memo || "未設定", 80))}</td>
-      <td><button type="button" class="secondary-btn edit-daily-report-btn" data-daily-report-id="${entry.id}">編集</button></td>
-      <td><button type="button" class="danger-btn delete-daily-report-btn" data-daily-report-id="${entry.id}">削除</button></td>
-    `;
-    dailyReportsBody.appendChild(tr);
+  const filtered = sorted.filter((entry) => {
+    if (!matchesDailyReportDateFilter(entry, state.dailyReportDateFilter)) return false;
+    if (!state.dailyReportSearchQuery) return true;
+    return matchesDailyReportSearch(entry, state.dailyReportSearchQuery);
   });
 
-  dailyReportsEmpty.hidden = sorted.length > 0;
-  dailyReportsListWrap.hidden = sorted.length === 0;
+  dailyReportsBody.innerHTML = "";
+
+  filtered.forEach((entry) => {
+    const card = document.createElement("article");
+    card.className = "daily-report-card";
+    card.innerHTML = `
+      <header class="daily-report-card-header">
+        <div>
+          <p class="daily-report-card-date">${formatDate(entry.reportDate)}</p>
+          <p class="daily-report-card-case">${escapeHtml(resolveDailyReportCaseName(entry.caseId))}</p>
+        </div>
+        <div class="daily-report-card-actions">
+          <button type="button" class="secondary-btn edit-daily-report-btn" data-daily-report-id="${entry.id}">編集</button>
+          <button type="button" class="danger-btn delete-daily-report-btn" data-daily-report-id="${entry.id}">削除</button>
+        </div>
+      </header>
+      <dl class="daily-report-card-meta">
+        <div class="daily-report-field-inline">
+          <dt>作業時間</dt>
+          <dd>${formatMinutes(entry.workMinutes)}</dd>
+        </div>
+        <div class="daily-report-field">
+          <dt>作業内容</dt>
+          <dd>${escapeHtml(entry.workContent || "未設定")}</dd>
+        </div>
+        <div class="daily-report-field">
+          <dt>次回対応</dt>
+          <dd>${escapeHtml(entry.nextAction || "未設定")}</dd>
+        </div>
+        <div class="daily-report-field">
+          <dt>メモ</dt>
+          <dd>${escapeHtml(entry.memo || "未設定")}</dd>
+        </div>
+      </dl>
+    `;
+    dailyReportsBody.appendChild(card);
+  });
+
+  dailyReportsEmpty.hidden = filtered.length > 0;
+  dailyReportsListWrap.hidden = filtered.length === 0;
+  dailyReportsEmpty.textContent = filtered.length || (!state.dailyReportSearchQuery && state.dailyReportDateFilter === "all")
+    ? "日報データはまだありません。"
+    : "条件に一致する日報はありません。";
+
+  if (dailyReportFilterCount) {
+    dailyReportFilterCount.textContent = `表示中 ${filtered.length}件 / 全${sorted.length}件`;
+  }
 
   const summary = buildDailyReportSummary();
   dailyReportSummaryList.innerHTML = "";
@@ -1565,6 +1630,28 @@ function renderDailyReports() {
     dailyReportSummaryList.appendChild(li);
   });
 }
+
+function matchesDailyReportSearch(entry, query) {
+  const haystacks = [
+    resolveDailyReportCaseName(entry.caseId),
+    entry.workContent,
+    entry.nextAction,
+    entry.memo,
+  ]
+    .map((value) => String(value || "").toLowerCase());
+  return haystacks.some((value) => value.includes(query));
+}
+
+function matchesDailyReportDateFilter(entry, filter) {
+  if (filter === "all") return true;
+  const reportDate = entry.reportDate;
+  if (!reportDate) return false;
+  const today = toDateString(new Date());
+  if (filter === "today") return reportDate === today;
+  if (filter === "month") return toMonthKey(reportDate) === toMonthKey(today);
+  return true;
+}
+
 
 function renderCases() {
   caseList.innerHTML = "";

--- a/index.html
+++ b/index.html
@@ -518,23 +518,25 @@
 
             <section class="panel report-list-panel">
               <h2>日報一覧</h2>
+              <div class="search-filter-bar daily-report-filter-bar">
+                <label class="inline-field" for="daily-report-search-input">
+                  キーワード検索
+                  <input id="daily-report-search-input" type="search" placeholder="案件名・作業内容・次回対応・メモで検索" />
+                </label>
+                <label class="inline-field" for="daily-report-date-filter">
+                  日付フィルター
+                  <select id="daily-report-date-filter">
+                    <option value="all">全期間</option>
+                    <option value="today">今日</option>
+                    <option value="month">今月</option>
+                  </select>
+                </label>
+                <button id="daily-report-filter-clear-btn" type="button" class="secondary-btn">条件クリア</button>
+              </div>
+              <p id="daily-report-filter-count" class="filter-count">表示中 0件 / 全0件</p>
               <div id="daily-reports-empty" class="empty">日報データはまだありません。</div>
-              <div id="daily-reports-list-wrap" class="table-wrap" hidden>
-                <table>
-                  <thead>
-                    <tr>
-                      <th>日付</th>
-                      <th>案件名</th>
-                      <th>作業内容</th>
-                      <th>作業時間</th>
-                      <th>次回対応</th>
-                      <th>メモ</th>
-                      <th>編集</th>
-                      <th>削除</th>
-                    </tr>
-                  </thead>
-                  <tbody id="daily-reports-body"></tbody>
-                </table>
+              <div id="daily-reports-list-wrap" class="daily-reports-cards" hidden>
+                <div id="daily-reports-body" class="daily-reports-grid"></div>
               </div>
             </section>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -571,6 +571,101 @@ tbody tr:last-child td {
   grid-column: 1 / -1;
 }
 
+
+.daily-report-filter-bar {
+  grid-template-columns: minmax(240px, 2fr) minmax(140px, 1fr) auto;
+}
+
+.daily-report-filter-bar button {
+  align-self: end;
+}
+
+.daily-reports-cards {
+  margin-top: 0.4rem;
+}
+
+.daily-reports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.daily-report-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fbfdff;
+  padding: 0.75rem;
+}
+
+.daily-report-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.65rem;
+  margin-bottom: 0.55rem;
+  align-items: start;
+}
+
+.daily-report-card-date {
+  margin: 0;
+  font-weight: 700;
+}
+
+.daily-report-card-case {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.daily-report-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.daily-report-card-meta {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.daily-report-field,
+.daily-report-field-inline {
+  margin: 0;
+}
+
+.daily-report-field dt,
+.daily-report-field-inline dt {
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin-bottom: 0.18rem;
+}
+
+.daily-report-field dd,
+.daily-report-field-inline dd {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.daily-report-field-inline {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+}
+
+.daily-report-field-inline dt {
+  margin: 0;
+}
+
+@media (max-width: 820px) {
+  .daily-report-filter-bar {
+    grid-template-columns: 1fr;
+  }
+}
+
 .compact-list {
   margin-top: 0.2rem;
 }
@@ -639,4 +734,7 @@ tbody tr:last-child td {
   .date-grid { grid-template-columns: 1fr; }
   .item { flex-direction: column; }
   .top-bar { flex-direction: column; align-items: flex-start; }
+  .daily-report-card-header { flex-direction: column; }
+  .daily-report-card-actions { width: 100%; justify-content: flex-start; }
+  .daily-report-card-actions button { flex: 1 1 auto; }
 }


### PR DESCRIPTION
### Motivation
- 日報一覧の列幅が狭く長文で一覧が崩れる問題を解消し、1件を見やすいカード表示にして読みやすさとスマホ対応を改善するため。 
- 検索・日付絞り込みで目的の日報を素早く見つけられるようにするため。 

### Description
- `index.html`の日報一覧をテーブルからカードコンテナに変更し、上部にキーワード検索欄（案件名/作業内容/次回対応/メモ）と日付フィルター（`all`/`today`/`month`）および条件クリアボタンと表示件数ラベルを追加しました。 
- `app.js`に日報用の状態を追加し（`dailyReportSearchQuery`, `dailyReportDateFilter`）、検索/日付フィルターのイベントハンドラと`applyDailyReportDateFilter`/`handleDailyReportSearchInput`/`clearDailyReportFilters`を実装しました。 
- `renderDailyReports`をテーブル描画からカード描画に置き換え、カード内で`日付`・`案件名`・`作業時間`・`作業内容`・`次回対応`・`メモ`と編集/削除ボタンを表示するようにしました（既存の編集・削除ボタンのクラス/`data-`属性は維持）。 
- `styles.css`に日報カード用のスタイルを追加し、長文が横にはみ出さないよう`white-space: pre-wrap`/`overflow-wrap: anywhere`/`word-break: break-word`を設定し、スマホ時にカードヘッダとボタンが縦並びになるレスポンシブ調整を行いました。 

### Testing
- `node --check app.js` による構文チェックは成功しました。 
- 変更はフロントエンドの表示/挙動に関するため、既存の登録/編集/削除のクラス/属性を維持しており既存フローを壊さないことを想定しています（自動のブラウザレンダリングテストは実行していません）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2d0960dc833388d02e061bd20da8)