### PR TITLE
未対応見積のフォローアラートをダッシュボードに追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const STATUS_ORDER = ["未着手", "進行中", "完了"];
 const STATUS_FILTER_KEYS = [...STATUS_ORDER, "その他"];
 const DEADLINE_FILTER_KEYS = ["all", "overdue", "within7", "within30"];
 const SALES_PAYMENT_STATUSES = ["未入金", "一部入金", "入金済"];
-const ESTIMATE_STATUS_ORDER = ["作成中", "提出済", "受注", "失注"];
+const ESTIMATE_STATUS_ORDER = ["作成中", "提出済", "未回答", "受注", "失注"];
 const EXPENSE_PAYMENT_METHODS = ["現金", "クレジットカード", "銀行振込", "電子マネー", "口座振替", "その他"];
 const DAILY_REPORT_INTERACTION_TYPES = ["作業", "電話", "メール", "面談", "訪問", "LINE", "その他"];
 const OFFICE_INFO = {
@@ -154,6 +154,11 @@ const todayTaskSummary = document.getElementById("today-task-summary");
 const todayTaskBody = document.getElementById("today-task-body");
 const todayTaskEmpty = document.getElementById("today-task-empty");
 const todayTaskListWrap = document.getElementById("today-task-list-wrap");
+const pendingEstimatesCard = document.getElementById("pending-estimates-card");
+const pendingEstimatesSummary = document.getElementById("pending-estimates-summary");
+const pendingEstimatesBody = document.getElementById("pending-estimates-body");
+const pendingEstimatesEmpty = document.getElementById("pending-estimates-empty");
+const pendingEstimatesListWrap = document.getElementById("pending-estimates-list-wrap");
 
 const clientForm = document.getElementById("client-form");
 const clientsList = document.getElementById("clients-list");
@@ -355,6 +360,7 @@ function bindEvents() {
   deadlineAlertBody?.addEventListener("click", handleDeadlineAlertClick);
   nextActionAlertBody?.addEventListener("click", handleNextActionAlertClick);
   todayTaskBody?.addEventListener("click", handleTodayTaskAction);
+  pendingEstimatesBody?.addEventListener("click", handlePendingEstimateAction);
   caseSearchInput?.addEventListener("input", handleCaseSearchInput);
   caseStatusFilterSelect?.addEventListener("change", handleCaseStatusFilterChange);
   caseDeadlineFilterSelect?.addEventListener("change", handleCaseDeadlineFilterChange);
@@ -1373,6 +1379,16 @@ function handleBillingLeakAlertAction(event) {
   if (!caseId) return;
   if (btn.classList.contains("register-sale-btn")) {
     openSaleFormForCase(caseId);
+  }
+}
+
+function handlePendingEstimateAction(event) {
+  const btn = event.target.closest("button");
+  if (!(btn instanceof HTMLButtonElement)) return;
+  const estimateId = btn.dataset.estimateId;
+  if (!estimateId) return;
+  if (btn.classList.contains("edit-pending-estimate-btn")) {
+    startEstimateEdit(estimateId).catch(() => {});
   }
 }
 
@@ -2448,6 +2464,7 @@ function renderAfterDataChanged() {
   safeRender("billingLeakAlerts", renderBillingLeakAlerts);
   safeRender("deadlineAlerts", renderDeadlineAlerts);
   safeRender("nextActionAlerts", renderNextActionAlerts);
+  safeRender("pendingEstimates", renderPendingEstimates);
   safeRender("clientAnalysis", renderClientAnalysis);
   safeRender("referralAnalysis", renderReferralAnalysis);
 }
@@ -2479,6 +2496,30 @@ function renderDeadlineAlerts() {
 function renderNextActionAlerts() {
   if (!nextActionAlertCard || !nextActionAlertSummary || !nextActionAlertBody || !nextActionAlertEmpty || !nextActionAlertListWrap) return;
   renderNextActionAlertCard();
+}
+
+function renderPendingEstimates() {
+  if (!pendingEstimatesCard || !pendingEstimatesSummary || !pendingEstimatesBody || !pendingEstimatesEmpty || !pendingEstimatesListWrap) return;
+  const targets = getPendingEstimates(state.estimates)
+    .slice()
+    .sort((a, b) => b.elapsedDays - a.elapsedDays || toSortTimestamp(a.baseDate) - toSortTimestamp(b.baseDate));
+  pendingEstimatesCard.classList.toggle("has-alert", targets.length > 0);
+  pendingEstimatesSummary.textContent = `対象 ${targets.length}件`;
+  pendingEstimatesBody.innerHTML = "";
+  pendingEstimatesEmpty.hidden = targets.length > 0;
+  pendingEstimatesListWrap.hidden = targets.length === 0;
+  if (!targets.length) return;
+  targets.slice(0, 5).forEach((entry) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${escapeHtml(entry.customerName || "未設定")}</td>
+      <td>${escapeHtml(entry.estimateTitle || "未設定")}</td>
+      <td>${formatDate(entry.baseDate)}</td>
+      <td>${entry.elapsedDays}日</td>
+      <td><button type="button" class="secondary-btn edit-pending-estimate-btn" data-estimate-id="${entry.id}">編集</button></td>
+    `;
+    pendingEstimatesBody.appendChild(tr);
+  });
 }
 
 function renderClientAnalysis() {
@@ -2604,6 +2645,7 @@ function renderDashboard() {
   renderDashboardWorktimeSummary();
   renderUnpaidList();
   renderAnalyticsSection();
+  renderPendingEstimates();
 }
 
 function renderTodayTaskCard() {
@@ -5814,6 +5856,7 @@ function mapEstimateFromDb(row) {
     estimateNumber: row.estimate_number || "",
     estimateTitle: row.estimate_title || "",
     estimateDate: row.estimate_date || "",
+    sentDate: row.sent_date || row.estimate_date || "",
     validUntil: row.valid_until || "",
     status: normalizeEstimateStatus(row.status),
     memo: row.memo || "",
@@ -5824,6 +5867,26 @@ function mapEstimateFromDb(row) {
     createdAt: Date.parse(row.created_at) || Date.now(),
     updatedAt: Date.parse(row.updated_at) || Date.now(),
   };
+}
+
+function getPendingEstimates(estimates) {
+  const today = new Date();
+  return (Array.isArray(estimates) ? estimates : []).reduce((acc, estimate) => {
+    if (!estimate || estimate.status !== "未回答") return acc;
+    const baseDate = estimate.sentDate || estimate.estimateDate;
+    if (!baseDate) return acc;
+    const sent = new Date(baseDate);
+    const sentTs = sent.getTime();
+    if (!Number.isFinite(sentTs)) return acc;
+    const diffDays = (today.getTime() - sentTs) / (1000 * 60 * 60 * 24);
+    if (!Number.isFinite(diffDays) || diffDays < 3) return acc;
+    acc.push({
+      ...estimate,
+      baseDate,
+      elapsedDays: Math.floor(diffDays),
+    });
+    return acc;
+  }, []);
 }
 
 function mapEstimateItemFromDb(row) {

--- a/index.html
+++ b/index.html
@@ -188,6 +188,27 @@
               </table>
             </div>
           </section>
+          <section id="pending-estimates-card" class="pending-estimates-card case-alert-block" aria-live="polite">
+            <div class="pending-estimates-header">
+              <h3>フォロー必要案件</h3>
+              <p id="pending-estimates-summary" class="pending-estimates-summary">対象 0件</p>
+            </div>
+            <div id="pending-estimates-empty" class="empty">フォローが必要な見積案件はありません。</div>
+            <div id="pending-estimates-list-wrap" class="table-wrap" hidden>
+              <table class="pending-estimates-table">
+                <thead>
+                  <tr>
+                    <th>顧客名</th>
+                    <th>案件名</th>
+                    <th>見積日</th>
+                    <th>経過日数</th>
+                    <th>編集</th>
+                  </tr>
+                </thead>
+                <tbody id="pending-estimates-body"></tbody>
+              </table>
+            </div>
+          </section>
           <section id="deadline-alert-card" class="deadline-alert-card case-alert-block" aria-live="polite">
             <div class="deadline-alert-header">
               <h3>期限アラート</h3>
@@ -601,6 +622,7 @@
                   <select id="estimate-status" name="status">
                     <option value="作成中">作成中</option>
                     <option value="提出済">提出済</option>
+                    <option value="未回答">未回答</option>
                     <option value="受注">受注</option>
                     <option value="失注">失注</option>
                   </select>
@@ -629,6 +651,7 @@
                     <option value="all">全件</option>
                     <option value="作成中">作成中</option>
                     <option value="提出済">提出済</option>
+                    <option value="未回答">未回答</option>
                     <option value="受注">受注</option>
                     <option value="失注">失注</option>
                   </select>

--- a/styles.css
+++ b/styles.css
@@ -328,6 +328,32 @@ button:hover { background: var(--primary-dark); }
   padding: 0.8rem;
 }
 
+.pending-estimates-card {
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.pending-estimates-card.has-alert {
+  border-color: #d97706;
+  box-shadow: 0 0 0 1px rgba(217, 119, 6, 0.12);
+}
+
+.pending-estimates-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+}
+
+.pending-estimates-header h3,
+.pending-estimates-summary {
+  margin: 0;
+}
+
 .today-task-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
### Motivation
- 見積送信後に放置されている案件を可視化してフォロー漏れを防ぐため、見積の「未回答」状態を追跡するアラートをダッシュボードに追加します。

### Description
- 見積ステータスに`未回答`を追加し、見積作成フォームと一覧のステータスフィルタに選択肢を追加しました（`ESTIMATE_STATUS_ORDER` と `index.html` の`<select id="estimate-status">`/`<select id="estimate-status-filter">`）。
- DBマッピングで`sentDate`を追加し、`sent_date`がない場合は既存の`estimate_date`を代替使用するようにしました（`mapEstimateFromDb`）。
- 判定ロジックとして`getPendingEstimates(estimates)`を実装し、条件は`status === "未回答"`かつ`sentDate || estimateDate`から3日以上経過（日付欠損や`NaN`は除外）です。関数は`app.js`に追加されています。
- ダッシュボードに「フォロー必要案件」セクションを追加し、`renderPendingEstimates`で件数表示と最大5件の一覧（顧客名・案件名・見積日・経過日数・編集ボタン）を描画し、編集ボタンから`startEstimateEdit`へ遷移できるようにしました（`renderAfterDataChanged`と`renderDashboard`で呼び出し、`safeRender("pendingEstimates", renderPendingEstimates)`を追加）。
- ダッシュボード用のHTML要素とスタイルを`index.html`/`styles.css`に追加し、クリックイベントをハンドルする`handlePendingEstimateAction`を導入しました。

### Testing
- `node --check app.js` を実行して構文チェックを行い、エラーは報告されませんでした（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda5af461c833394f32d78c3bd33ed)