### PR TITLE
見積一覧カード化・案件化ロジック修正・メインタブのサブタブ化

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,6 +58,8 @@ const exportExcelBtn = document.getElementById("export-excel-btn");
 const excelImportForm = document.getElementById("excel-import-form");
 
 const tabs = Array.from(document.querySelectorAll(".tab-btn"));
+const subtabButtons = Array.from(document.querySelectorAll(".subtab-btn"));
+const subtabPanels = Array.from(document.querySelectorAll(".subtab-panel"));
 const panels = {
   cases: document.getElementById("tab-cases"),
   estimates: document.getElementById("tab-estimates"),
@@ -66,6 +68,13 @@ const panels = {
   "daily-reports": document.getElementById("tab-daily-reports"),
 };
 const dashboardSection = document.querySelector(".dashboard");
+const subtabState = {
+  cases: "dashboard",
+  estimates: "create",
+  sales: "entry",
+  expenses: "entry",
+  "daily-reports": "entry",
+};
 
 const summaryGrid = document.getElementById("summary-grid");
 const worktimeSummaryGrid = document.getElementById("worktime-summary-grid");
@@ -224,6 +233,7 @@ async function initialize() {
 
 function bindEvents() {
   tabs.forEach((btn) => btn.addEventListener("click", () => activateTab(btn.dataset.tab)));
+  subtabButtons.forEach((btn) => btn.addEventListener("click", () => activateSubtab(btn.dataset.parentTab, btn.dataset.subtab)));
   authForm.addEventListener("submit", handleLogin);
   signupBtn.addEventListener("click", handleSignup);
   logoutBtn.addEventListener("click", handleLogout);
@@ -293,6 +303,7 @@ function bindEvents() {
     state.estimateExpiredFilter = event.target.value || "all";
     renderEstimates();
   });
+  activateTab("cases");
 }
 
 function handleAggregationChange(event) {
@@ -545,6 +556,7 @@ async function loadAllData() {
   state.expenses = (expensesRes.data || []).map(mapExpenseFromDb);
   state.fixedExpenses = (fixedExpensesRes.data || []).map(mapFixedExpenseFromDb);
   state.dailyReports = (dailyReportsRes.data || []).map(mapDailyReportFromDb);
+  await cleanupLegacyEstimateMemoMarkers();
 
   const createdCount = await ensureMonthlyFixedExpenses();
   if (createdCount > 0) {
@@ -796,6 +808,7 @@ async function handleCaseListAction(event) {
 function startCaseEdit(caseId) {
   const target = state.cases.find((entry) => entry.id === caseId);
   if (!target) return;
+  subtabState.cases = "entry";
   activateTab("cases");
   editState.caseId = target.id;
   caseForm.elements.customerName.value = target.customerName;
@@ -803,7 +816,7 @@ function startCaseEdit(caseId) {
   caseForm.elements.amount.value = target.estimateAmount ?? "";
   caseForm.elements.receivedDate.value = target.receivedDate || "";
   caseForm.elements.dueDate.value = target.dueDate || "";
-  caseForm.elements.workMemo.value = target.workMemo || "";
+  caseForm.elements.workMemo.value = sanitizeLegacyEstimateMemo(target.workMemo) || "";
   caseForm.elements.nextActionDate.value = target.nextActionDate || "";
   caseForm.elements.nextAction.value = target.nextAction || "";
   caseForm.elements.status.value = normalizeStatus(target.status);
@@ -1030,7 +1043,7 @@ function handleExportCasesCsv() {
     received_date: entry.receivedDate || "",
     due_date: entry.dueDate || "",
     status: normalizeStoredStatus(entry.status),
-    work_memo: entry.workMemo || "",
+    work_memo: sanitizeLegacyEstimateMemo(entry.workMemo) || "",
     next_action_date: entry.nextActionDate || "",
     next_action: entry.nextAction || "",
   }));
@@ -1094,7 +1107,7 @@ function handleExportAllCsv() {
       received_date: entry.receivedDate || "",
       due_date: entry.dueDate || "",
       status: normalizeStoredStatus(entry.status),
-      work_memo: entry.workMemo || "",
+      work_memo: sanitizeLegacyEstimateMemo(entry.workMemo) || "",
       next_action_date: entry.nextActionDate || "",
       next_action: entry.nextAction || "",
     });
@@ -1175,7 +1188,7 @@ function exportExcel() {
       received_date: entry.receivedDate || "",
       due_date: entry.dueDate || "",
       status: normalizeStoredStatus(entry.status),
-      work_memo: entry.workMemo || "",
+      work_memo: sanitizeLegacyEstimateMemo(entry.workMemo) || "",
       next_action_date: entry.nextActionDate || "",
       next_action: entry.nextAction || "",
     }));
@@ -1269,8 +1282,37 @@ function activateTab(tabKey) {
   tabs.forEach((btn) => btn.classList.toggle("active", normalizeTabKey(btn.dataset.tab) === normalizedTabKey));
   Object.entries(panels).forEach(([key, panel]) => panel.classList.toggle("active", key === normalizedTabKey));
 
-  if (dashboardSection) {
-    dashboardSection.hidden = normalizedTabKey === "daily-reports";
+  if (dashboardSection) dashboardSection.hidden = normalizedTabKey !== "cases";
+  applySubtabVisibility(normalizedTabKey);
+}
+
+function activateSubtab(parentTab, subtab) {
+  const normalizedTab = normalizeTabKey(parentTab);
+  if (!subtab) return;
+  subtabState[normalizedTab] = subtab;
+  applySubtabVisibility(normalizedTab);
+}
+
+function applySubtabVisibility(activeMainTab) {
+  const normalizedTab = normalizeTabKey(activeMainTab);
+  Object.keys(subtabState).forEach((tabKey) => {
+    const activeSubtab = subtabState[tabKey];
+    subtabButtons
+      .filter((btn) => normalizeTabKey(btn.dataset.parentTab) === tabKey)
+      .forEach((btn) => {
+        btn.classList.toggle("active", tabKey === normalizedTab && btn.dataset.subtab === activeSubtab);
+      });
+    subtabPanels
+      .filter((panel) => normalizeTabKey(panel.dataset.parentTab) === tabKey)
+      .forEach((panel) => {
+        const isCasesDashboardPanel = tabKey === "cases" && panel.id === "cases-dashboard-panel";
+        const shouldShow = tabKey === normalizedTab && (panel.dataset.subtab === activeSubtab || (isCasesDashboardPanel && activeSubtab === "alerts"));
+        panel.hidden = !shouldShow;
+      });
+  });
+  if (dashboardSection && normalizedTab === "cases") {
+    const isAlertMode = subtabState.cases === "alerts";
+    dashboardSection.classList.toggle("alerts-only", isAlertMode);
   }
 }
 
@@ -1838,18 +1880,27 @@ function renderEstimates() {
     });
   filtered.forEach((entry) => {
     const li = document.createElement("li");
-    li.className = "item";
+    li.className = "item estimate-card";
     li.dataset.id = entry.id;
     const itemCount = state.estimateItems.filter((row) => row.estimateId === entry.id).length;
+    const casedLabel = entry.caseId ? "案件化済み" : "未案件化";
     li.innerHTML = `
-      <div>
-        <p class="title">${escapeHtml(entry.customerName)}｜${escapeHtml(entry.estimateTitle)}</p>
-        <p class="meta">見積日: ${formatDate(entry.estimateDate)} / 有効期限: ${formatDate(entry.validUntil)} / ステータス: ${escapeHtml(entry.status)} / 合計: ${formatCurrency(entry.total)} / 明細: ${itemCount}件</p>
+      <div class="estimate-card-body">
+        <p class="title estimate-card-title">${escapeHtml(entry.estimateTitle)}</p>
+        <div class="estimate-card-grid">
+          <p class="meta"><span>顧客名:</span> ${escapeHtml(entry.customerName)}</p>
+          <p class="meta"><span>見積日:</span> ${formatDate(entry.estimateDate)}</p>
+          <p class="meta"><span>有効期限:</span> ${formatDate(entry.validUntil)}</p>
+          <p class="meta"><span>ステータス:</span> ${escapeHtml(entry.status)}</p>
+          <p class="meta"><span>合計金額:</span> ${formatCurrency(entry.total)}</p>
+          <p class="meta"><span>明細件数:</span> ${itemCount}件</p>
+          <p class="meta"><span>案件化:</span> ${casedLabel}</p>
+        </div>
       </div>
-      <div class="row-actions">
+      <div class="row-actions estimate-card-actions">
         <button type="button" class="secondary-btn estimate-edit-btn">編集</button>
         <button type="button" class="danger-btn estimate-delete-btn">削除</button>
-        <button type="button" class="secondary-btn estimate-case-btn">案件化</button>
+        <button type="button" class="secondary-btn estimate-case-btn" ${entry.caseId ? "disabled" : ""}>案件化</button>
         <button type="button" class="secondary-btn estimate-csv-btn">請求CSV</button>
         <button type="button" class="secondary-btn estimate-xlsx-btn">請求Excel</button>
         <button type="button" class="secondary-btn estimate-sale-btn">売上登録</button>
@@ -1884,6 +1935,11 @@ async function handleEstimateListAction(event) {
     return;
   }
   if (btn.classList.contains("estimate-case-btn")) return withLoading(async () => {
+    const estimate = state.estimates.find((entry) => entry.id === estimateId);
+    if (estimate?.caseId) {
+      showAppMessage("この見積はすでに案件化済みです。", true);
+      return;
+    }
     await ensureCaseFromEstimate(estimateId, true);
     await refreshAfterMutation("案件化しました。");
   }, "案件化に失敗しました。");
@@ -1924,7 +1980,7 @@ function renderCases() {
     title.textContent = `${entry.customerName}｜${entry.caseName}`;
     meta.textContent = `見積: ${formatCurrency(entry.estimateAmount)} / ステータス: ${entry.status} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)} / 次回対応日: ${formatDate(entry.nextActionDate)} / 次回対応内容: ${entry.nextAction || "未設定"}`;
     if (caseWorkMeta) {
-      caseWorkMeta.textContent = `作業メモ: ${truncateText(entry.workMemo || "未設定", 60)}`;
+      caseWorkMeta.textContent = `作業メモ: ${truncateText(sanitizeLegacyEstimateMemo(entry.workMemo) || "未設定", 60)}`;
       caseWorkMeta.classList.remove("next-action-overdue", "next-action-within3", "next-action-within7");
       if (nextActionInfo) caseWorkMeta.classList.add(nextActionInfo.urgencyClass);
     }
@@ -2139,6 +2195,7 @@ function resolveDailyReportCaseName(caseId) {
 function startEstimateEdit(estimateId) {
   const target = state.estimates.find((entry) => entry.id === estimateId);
   if (!target || !estimateForm) return;
+  subtabState.estimates = "create";
   activateTab("estimates");
   editState.estimateId = target.id;
   estimateForm.elements.customerName.value = target.customerName;
@@ -2218,9 +2275,7 @@ function normalizeEstimateStatus(status) {
 async function ensureCaseFromEstimate(estimateId, force = false) {
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
   if (!estimate || (!force && estimate.status !== "受注")) return null;
-  const marker = `[estimate:${estimateId}]`;
-  const existing = state.cases.find((entry) => (entry.workMemo || "").includes(marker));
-  if (existing) return existing.id;
+  if (estimate.caseId) return estimate.caseId;
   const payload = {
     user_id: currentUser.id,
     customer_name: estimate.customerName,
@@ -2229,10 +2284,14 @@ async function ensureCaseFromEstimate(estimateId, force = false) {
     received_date: toDateString(new Date()),
     due_date: null,
     status: "未着手",
-    work_memo: marker,
+    work_memo: asTrimmedText(estimate.memo) || "",
+    next_action_date: null,
+    next_action: "",
   };
   const res = await sbClient.from("cases").insert(payload).select("id").single();
   if (res.error) throw res.error;
+  const updateRes = await sbClient.from("estimates").update({ case_id: res.data.id }).eq("id", estimateId).eq("user_id", currentUser.id);
+  if (updateRes.error) throw updateRes.error;
   return res.data.id;
 }
 
@@ -2313,9 +2372,9 @@ function exportInvoiceDataForCase(caseId, type) {
 }
 
 async function registerSaleFromEstimate(estimateId) {
-  const caseId = await ensureCaseFromEstimate(estimateId, true);
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
   if (!estimate) return;
+  const caseId = estimate.caseId || await ensureCaseFromEstimate(estimateId, true);
   const payload = {
     user_id: currentUser.id,
     case_id: caseId || null,
@@ -3035,6 +3094,26 @@ function mapCaseFromDb(row) {
   };
 }
 
+function sanitizeLegacyEstimateMemo(workMemo) {
+  return String(workMemo || "")
+    .replace(/\[estimate:[^\]]+\]/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+async function cleanupLegacyEstimateMemoMarkers() {
+  if (!currentUser || !state.cases.length) return;
+  const targets = state.cases.filter((entry) => String(entry.workMemo || "").includes("[estimate:"));
+  if (!targets.length) return;
+  await Promise.all(targets.map(async (entry) => {
+    const cleanedMemo = sanitizeLegacyEstimateMemo(entry.workMemo);
+    if (cleanedMemo === entry.workMemo) return;
+    const { error } = await sbClient.from("cases").update({ work_memo: cleanedMemo }).eq("id", entry.id).eq("user_id", currentUser.id);
+    if (error) throw error;
+    entry.workMemo = cleanedMemo;
+  }));
+}
+
 function mapEstimateFromDb(row) {
   return {
     id: row.id,
@@ -3047,6 +3126,7 @@ function mapEstimateFromDb(row) {
     subtotal: normalizeAmount(row.subtotal) ?? 0,
     tax: normalizeAmount(row.tax) ?? 0,
     total: normalizeAmount(row.total) ?? 0,
+    caseId: row.case_id || null,
     createdAt: Date.parse(row.created_at) || Date.now(),
     updatedAt: Date.parse(row.updated_at) || Date.now(),
   };

--- a/index.html
+++ b/index.html
@@ -111,9 +111,9 @@
           <button type="button" class="tab-btn" data-tab="daily-reports">日報</button>
         </nav>
 
-        <section class="dashboard panel">
+        <section id="cases-dashboard-panel" class="dashboard panel subtab-panel active" data-parent-tab="cases" data-subtab="dashboard">
           <h2>ダッシュボード</h2>
-          <section id="next-action-alert-card" class="next-action-alert-card" aria-live="polite">
+          <section id="next-action-alert-card" class="next-action-alert-card case-alert-block" aria-live="polite">
             <div class="next-action-alert-header">
               <h3>次回対応アラート</h3>
               <p id="next-action-alert-summary" class="next-action-alert-summary">対象 0件</p>
@@ -134,7 +134,7 @@
               </table>
             </div>
           </section>
-          <section id="deadline-alert-card" class="deadline-alert-card" aria-live="polite">
+          <section id="deadline-alert-card" class="deadline-alert-card case-alert-block" aria-live="polite">
             <div class="deadline-alert-header">
               <h3>期限アラート</h3>
             </div>
@@ -156,7 +156,7 @@
               </table>
             </div>
           </section>
-          <section class="status-summary-card" aria-labelledby="status-summary-heading">
+          <section class="status-summary-card case-dashboard-block" aria-labelledby="status-summary-heading">
             <div class="status-summary-header">
               <h3 id="status-summary-heading">ステータス別案件数</h3>
               <button id="status-filter-clear-btn" type="button" class="secondary-btn">全件表示</button>
@@ -164,7 +164,7 @@
             <div id="status-summary-list" class="status-summary-list"></div>
             <p id="status-summary-total" class="status-summary-total">全案件数：0件</p>
           </section>
-          <section id="unpaid-alert-card" class="unpaid-alert-card" aria-live="polite">
+          <section id="unpaid-alert-card" class="unpaid-alert-card case-alert-block" aria-live="polite">
             <div class="unpaid-alert-header">
               <h3>未入金アラート</h3>
               <p id="unpaid-alert-period" class="unpaid-alert-period"></p>
@@ -186,7 +186,7 @@
               </table>
             </div>
           </section>
-          <section id="billing-leak-alert-card" class="billing-leak-alert-card" aria-live="polite">
+          <section id="billing-leak-alert-card" class="billing-leak-alert-card case-alert-block" aria-live="polite">
             <div class="billing-leak-alert-header">
               <h3>請求漏れアラート</h3>
             </div>
@@ -207,11 +207,11 @@
               </table>
             </div>
           </section>
-          <section class="dashboard-worktime-card">
+          <section class="dashboard-worktime-card case-dashboard-block">
             <h3>日報作業時間</h3>
             <div class="summary-grid" id="worktime-summary-grid"></div>
           </section>
-          <div class="dashboard-filter-group">
+          <div class="dashboard-filter-group case-dashboard-block">
             <fieldset class="aggregation-switch" aria-label="集計単位の切替">
               <legend>集計単位</legend>
               <label><input type="radio" name="aggregation-unit" value="month" checked /> 月別</label>
@@ -230,8 +230,8 @@
               </label>
             </div>
           </div>
-          <div class="summary-grid" id="summary-grid"></div>
-          <section id="yearly-breakdown" class="yearly-breakdown" hidden>
+          <div class="summary-grid case-dashboard-block" id="summary-grid"></div>
+          <section id="yearly-breakdown" class="yearly-breakdown case-dashboard-block" hidden>
             <h3 class="subheading">月別内訳（1月〜12月）</h3>
             <div class="table-wrap">
               <table>
@@ -242,12 +242,12 @@
               </table>
             </div>
           </section>
-          <h3 class="subheading">案件別利益一覧</h3>
-          <div id="case-profit-empty" class="empty">案件データがありません。</div>
-          <ul id="case-profit-list" class="item-list compact-list"></ul>
-          <h3 class="subheading">未入金一覧（全期間）</h3>
-          <div id="unpaid-list-empty" class="empty">未入金はありません。</div>
-          <div id="unpaid-list-wrap" class="table-wrap" hidden>
+          <h3 class="subheading case-dashboard-block">案件別利益一覧</h3>
+          <div id="case-profit-empty" class="empty case-dashboard-block">案件データがありません。</div>
+          <ul id="case-profit-list" class="item-list compact-list case-dashboard-block"></ul>
+          <h3 class="subheading case-dashboard-block">未入金一覧（全期間）</h3>
+          <div id="unpaid-list-empty" class="empty case-dashboard-block">未入金はありません。</div>
+          <div id="unpaid-list-wrap" class="table-wrap case-dashboard-block" hidden>
             <table>
               <thead>
                 <tr>
@@ -266,8 +266,14 @@
         </section>
 
         <section id="tab-cases" class="tab-panel active">
+          <nav class="subtabs" aria-label="案件サブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="cases" data-subtab="dashboard">ダッシュボード</button>
+            <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="entry">案件登録</button>
+            <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="list">案件一覧</button>
+            <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="alerts">アラート</button>
+          </nav>
           <div class="layout two-col">
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="cases" data-subtab="entry" hidden>
               <h2>新規案件登録</h2>
               <form id="case-form" class="form">
                 <label>
@@ -318,7 +324,7 @@
               </form>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="cases" data-subtab="list" hidden>
               <div class="panel-title-row">
                 <h2>案件一覧（期限順）</h2>
                 <button id="clear-btn" type="button" class="danger-btn">全件削除</button>
@@ -357,8 +363,13 @@
         </section>
 
         <section id="tab-estimates" class="tab-panel">
+          <nav class="subtabs" aria-label="見積サブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="estimates" data-subtab="create">見積作成</button>
+            <button type="button" class="subtab-btn" data-parent-tab="estimates" data-subtab="list">見積一覧</button>
+            <button type="button" class="subtab-btn" data-parent-tab="estimates" data-subtab="export">請求データ出力</button>
+          </nav>
           <div class="layout two-col">
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="estimates" data-subtab="create">
               <h2>見積作成</h2>
               <form id="estimate-form" class="form">
                 <label>顧客名 <span class="required">必須</span><input id="estimate-customer-name" name="customerName" type="text" required maxlength="80" /></label>
@@ -390,7 +401,7 @@
                 <button id="estimate-submit-btn" type="submit">見積を登録</button>
               </form>
             </section>
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="estimates" data-subtab="list" hidden>
               <h2>見積一覧</h2>
               <div class="search-filter-bar">
                 <label class="inline-field">顧客名検索<input id="estimate-customer-search" type="text" /></label>
@@ -412,14 +423,23 @@
                 </label>
               </div>
               <div id="estimate-empty" class="empty">見積データはまだありません。</div>
-              <ul id="estimate-list" class="item-list"></ul>
+              <ul id="estimate-list" class="item-list estimate-list-grid"></ul>
+            </section>
+            <section class="panel subtab-panel" data-parent-tab="estimates" data-subtab="export" hidden>
+              <h2>請求データ出力</h2>
+              <p class="meta">見積一覧カードの「請求CSV」「請求Excel」ボタンから、見積単位で請求データを出力できます。</p>
             </section>
           </div>
         </section>
 
         <section id="tab-sales" class="tab-panel">
+          <nav class="subtabs" aria-label="売上サブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="sales" data-subtab="entry">売上登録</button>
+            <button type="button" class="subtab-btn" data-parent-tab="sales" data-subtab="list">売上一覧</button>
+            <button type="button" class="subtab-btn" data-parent-tab="sales" data-subtab="unpaid">未入金</button>
+          </nav>
           <div class="layout two-col">
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="sales" data-subtab="entry">
               <h2>売上登録</h2>
               <form id="sale-form" class="form">
                 <label>
@@ -446,7 +466,7 @@
               </form>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="sales" data-subtab="list" hidden>
               <h2>売上一覧</h2>
               <div class="search-filter-bar">
                 <label class="inline-field">
@@ -459,12 +479,21 @@
               <div id="sales-empty" class="empty">売上データはまだありません。</div>
               <ul id="sales-list" class="item-list"></ul>
             </section>
+            <section class="panel subtab-panel" data-parent-tab="sales" data-subtab="unpaid" hidden>
+              <h2>未入金</h2>
+              <p class="meta">未入金アラート・一覧は「案件 ＞ ダッシュボード」から確認できます。</p>
+            </section>
           </div>
         </section>
 
         <section id="tab-expenses" class="tab-panel">
+          <nav class="subtabs" aria-label="経費サブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="expenses" data-subtab="entry">経費登録</button>
+            <button type="button" class="subtab-btn" data-parent-tab="expenses" data-subtab="list">経費一覧</button>
+            <button type="button" class="subtab-btn" data-parent-tab="expenses" data-subtab="fixed">固定費</button>
+          </nav>
           <div class="layout two-col">
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="expenses" data-subtab="entry">
               <h2>経費登録</h2>
               <form id="expense-form" class="form">
                 <div class="date-grid">
@@ -489,7 +518,7 @@
               </form>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="expenses" data-subtab="list" hidden>
               <h2>経費一覧</h2>
               <div class="search-filter-bar">
                 <label class="inline-field">
@@ -503,7 +532,7 @@
               <ul id="expenses-list" class="item-list"></ul>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="expenses" data-subtab="fixed" hidden>
               <h2>固定費登録</h2>
               <form id="fixed-expense-form" class="form">
                 <label>
@@ -532,7 +561,7 @@
               </form>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="expenses" data-subtab="fixed" hidden>
               <h2>固定費一覧</h2>
               <div id="fixed-expenses-empty" class="empty">固定費データはまだありません。</div>
               <ul id="fixed-expenses-list" class="item-list"></ul>
@@ -541,8 +570,13 @@
         </section>
 
         <section id="tab-daily-reports" class="tab-panel">
+          <nav class="subtabs" aria-label="日報サブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="daily-reports" data-subtab="entry">日報登録</button>
+            <button type="button" class="subtab-btn" data-parent-tab="daily-reports" data-subtab="list">日報一覧</button>
+            <button type="button" class="subtab-btn" data-parent-tab="daily-reports" data-subtab="summary">日報集計</button>
+          </nav>
           <div class="layout two-col">
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="daily-reports" data-subtab="entry">
               <h2>日報登録フォーム</h2>
               <form id="daily-report-form" class="form">
                 <label>
@@ -573,12 +607,12 @@
               </form>
             </section>
 
-            <section class="panel">
+            <section class="panel subtab-panel" data-parent-tab="daily-reports" data-subtab="summary" hidden>
               <h2>日報集計</h2>
               <ul id="daily-report-summary-list" class="item-list compact-list"></ul>
             </section>
 
-            <section class="panel report-list-panel">
+            <section class="panel report-list-panel subtab-panel" data-parent-tab="daily-reports" data-subtab="list" hidden>
               <h2>日報一覧</h2>
               <div class="search-filter-bar daily-report-filter-bar">
                 <label class="inline-field" for="daily-report-search-input">

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,27 @@ body {
 }
 
 .tabs { display: flex; gap: 0.55rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.subtabs {
+  display: flex;
+  gap: 0.45rem;
+  margin-bottom: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.subtab-btn {
+  background: #eef2f8;
+  color: #334155;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.86rem;
+}
+
+.subtab-btn.active {
+  background: #dbe7ff;
+  color: #1d3e89;
+  border-color: #9eb9ff;
+}
 
 .tab-btn {
   border: 1px solid var(--border);
@@ -184,6 +205,41 @@ button:hover { background: var(--primary-dark); }
   padding: 0;
   display: grid;
   gap: 0.7rem;
+}
+
+.estimate-list-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.estimate-card {
+  flex-direction: column;
+}
+
+.estimate-card-body {
+  width: 100%;
+}
+
+.estimate-card-title {
+  margin-bottom: 0.55rem;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.estimate-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem 0.75rem;
+}
+
+.estimate-card-grid .meta {
+  margin: 0;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.estimate-card-actions {
+  width: 100%;
+  flex-wrap: wrap;
 }
 
 .item {
@@ -574,6 +630,13 @@ tbody tr:last-child td {
 .dashboard-worktime-card h3 {
   margin: 0 0 0.5rem;
 }
+.dashboard.alerts-only .case-dashboard-block {
+  display: none;
+}
+
+.dashboard:not(.alerts-only) .case-alert-block {
+  display: none;
+}
 
 .report-list-panel {
   grid-column: 1 / -1;
@@ -739,6 +802,10 @@ tbody tr:last-child td {
 }
 
 @media (max-width: 640px) {
+  .estimate-list-grid,
+  .estimate-card-grid {
+    grid-template-columns: 1fr;
+  }
   .date-grid { grid-template-columns: 1fr; }
   .item { flex-direction: column; }
   .top-bar { flex-direction: column; align-items: flex-start; }


### PR DESCRIPTION
### Motivation
- 見積一覧の縦長／文字折返しやボタン配置が見にくく、案件化時に`cases.work_memo`へ不要な`[estimate:...]`マーカーが埋め込まれてしまう問題を解消するため。 
- ページ全体が縦に長くなりすぎて操作性が悪いため、主要タブ内をサブタブ化して表示を整理するため。 

### Description
- 見積一覧をカード表示に再設計し、カードごとに`顧客名/見積件名/見積日/有効期限/ステータス/合計金額/明細件数/案件化状態`を表示してボタンをカード下部に並べるUIを導入し、`word-break: keep-all; overflow-wrap: anywhere;`で長い件名の改行を制御しました（主変更ファイル: `index.html`, `styles.css`, `app.js`）。
- 案件化ロジックを`estimates.case_id`ベースに移行し、`ensureCaseFromEstimate`で`cases.work_memo`へ`[estimate:...]`を書き込まないように変更し、作成時のフィールドを要件どおりに登録して、作成後に`estimates.case_id`を更新保存するようにしました（`app.js`）。
- 既存データ対策として、読み込み時に`cases.work_memo`内の legacy マーカー（`[estimate:...]`）を自動クリーンアップする処理を追加し、表示・編集・CSV/Excel出力時にもマーカーが見えないようにサニタイズを適用しました（`app.js`）。
- 各メインタブ（案件/見積/売上/経費/日報）にサブタブを導入して不要なフォームや一覧の同時表示を抑え、サブタブ選択で該当パネルのみ表示する制御を実装しました（`index.html`, `styles.css`, `app.js`）。

### Testing
- 自動構文チェックとして `node --check app.js` を実行し問題ないことを確認しました（成功）。
- 既存の機能に影響を与えないように UI とデータ処理は既存のフローを維持して実装しましたが、ブラウザ上の表現確認（スクリーンショット等）は行っていません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4c13eae4833394ef27fee49e494b)