### PR TITLE
Fix stuck loading overlay after file exports

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,6 +222,7 @@ const estimateExpiredFilter = document.getElementById("estimate-expired-filter")
 let currentUser = null;
 let isResuming = false;
 let isLoggingOut = false;
+let eventsBound = false;
 let loadingCount = 0;
 let loadingTimeoutId = null;
 const BACKUP_TABLE_KEYS = ["clients", "cases", "estimates", "estimate_items", "sales", "expenses", "fixed_expenses", "daily_reports"];
@@ -279,6 +280,8 @@ async function initialize() {
 }
 
 function bindEvents() {
+  if (eventsBound) return;
+  eventsBound = true;
   tabs.forEach((btn) => btn.addEventListener("click", () => activateTab(btn.dataset.tab)));
   subtabButtons.forEach((btn) => btn.addEventListener("click", () => activateSubtab(btn.dataset.parentTab, btn.dataset.subtab)));
   authForm.addEventListener("submit", handleLogin);
@@ -1030,15 +1033,11 @@ async function handleCaseListAction(event) {
     return;
   }
   if (btn.classList.contains("case-print-btn")) {
-    await withLoading("帳票出力", async () => {
-      openInvoicePrintPreviewFromCase(id);
-    });
+    openInvoicePrintPreviewFromCase(id);
     return;
   }
   if (btn.classList.contains("case-xlsx-btn")) {
-    await withLoading("帳票出力", async () => {
-      exportInvoiceDataForCase(id);
-    });
+    exportInvoiceDataForCase(id);
     return;
   }
 
@@ -1803,15 +1802,23 @@ async function handleCsvImportSubmit(event) {
 }
 
 function handleExportExcel() {
-  withLoading("帳票出力", async () => {
+  try {
+    clearAppMessage();
     exportExcel();
-  }).catch(() => {});
+  } catch (error) {
+    console.error("Excel出力に失敗しました。", error);
+    showAppMessage("Excel出力に失敗しました。", true);
+  }
 }
 
 function handleExportAnalysisExcel() {
-  withLoading("分析出力", async () => {
+  try {
+    clearAppMessage();
     exportAnalysisExcel();
-  }).catch(() => {});
+  } catch (error) {
+    console.error("分析Excel出力に失敗しました。", error);
+    showAppMessage("分析Excel出力に失敗しました。", true);
+  }
 }
 
 function exportExcel() {
@@ -1983,13 +1990,13 @@ async function handleExcelImportSubmit(event) {
 async function handleExportBackupJson() {
   if (!currentUser) return;
   try {
-    await withLoading("バックアップ出力", async () => {
-      const payload = await buildBackupPayload();
-      const today = new Date().toISOString().slice(0, 10);
-      downloadJsonFile(`gyosei-app-backup-${today}.json`, payload);
-      showAppMessage("バックアップJSONを出力しました。", false);
-    }, { triggerButton: exportBackupJsonBtn });
+    clearAppMessage();
+    const payload = await buildBackupPayload();
+    const today = new Date().toISOString().slice(0, 10);
+    downloadJsonFile(`gyosei-app-backup-${today}.json`, payload);
+    showAppMessage("バックアップJSONを出力しました。", false);
   } catch (error) {
+    console.error("バックアップJSON出力に失敗しました。", error);
     showAppMessage(`バックアップJSONの出力に失敗しました。${error?.message || ""}`, true);
   } finally {
     forceHideLoading();
@@ -3194,10 +3201,10 @@ async function handleEstimateListAction(event) {
       forceHideLoading();
     }
   }
-  if (btn.classList.contains("estimate-estimate-print-btn")) return withLoading("帳票出力", async () => openEstimatePrintPreview(estimateId));
-  if (btn.classList.contains("estimate-print-btn")) return withLoading("帳票出力", async () => openInvoicePrintPreviewFromEstimate(estimateId));
-  if (btn.classList.contains("estimate-estimate-xlsx-btn")) return withLoading("帳票出力", async () => exportEstimateDataForEstimate(estimateId));
-  if (btn.classList.contains("estimate-xlsx-btn")) return withLoading("帳票出力", async () => exportInvoiceDataForEstimate(estimateId));
+  if (btn.classList.contains("estimate-estimate-print-btn")) return openEstimatePrintPreview(estimateId);
+  if (btn.classList.contains("estimate-print-btn")) return openInvoicePrintPreviewFromEstimate(estimateId);
+  if (btn.classList.contains("estimate-estimate-xlsx-btn")) return exportEstimateDataForEstimate(estimateId);
+  if (btn.classList.contains("estimate-xlsx-btn")) return exportInvoiceDataForEstimate(estimateId);
   if (btn.classList.contains("estimate-sale-btn")) {
     try {
       return await withLoading("見積から売上登録", async () => {
@@ -4715,7 +4722,7 @@ function downloadBlobFile(filename, blob) {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function buildCsvString(headers, rows) {


### PR DESCRIPTION
### Motivation

- Prevent the UI from getting permanently stuck showing the loading overlay (`読み込み中です…`) after file export actions such as backup JSON, CSV, Excel, and business-document outputs.
- Avoid showing unnecessary long-running loading indicators for operations that do not mutate the DB or require UI re-render.
- Prevent duplicate event listener registration that can cause handlers to run multiple times and contribute to unexpected loading states.

### Description

- Added an `eventsBound` guard and early return in `bindEvents()` to avoid double registration of event listeners (prevents duplicate handlers running).
- Removed use of `withLoading` from non-mutating file-export handlers and switched handlers to direct calls with `try/catch/finally` semantics where appropriate, including `handleExportBackupJson`, `handleExportExcel`, `handleExportAnalysisExcel`, case/estimate print and xlsx actions, to ensure loading UI is not shown or is always cleared.
- Ensured `handleExportBackupJson()` follows a `try/catch/finally` pattern, calls `forceHideLoading()` in `finally`, and logs export errors with `console.error` before showing an app message.
- Changed `downloadBlobFile()` to revoke object URLs via `window.setTimeout(() => URL.revokeObjectURL(url), 1000)` to avoid timing-sensitive immediate revocation after `click()`.

### Testing

- Ran `node --check app.js` to validate the modified file has no syntax errors, and it completed successfully.
- Verified the codebase builds/parse-checks without errors (no runtime syntax issues detected by the static check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed757b5630833398e391e2ef6590c1)