### PR TITLE
Fix blank about:blank issue for estimate/invoice print previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -2405,30 +2405,77 @@ function exportInvoiceDataForCase(caseId) {
 
 function openEstimatePrintPreview(estimateId) {
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
-  if (!estimate) return;
-  openBusinessDocumentPrintWindow(buildEstimateDocumentFromEstimate(estimate), { type: "estimate" });
+  if (!estimate) {
+    showAppMessage("出力対象データが見つかりません", true);
+    return;
+  }
+
+  try {
+    const documentData = buildEstimateDocumentFromEstimate(estimate);
+    openBusinessDocumentPrintWindow(documentData, { type: "estimate" });
+  } catch (error) {
+    console.error("見積書の出力に失敗しました。", error);
+    showAppMessage("見積書の出力に失敗しました。再度お試しください。", true);
+  }
 }
 
 function openInvoicePrintPreviewFromEstimate(estimateId) {
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
-  if (!estimate) return;
-  openBusinessDocumentPrintWindow(buildInvoiceDocumentFromEstimate(estimate), { type: "invoice" });
+  if (!estimate) {
+    showAppMessage("出力対象データが見つかりません", true);
+    return;
+  }
+
+  try {
+    const documentData = buildInvoiceDocumentFromEstimate(estimate);
+    openBusinessDocumentPrintWindow(documentData, { type: "invoice" });
+  } catch (error) {
+    console.error("請求書の出力に失敗しました。", error);
+    showAppMessage("請求書の出力に失敗しました。再度お試しください。", true);
+  }
 }
 
 function openInvoicePrintPreviewFromCase(caseId) {
   const foundCase = state.cases.find((entry) => entry.id === caseId);
-  if (!foundCase) return;
-  openBusinessDocumentPrintWindow(buildInvoiceDocumentFromCase(foundCase), { type: "invoice" });
+  if (!foundCase) {
+    showAppMessage("出力対象データが見つかりません", true);
+    return;
+  }
+
+  try {
+    const documentData = buildInvoiceDocumentFromCase(foundCase);
+    openBusinessDocumentPrintWindow(documentData, { type: "invoice" });
+  } catch (error) {
+    console.error("請求書の出力に失敗しました。", error);
+    showAppMessage("請求書の出力に失敗しました。再度お試しください。", true);
+  }
 }
 
 function openBusinessDocumentPrintWindow(documentData, options = { type: "invoice" }) {
-  const win = window.open("", "_blank", "noopener,noreferrer");
-  if (!win) {
-    showAppMessage("帳票画面を開けませんでした。ポップアップ許可を確認してください。", true);
+  let html = "";
+  try {
+    html = buildBusinessDocumentHtml(documentData, options);
+  } catch (error) {
+    console.error("帳票HTMLの生成に失敗しました。", error);
+    showAppMessage("帳票の生成に失敗しました。再度お試しください。", true);
     return;
   }
-  win.document.write(buildBusinessDocumentHtml(documentData, options));
-  win.document.close();
+
+  if (typeof html !== "string" || !html.trim()) {
+    console.error("帳票HTMLの生成結果が不正です。", { documentData, options, html });
+    showAppMessage("帳票の生成に失敗しました。再度お試しください。", true);
+    return;
+  }
+
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) {
+    showAppMessage("ポップアップがブロックされています。ブラウザ設定を確認してください。", true);
+    return;
+  }
+
+  printWindow.document.open();
+  printWindow.document.write(html);
+  printWindow.document.close();
 }
 
 function downloadInvoiceWorkbook(invoiceData) {
@@ -2627,7 +2674,7 @@ function buildBusinessDocumentHtml(documentData, options = { type: "invoice" }) 
   }).join("");
   const headerToneClass = isInvoice ? "tone-dark" : "tone-blue";
 
-  return `<!doctype html>
+  return `<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />


### PR DESCRIPTION
### Motivation
- 見積書／請求書の出力で新しいタブが `about:blank` のまま帳票HTMLが表示されない不具合を解消するため、開いたウィンドウへ確実に HTML を書き込む実装にする。 
- 出力対象データ未取得や帳票生成エラー時に利用者へ分かりやすく通知するためのハンドリングを追加する。

### Description
- `openEstimatePrintPreview`、`openInvoicePrintPreviewFromEstimate`、`openInvoicePrintPreviewFromCase` を修正し、対象データが見つからない場合に `showAppMessage("出力対象データが見つかりません", true)` を表示するようにした。 
- 帳票生成処理を `try/catch` で保護し、例外発生時は `console.error` に加えて `showAppMessage` で画面表示するようにした。 
- `openBusinessDocumentPrintWindow` を改修して `buildBusinessDocumentHtml` の戻り値を検証し、`window.open()` の戻り値を変数 `printWindow` で受け取り `printWindow.document.open()` → `printWindow.document.write(html)` → `printWindow.document.close()` を確実に実行するようにした。 
- 帳票HTMLの先頭を `<!DOCTYPE html>` に統一し、`<html lang="ja">`、`<meta charset="UTF-8">`、`<title>`、`<body>` 等を含む構造を担保するとともに、既存の印刷ボタンと `@media print` の非表示ルールは維持した（変更対象ファイルは `app.js`）。

### Testing
- Ran `node --check app.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6bca6e7c8333ab60952fbb2ee932)