### PR TITLE
Fix daily report schema/payload and disable number-input wheel/spinner changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ create table if not exists daily_reports (
 
 alter table daily_reports add column if not exists client_id uuid;
 alter table daily_reports add column if not exists interaction_type text;
+alter table daily_reports add column if not exists next_action text;
 alter table daily_reports add column if not exists next_action_date date;
+alter table daily_reports add column if not exists memo text;
 
 alter table daily_reports enable row level security;
 
@@ -140,6 +142,23 @@ create policy "daily_reports_own" on daily_reports
 for all
 using (auth.uid() = user_id)
 with check (auth.uid() = user_id);
+```
+
+日報の insert / update payload は以下のキーで統一しています（DBに未作成のカラムは先に上記SQLで追加してください）。
+
+```js
+{
+  user_id,
+  report_date,
+  client_id,
+  case_id,
+  interaction_type,
+  work_content,
+  work_minutes,
+  next_action,
+  next_action_date,
+  memo
+}
 ```
 
 ## 見積機能（見積作成・管理・請求データ出力）の追加SQL

--- a/app.js
+++ b/app.js
@@ -387,6 +387,7 @@ function bindEvents() {
   excelImportForm?.addEventListener("submit", handleExcelImportSubmit);
   exportBackupJsonBtn?.addEventListener("click", handleExportBackupJson);
   backupRestoreForm?.addEventListener("submit", handleBackupRestoreSubmit);
+  document.addEventListener("wheel", handleNumberInputWheel, { passive: true });
   estimateAddItemBtn?.addEventListener("click", () => addEstimateItemRow());
   estimateItemsWrap?.addEventListener("input", handleEstimateItemsInput);
   estimateItemsWrap?.addEventListener("click", handleEstimateItemsClick);
@@ -1135,7 +1136,7 @@ async function handleDailyReportSubmit(event) {
       renderAfterDataChanged();
       resetDailyReportForm();
       activateSubtab("daily-reports", "list");
-      showAppMessage("日報を登録しました。", false);
+      showAppMessage(isEdit ? "日報を更新しました。" : "日報を登録しました。", false);
     }, { triggerButton: event.submitter });
   } catch (error) {
     showAppMessage(`日報登録に失敗しました。${error?.message || ""} ${error?.details || ""} ${error?.hint || ""} ${error?.code || ""}`, true);
@@ -3401,8 +3402,8 @@ function addEstimateItemRow(defaultItem = {}) {
   row.className = "estimate-item-row";
   row.innerHTML = `
     <input type="text" data-key="itemName" placeholder="項目名" value="${escapeHtml(defaultItem.itemName || "")}" />
-    <input type="number" data-key="quantity" min="0" step="0.01" placeholder="数量" value="${defaultItem.quantity ?? 1}" />
-    <input type="number" data-key="unitPrice" min="0" step="1" placeholder="単価" value="${defaultItem.unitPrice ?? 0}" />
+    <input type="text" inputmode="decimal" pattern="[0-9.,]*" data-key="quantity" placeholder="数量" value="${defaultItem.quantity ?? 1}" />
+    <input type="text" inputmode="numeric" pattern="[0-9,]*" data-key="unitPrice" placeholder="単価" value="${defaultItem.unitPrice ?? 0}" />
     <p class="meta item-amount">${formatCurrency(defaultItem.amount ?? 0)}</p>
     <button type="button" class="danger-btn estimate-item-remove-btn">削除</button>
   `;
@@ -3427,7 +3428,7 @@ function getEstimateItemsFromForm() {
   return Array.from(estimateItemsWrap.querySelectorAll(".estimate-item-row"))
     .map((row, idx) => {
       const itemName = asTrimmedText(row.querySelector('[data-key="itemName"]')?.value);
-      const quantity = Number(row.querySelector('[data-key="quantity"]')?.value || 0);
+      const quantity = parseDecimalInput(row.querySelector('[data-key="quantity"]')?.value);
       const unitPrice = normalizeAmount(row.querySelector('[data-key="unitPrice"]')?.value) ?? 0;
       const amount = Math.floor((Number.isFinite(quantity) ? quantity : 0) * unitPrice);
       return { itemName, quantity, unitPrice, amount, sortOrder: idx };
@@ -3438,7 +3439,7 @@ function getEstimateItemsFromForm() {
 function recalcEstimateTotals() {
   let subtotal = 0;
   Array.from(estimateItemsWrap?.querySelectorAll(".estimate-item-row") || []).forEach((row) => {
-    const quantity = Number(row.querySelector('[data-key="quantity"]')?.value || 0);
+    const quantity = parseDecimalInput(row.querySelector('[data-key="quantity"]')?.value);
     const unitPrice = normalizeAmount(row.querySelector('[data-key="unitPrice"]')?.value) ?? 0;
     const amount = Math.floor((Number.isFinite(quantity) ? quantity : 0) * unitPrice);
     subtotal += amount;
@@ -4913,7 +4914,7 @@ function toYearNumber(dateSource) {
 }
 
 function normalizeYear(value) {
-  const year = Number(value);
+  const year = Number(String(value ?? "").replace(/,/g, "").trim());
   if (!Number.isInteger(year) || year < 1900 || year > 9999) return null;
   return year;
 }
@@ -4966,9 +4967,27 @@ function toDateString(dateSource) {
 
 function normalizeAmount(raw) {
   if (raw === "" || raw === null || raw === undefined) return null;
-  const value = Number(raw);
+  const normalized = String(raw).replace(/,/g, "").trim();
+  if (!normalized) return null;
+  const value = Number(normalized);
   if (!Number.isFinite(value) || value < 0) return null;
   return Math.floor(value);
+}
+
+function parseDecimalInput(raw) {
+  if (raw === "" || raw === null || raw === undefined) return 0;
+  const normalized = String(raw).replace(/,/g, "").trim();
+  const value = Number(normalized);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return value;
+}
+
+function handleNumberInputWheel(event) {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLInputElement)) return;
+  if (activeElement.type !== "number") return;
+  if (event.target !== activeElement) return;
+  activeElement.blur();
 }
 
 function normalizeStatus(status) {
@@ -5127,7 +5146,7 @@ function toStatusClassKey(status) {
 }
 
 function normalizeDayOfMonth(raw) {
-  const value = Number(raw);
+  const value = Number(String(raw ?? "").replace(/,/g, "").trim());
   if (!Number.isInteger(value) || value < 1 || value > 31) return null;
   return value;
 }

--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@
             <div id="year-filter" class="dashboard-filter" hidden>
               <label for="target-year">
                 対象年
-                <input id="target-year" name="targetYear" type="number" min="2000" max="9999" step="1" />
+                <input id="target-year" name="targetYear" type="text" inputmode="numeric" pattern="[0-9,]*" />
               </label>
             </div>
           </div>
@@ -462,7 +462,7 @@
                 </label>
                 <label>
                   見積金額（円）
-                  <input id="amount" name="amount" type="number" min="0" step="1" />
+                  <input id="amount" name="amount" type="text" inputmode="numeric" pattern="[0-9,]*" />
                 </label>
                 <div class="date-grid">
                   <label>
@@ -564,7 +564,7 @@
               <h2>業務テンプレート登録</h2>
               <form id="work-template-form" class="form">
                 <label>テンプレート名 <span class="required">必須</span><input id="template-name" name="templateName" type="text" required maxlength="120" /></label>
-                <label>標準期限（日数）<input id="template-default-due-days" name="templateDefaultDueDays" type="number" min="0" step="1" placeholder="例: 30" /></label>
+                <label>標準期限（日数）<input id="template-default-due-days" name="templateDefaultDueDays" type="text" inputmode="numeric" pattern="[0-9,]*" placeholder="例: 30" /></label>
                 <label>必要書類<textarea id="template-required-documents" name="templateRequiredDocuments" rows="4" maxlength="4000" placeholder="登記事項証明書&#10;納税証明書"></textarea></label>
                 <label>標準タスク<textarea id="template-default-tasks" name="templateDefaultTasks" rows="5" maxlength="4000" placeholder="要件確認&#10;必要書類案内&#10;書類回収"></textarea></label>
                 <label>作業メモ<textarea id="template-memo" name="templateMemo" rows="3" maxlength="2000"></textarea></label>
@@ -666,11 +666,11 @@
                 </label>
                 <label>
                   請求額（円） <span class="required">必須</span>
-                  <input id="invoice-amount" name="invoiceAmount" type="number" min="0" step="1" required />
+                  <input id="invoice-amount" name="invoiceAmount" type="text" inputmode="numeric" pattern="[0-9,]*" required />
                 </label>
                 <label>
                   入金額（円）
-                  <input id="paid-amount" name="paidAmount" type="number" min="0" step="1" />
+                  <input id="paid-amount" name="paidAmount" type="text" inputmode="numeric" pattern="[0-9,]*" />
                 </label>
                 <label>
                   入金日
@@ -751,7 +751,7 @@
                 </label>
                 <label>
                   金額（円） <span class="required">必須</span>
-                  <input id="expense-amount" name="expenseAmount" type="number" min="0" step="1" required />
+                  <input id="expense-amount" name="expenseAmount" type="text" inputmode="numeric" pattern="[0-9,]*" required />
                 </label>
                 <label>
                   領収書URL
@@ -784,12 +784,12 @@
                 </label>
                 <label>
                   金額（円） <span class="required">必須</span>
-                  <input id="fixed-expense-amount" name="fixedExpenseAmount" type="number" min="0" step="1" required />
+                  <input id="fixed-expense-amount" name="fixedExpenseAmount" type="text" inputmode="numeric" pattern="[0-9,]*" required />
                 </label>
                 <div class="date-grid">
                   <label>
                     毎月の計上日 <span class="required">必須</span>
-                    <input id="fixed-expense-day" name="fixedExpenseDayOfMonth" type="number" min="1" max="31" step="1" required />
+                    <input id="fixed-expense-day" name="fixedExpenseDayOfMonth" type="text" inputmode="numeric" pattern="[0-9,]*" required />
                   </label>
                   <label>
                     開始日 <span class="required">必須</span>
@@ -852,7 +852,7 @@
                 </label>
                 <label>
                   作業時間（分）
-                  <input id="report-work-minutes" name="reportWorkMinutes" type="number" min="0" step="1" />
+                  <input id="report-work-minutes" name="reportWorkMinutes" type="text" inputmode="numeric" pattern="[0-9,]*" />
                 </label>
                 <label>
                   次回対応

--- a/styles.css
+++ b/styles.css
@@ -894,6 +894,16 @@ tbody tr:last-child td {
   margin: 0;
 }
 
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 @media (max-width: 640px) {
   .estimate-list-grid,
   .estimate-card-grid {


### PR DESCRIPTION
### Motivation
- 日報登録時に `next_action_date` 等のカラム不整合で登録エラーが発生していたため、DBスキーマ要件とJS側payloadの整合をとる必要があった。
- マウスホイールやスクロールで `type="number"` の入力値が意図せず変わる問題を防止したかった。

### Description
- READMEを更新して `daily_reports` に不足しがちな `next_action` と `memo` の `ALTER TABLE` を追記し、日報の統一insert/update payloadを明記した（ファイル: `README.md`）。
- 日報送信処理を `user_id, report_date, client_id, case_id, interaction_type, work_content, work_minutes, next_action, next_action_date, memo` のキーを前提に保持し、成功後の流れで `loadAllData()` → `renderAfterDataChanged()` → `resetDailyReportForm()` → サブタブ切替を行い `forceHideLoading()` を `finally` で呼ぶ構成を維持・明確化した（ファイル: `app.js`）。
- 金額・作業時間系の主要入力を `type="number"` から `type="text"` + `inputmode`/`pattern` に変更してホイールでの変化を回避し、見積明細の `quantity`/`unitPrice` も同様に変更してJSで数値化するようにした（ファイル: `index.html`, `app.js`）。
- カンマ許容の数値パースを導入し `normalizeAmount` を強化、`parseDecimalInput` を追加し `normalizeYear` / `normalizeDayOfMonth` もカンマ除去に対応させた（ファイル: `app.js`）。
- 追加でホイールイベント時にフォーカス中の `type="number"` 要素を `blur` する `handleNumberInputWheel` を登録し、将来残る `type="number"` に備えてスピンボタン非表示のCSSを追加した（ファイル: `app.js`, `styles.css`）。
- 日報の成功メッセージを登録/更新で出し分けるように修正した（ファイル: `app.js`）。

### Testing
- `node --check app.js` を実行して構文チェックを行い成功した。  
- 変更後のフォーム要素を確認するために `rg -n 'type="number"' index.html app.js` を実行し、主要な数値入力を `type="text"` に置換済みであることを確認した。  
- 上記は静的確認とユニット的な構文検査のみで、Supabase実環境へのマイグレーション/登録テストはローカルDB/環境で別途実行してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9f052cd083338e9c75dbdfbe06fd)