### PR TITLE
Fix stuck loading overlay and harden estimate update flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -447,17 +447,17 @@ function clearDailyReportFilters() {
 
 async function handleVisibilityChange() {
   if (document.hidden) return;
-  showLoading(false);
+  clearLoadingState();
   await handleResumeRefresh("visibilitychange");
 }
 
 async function handleWindowFocus() {
-  showLoading(false);
+  clearLoadingState();
   await handleResumeRefresh("focus");
 }
 
 async function handlePageShow() {
-  showLoading(false);
+  clearLoadingState();
   await handleResumeRefresh("pageshow");
 }
 
@@ -843,6 +843,9 @@ async function startCaseEdit(caseId) {
     caseForm.elements.status.value = normalizeStatus(target.status);
     caseSubmitBtn.textContent = "案件を更新";
     caseForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("案件編集の開始に失敗しました。", error);
+    showAppMessage(`案件編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }
@@ -928,6 +931,9 @@ async function startSaleEdit(saleId) {
     saleForm.elements.isUnpaid.checked = Boolean(target.isUnpaid);
     saleSubmitBtn.textContent = "売上を更新";
     saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("売上編集の開始に失敗しました。", error);
+    showAppMessage(`売上編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }
@@ -946,6 +952,9 @@ async function startExpenseEdit(expenseId) {
     expenseCaseSelect.value = target.caseId || "";
     expenseSubmitBtn.textContent = "経費を更新";
     expenseForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("経費編集の開始に失敗しました。", error);
+    showAppMessage(`経費編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }
@@ -978,6 +987,9 @@ async function startFixedExpenseEdit(fixedExpenseId) {
     fixedExpenseForm.elements.fixedExpenseActive.checked = Boolean(target.active);
     fixedExpenseSubmitBtn.textContent = "固定費を更新";
     fixedExpenseForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("固定費編集の開始に失敗しました。", error);
+    showAppMessage(`固定費編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }
@@ -1059,6 +1071,9 @@ async function startDailyReportEdit(dailyReportId) {
     dailyReportForm.elements.reportMemo.value = target.memo || "";
     dailyReportSubmitBtn.textContent = "日報を更新";
     dailyReportForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("日報編集の開始に失敗しました。", error);
+    showAppMessage(`日報編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }
@@ -1895,8 +1910,12 @@ async function handleEstimateSubmit(event) {
     tax: totals.tax,
     total: totals.total,
   };
-  await withLoading(async () => {
+
+  showLoading(true);
+  try {
+    clearAppMessage();
     let estimateId = editState.estimateId;
+    const isUpdate = Boolean(estimateId);
     if (estimateId) {
       const { error } = await sbClient.from("estimates").update(payload).eq("id", estimateId).eq("user_id", currentUser.id);
       if (error) throw error;
@@ -1921,8 +1940,18 @@ async function handleEstimateSubmit(event) {
     }
     if (payload.status === "受注") await ensureCaseFromEstimate(estimateId);
     resetEstimateForm();
-    await refreshAfterMutation("見積を保存しました。");
-  }, "見積の保存に失敗しました。");
+    editState.estimateId = null;
+    subtabState.estimates = "list";
+    await loadAllData();
+    renderAfterDataChanged();
+    activateTab("estimates");
+    showAppMessage(isUpdate ? "見積を更新しました。" : "見積を登録しました。", false);
+  } catch (error) {
+    console.error("見積の保存に失敗しました。", error);
+    showAppMessage(`見積の保存に失敗しました。\n詳細: ${error?.message || error}`, true);
+  } finally {
+    showLoading(false);
+  }
 }
 
 function renderEstimates() {
@@ -2279,6 +2308,9 @@ async function startEstimateEdit(estimateId) {
     recalcEstimateTotals();
     estimateSubmitBtn.textContent = "見積を更新";
     estimateForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  } catch (error) {
+    console.error("見積編集の開始に失敗しました。", error);
+    showAppMessage(`見積編集の開始に失敗しました。\n詳細: ${error?.message || error}`, true);
   } finally {
     showLoading(false);
   }


### PR DESCRIPTION
### Motivation
- 見積の更新後に画面に「読み込み中です…」オーバーレイが残り操作不能になる不具合を防止するため、見積更新処理を必ず `try/catch/finally` にして `showLoading(false)` を保証する必要があった。  
- 更新後に編集モードを確実に解除し、見積一覧へ戻してデータ再読込・再描画を行うことで画面状態を正常化することが狙い。  
- ブラウザ復帰時や編集開始処理でローディングが残る可能性がある箇所も点検し、UIにエラーメッセージを表示する堅牢性向上が必要だった。  

### Description
- `handleEstimateSubmit` を `showLoading(true)` + `try/catch/finally` 構成へ書き換え、`finally` で必ず `showLoading(false)` を呼ぶようにした。  
- 見積保存成功時に `editState.estimateId = null`、`subtabState.estimates = 'list'`、`resetEstimateForm()` を実行し、`loadAllData()` と `renderAfterDataChanged()` を呼んで `activateTab('estimates')` で一覧表示に戻し、`showAppMessage` で成功メッセージを出すようにした。  
- 見積更新処理で `withLoading` を置き換え、失敗時は `console.error` に加えて画面表示 (`showAppMessage`) を行うようにした。  
- 編集開始系ハンドラ（案件/売上/経費/固定費/日報/見積の `start*Edit` 関数）に `catch` を追加して `showAppMessage` を表示するようにし、`finally` でローディング解除を維持した。  
- `pageshow`/`focus`/`visibilitychange` イベントで単に `showLoading(false)` していた箇所を `clearLoadingState()` に変更し、ブラウザ復帰時のローディング残りを強制解除するようにした。  
- 指定の CSS セレクタ ``.loading-overlay[hidden] { display: none !important; }`` はそのまま維持している。  

### Testing
- `node --check app.js` を実行して構文チェックを行い成功した（エラーなし）。  
- 変更後のファイル差分を確認し (`git diff`) 影響箇所をレビュー済み。  
- 既存の `showLoading` / `clearLoadingState` フローに沿って手動動作確認を想定できる形で修正を適用した（自動化テストは構文チェックのみ）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb787014d88333a252246af35f142b)