### PR TITLE
未入金管理を実務向けに強化（売上フォーム/一覧/ダッシュボード/CSV対応）

### DIFF
--- a/app.js
+++ b/app.js
@@ -185,7 +185,9 @@ const caseFilterCount = document.getElementById("case-filter-count");
 
 const saleForm = document.getElementById("sale-form");
 const saleCaseSelect = document.getElementById("sale-case-id");
-const salesList = document.getElementById("sales-list");
+const saleInvoiceNumberInput = document.getElementById("sale-invoice-number");
+const salesListBody = document.getElementById("sales-list-body");
+const salesListWrap = document.getElementById("sales-list-wrap");
 const salesEmpty = document.getElementById("sales-empty");
 const saleSubmitBtn = saleForm.querySelector('button[type="submit"]');
 const saleInvoiceMemoInput = document.getElementById("sale-invoice-memo");
@@ -225,7 +227,6 @@ const workTemplateSubmitBtn = document.getElementById("work-template-submit-btn"
 const workTemplatesList = document.getElementById("work-templates-list");
 const workTemplatesEmpty = document.getElementById("work-templates-empty");
 const workTemplateItemTemplate = document.getElementById("work-template-item-template");
-const saleItemTemplate = document.getElementById("sale-item-template");
 const expenseItemTemplate = document.getElementById("expense-item-template");
 const fixedExpenseItemTemplate = document.getElementById("fixed-expense-item-template");
 const estimateForm = document.getElementById("estimate-form");
@@ -345,11 +346,12 @@ function bindEvents() {
   clientHistoryClientSelect?.addEventListener("change", renderClientHistory);
   caseList.addEventListener("click", handleCaseListAction);
   workTemplatesList?.addEventListener("click", handleWorkTemplateListAction);
-  salesList.addEventListener("click", handleSalesListAction);
+  salesListBody?.addEventListener("click", handleSalesListAction);
   expensesList.addEventListener("click", handleExpensesListAction);
   fixedExpensesList.addEventListener("click", handleFixedExpensesListAction);
   dailyReportsBody?.addEventListener("click", handleDailyReportsListAction);
   unpaidListBody?.addEventListener("click", handleUnpaidListAction);
+  unpaidAlertBody?.addEventListener("click", handleUnpaidListAction);
   billingLeakAlertBody?.addEventListener("click", handleBillingLeakAlertAction);
   targetMonthInput?.addEventListener("input", handleTargetMonthChange);
   targetYearInput?.addEventListener("input", handleTargetYearChange);
@@ -932,7 +934,9 @@ async function handleSaleSubmit(event) {
         if (error) throw error;
         if (!data) throw new Error("更新結果を取得できませんでした。");
         console.log("DB DONE", actionName, editState.saleId);
-        await refreshAfterMutation(actionName, "売上を更新しました。");
+        await loadAllData();
+        renderAfterDataChanged();
+        showAppMessage("売上を更新しました。", false);
         resetSaleForm();
         subtabState.sales = "list";
         activateTab("sales");
@@ -943,7 +947,9 @@ async function handleSaleSubmit(event) {
       if (error) throw error;
       if (!data) throw new Error("売上登録結果を取得できませんでした。");
       console.log("DB DONE", actionName, data.id || "new");
-      await refreshAfterMutation(actionName, "売上を登録しました。");
+      await loadAllData();
+      renderAfterDataChanged();
+      showAppMessage("売上を登録しました。", false);
       resetSaleForm();
       subtabState.sales = "list";
       activateTab("sales");
@@ -954,6 +960,11 @@ async function handleSaleSubmit(event) {
     console.log("ACTION FINALLY", actionName);
     forceHideLoading();
   }
+}
+
+function setSaleInvoiceNumberDisplay(value = "") {
+  if (!saleInvoiceNumberInput) return;
+  saleInvoiceNumberInput.value = value || "（登録時に自動採番）";
 }
 
 async function handleExpenseSubmit(event) {
@@ -1403,6 +1414,7 @@ async function startSaleEdit(saleId) {
     saleForm.elements.paidAmount.value = target.paidAmount ?? "";
     saleForm.elements.paidDate.value = target.paidDate || "";
     saleForm.elements.dueDate.value = target.dueDate || "";
+    setSaleInvoiceNumberDisplay(target.invoiceNumber || "");
     saleSubmitBtn.textContent = "売上を更新";
     saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
 }
@@ -1435,6 +1447,7 @@ function openSaleFormForCase(caseId) {
   saleForm.elements.paidAmount.value = "";
   saleForm.elements.paidDate.value = "";
   saleForm.elements.dueDate.value = "";
+  setSaleInvoiceNumberDisplay("");
   saleForm.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
@@ -1905,17 +1918,19 @@ function handleExportSalesCsv() {
   const rows = state.sales.map((entry) => {
     const foundCase = state.cases.find((c) => c.id === entry.caseId);
     return {
+      customer_name: foundCase?.customerName || "",
       case_name: foundCase?.caseName || "",
       invoice_number: entry.invoiceNumber || "",
       invoice_amount: entry.invoiceAmount ?? "",
       paid_amount: entry.paidAmount ?? "",
+      remaining_amount: getRemainingAmount(entry),
       paid_date: entry.paidDate || "",
       due_date: entry.dueDate || "",
       payment_status: entry.paymentStatus || "",
       is_unpaid: entry.paymentStatus !== "入金済" ? "true" : "false",
     };
   });
-  downloadCsvFile("sales.csv", ["case_name", "invoice_number", "invoice_amount", "paid_amount", "paid_date", "due_date", "payment_status", "is_unpaid"], rows);
+  downloadCsvFile("sales.csv", ["customer_name", "case_name", "invoice_number", "invoice_amount", "paid_amount", "remaining_amount", "paid_date", "due_date", "payment_status", "is_unpaid"], rows);
 }
 
 function handleExportExpensesCsv() {
@@ -1950,7 +1965,7 @@ function handleExportAllCsv() {
     "data_type",
     "client_name", "client_type", "address", "tel", "email", "referral_source", "client_memo",
     "client_id", "customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status", "work_memo", "next_action_date", "next_action", "document_url", "invoice_url", "receipt_url",
-    "estimate_number", "invoice_number", "invoice_amount", "paid_amount", "paid_date", "due_date", "payment_status", "is_unpaid",
+    "estimate_number", "invoice_number", "invoice_amount", "paid_amount", "remaining_amount", "paid_date", "due_date", "payment_status", "is_unpaid",
     "date", "content", "amount", "payee", "payment_method",
     "day_of_month", "start_date", "active",
     "report_date", "report_client_id", "report_client_name", "report_case_name", "report_interaction_type", "report_work_content", "report_work_minutes", "report_next_action", "report_next_action_date", "report_memo",
@@ -2008,6 +2023,7 @@ function handleExportAllCsv() {
       invoice_number: entry.invoiceNumber || "",
       invoice_amount: entry.invoiceAmount ?? "",
       paid_amount: entry.paidAmount ?? "",
+      remaining_amount: getRemainingAmount(entry),
       paid_date: entry.paidDate || "",
       due_date: entry.dueDate || "",
       payment_status: entry.paymentStatus || "",
@@ -2136,7 +2152,7 @@ function exportExcel() {
     const workbook = XLSX.utils.book_new();
     const clientHeaders = ["name", "client_type", "address", "tel", "email", "referral_source", "memo"];
     const caseHeaders = ["client_id", "customer_name", "case_name", "estimate_amount", "received_date", "due_date", "status", "work_memo", "next_action_date", "next_action", "document_url", "invoice_url", "receipt_url"];
-    const saleHeaders = ["case_name", "invoice_number", "invoice_amount", "paid_amount", "paid_date", "due_date", "payment_status", "is_unpaid"];
+    const saleHeaders = ["customer_name", "case_name", "invoice_number", "invoice_amount", "paid_amount", "remaining_amount", "paid_date", "due_date", "payment_status", "is_unpaid"];
     const expenseHeaders = ["case_name", "date", "content", "amount", "payee", "payment_method", "receipt_url"];
     const fixedExpenseHeaders = ["content", "amount", "day_of_month", "start_date", "active"];
     const dailyReportHeaders = ["report_date", "client_id", "client_name", "case_name", "interaction_type", "work_content", "work_minutes", "next_action", "next_action_date", "memo"];
@@ -2167,10 +2183,12 @@ function exportExcel() {
     const saleRows = state.sales.map((entry) => {
       const foundCase = state.cases.find((c) => c.id === entry.caseId);
       return {
+        customer_name: foundCase?.customerName || "",
         case_name: foundCase?.caseName || "",
         invoice_number: entry.invoiceNumber || "",
         invoice_amount: entry.invoiceAmount ?? "",
         paid_amount: entry.paidAmount ?? "",
+        remaining_amount: getRemainingAmount(entry),
         paid_date: entry.paidDate || "",
         due_date: entry.dueDate || "",
         payment_status: entry.paymentStatus || "",
@@ -2694,10 +2712,20 @@ function buildTodayTasks() {
       action: `期限対応（${entry.status}）`, date: entry.dueDate, urgencyClass: dueTs <= todayLimit ? "task-overdue" : "task-soon",
     });
   });
-  getCollectionTargetSales().forEach((sale) => {
+  getCollectionTargetSales()
+    .filter((sale) => {
+      const dueTs = toDateOnlyTimestamp(sale.dueDate);
+      return Number.isFinite(dueTs) && dueTs <= todayLimit;
+    })
+    .forEach((sale) => {
     const linked = state.cases.find((entry) => entry.id === sale.caseId);
+    const saleType = isSaleOverdue(sale)
+      ? "期限超過入金確認"
+      : sale.paymentStatus === "一部入金"
+        ? "一部入金確認"
+        : "未入金確認";
     tasks.push({
-      id: sale.id, target: "sale", type: "未入金", customerName: linked?.customerName || "（削除済み顧客）", caseName: linked?.caseName || "（削除済み案件）",
+      id: sale.id, target: "sale", type: saleType, customerName: linked?.customerName || "（削除済み顧客）", caseName: linked?.caseName || "（削除済み案件）",
       action: `${sale.paymentStatus} ${formatCurrency(getRemainingAmount(sale))}`, date: sale.dueDate || sale.paidDate || toDateString(sale.createdAt), urgencyClass: isSaleOverdue(sale) ? "task-overdue" : "task-soon",
     });
   });
@@ -2914,14 +2942,18 @@ function renderUnpaidAlert(filter = {}) {
     .slice()
     .sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt))
     .forEach((sale) => {
+      const linkedCase = state.cases.find((entry) => entry.id === sale.caseId);
       const tr = document.createElement("tr");
       tr.innerHTML = `
-        <td>${escapeHtml(resolveCaseName(sale.caseId))}</td>
+        <td>${escapeHtml(linkedCase?.customerName || "（削除済み顧客）")}</td>
+        <td>${escapeHtml(linkedCase?.caseName || "（削除済み案件）")}</td>
         <td>${formatCurrency(sale.invoiceAmount)}</td>
         <td>${formatCurrency(sale.paidAmount)}</td>
         <td>${formatCurrency(getRemainingAmount(sale))}</td>
-        <td><span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span></td>
         <td>${formatDate(sale.dueDate)}</td>
+        <td><span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span></td>
+        <td>${getSaleDeadlineDaysLabel(sale)}</td>
+        <td><button type="button" class="secondary-btn edit-sale-btn" data-sale-id="${sale.id}">編集</button></td>
       `;
       tr.classList.add(getSaleRowClass(sale));
       unpaidAlertBody.appendChild(tr);
@@ -2944,8 +2976,10 @@ function renderUnpaidList() {
       <td>${formatCurrency(sale.invoiceAmount)}</td>
       <td>${formatCurrency(sale.paidAmount)}</td>
       <td>${formatCurrency(getRemainingAmount(sale))}</td>
-      <td><span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span></td>
       <td>${formatDate(sale.dueDate)}</td>
+      <td>${formatDate(sale.paidDate)}</td>
+      <td><span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span></td>
+      <td>${getSaleDeadlineDaysLabel(sale)}</td>
       <td><button type="button" class="secondary-btn edit-sale-btn" data-sale-id="${sale.id}">編集</button></td>
     `;
     tr.classList.add(getSaleRowClass(sale));
@@ -3899,8 +3933,8 @@ function renderYearlyBreakdown(salesByMonth, expenseByMonth) {
 }
 
 function renderSales() {
-  if (!salesList || !salesEmpty || !saleItemTemplate) return;
-  salesList.innerHTML = "";
+  if (!salesListBody || !salesEmpty || !salesListWrap) return;
+  salesListBody.innerHTML = "";
   const sorted = state.sales.slice().sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt));
   const filteredSales = sorted.filter((sale) => {
     if (!state.salesSearchQuery) return true;
@@ -3908,20 +3942,29 @@ function renderSales() {
   });
 
   filteredSales.forEach((sale) => {
-    const node = saleItemTemplate.content.cloneNode(true);
-    const item = node.querySelector(".item");
-    const title = node.querySelector(".title");
-    const meta = node.querySelector(".meta");
-
-    item.dataset.id = sale.id;
-    title.textContent = `${resolveCaseName(sale.caseId)}｜請求: ${formatCurrency(sale.invoiceAmount)}｜残額: ${formatCurrency(getRemainingAmount(sale))}｜請求番号: ${sale.invoiceNumber || "未採番"}`;
-    meta.innerHTML = `入金: ${formatCurrency(sale.paidAmount)} / 入金日: ${formatDate(sale.paidDate)} / 支払期限: ${formatDate(sale.dueDate)} / ステータス: <span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span>`;
-    salesList.appendChild(node);
+    const linkedCase = state.cases.find((entry) => entry.id === sale.caseId);
+    const tr = document.createElement("tr");
+    tr.dataset.id = sale.id;
+    tr.classList.add(getSaleRowClass(sale));
+    tr.innerHTML = `
+      <td>${escapeHtml(linkedCase?.customerName || "（削除済み顧客）")}</td>
+      <td>${escapeHtml(linkedCase?.caseName || "（削除済み案件）")}<br /><small>${escapeHtml(sale.invoiceNumber || "請求番号なし")}</small></td>
+      <td>${formatCurrency(sale.invoiceAmount)}</td>
+      <td>${formatCurrency(sale.paidAmount)}</td>
+      <td>${formatCurrency(getRemainingAmount(sale))}</td>
+      <td><span class="${getSaleStatusClass(sale)}">${escapeHtml(sale.paymentStatus)}</span></td>
+      <td>${formatDate(sale.dueDate)}</td>
+      <td>${formatDate(sale.paidDate)}</td>
+      <td><button type="button" class="edit-btn secondary-btn">編集</button></td>
+      <td><button type="button" class="danger-btn delete-btn">削除</button></td>
+    `;
+    salesListBody.appendChild(tr);
   });
 
   if (salesFilterCount) {
     salesFilterCount.textContent = `表示中 ${filteredSales.length}件 / 全${sorted.length}件`;
   }
+  salesListWrap.hidden = filteredSales.length === 0;
   salesEmpty.hidden = filteredSales.length > 0;
   salesEmpty.textContent = filteredSales.length || !state.salesSearchQuery
     ? "売上データはまだありません。"
@@ -4067,6 +4110,7 @@ function resetWorkTemplateForm() {
 function resetSaleForm() {
   resetEditMode("sale");
   saleForm.reset();
+  setSaleInvoiceNumberDisplay("");
   saleSubmitBtn.textContent = "売上を登録";
 }
 
@@ -5144,7 +5188,6 @@ function getSalePaymentStatus(invoiceAmount, paidAmount) {
 }
 
 function normalizeSalePaymentStatus(value, invoiceAmount, paidAmount) {
-  if (SALES_PAYMENT_STATUSES.includes(value)) return value;
   return getSalePaymentStatus(invoiceAmount, paidAmount);
 }
 
@@ -5166,7 +5209,17 @@ function getSaleStatusClass(sale) {
 function getSaleRowClass(sale) {
   if (isSaleOverdue(sale)) return "sale-row-overdue";
   if (sale.paymentStatus === "一部入金") return "sale-row-partial";
+  if (sale.paymentStatus === "未入金") return "sale-row-unpaid";
   return "";
+}
+
+function getSaleDeadlineDaysLabel(sale) {
+  if (!sale?.dueDate) return "-";
+  const dueTimestamp = toDateOnlyTimestamp(sale.dueDate);
+  const todayTimestamp = getTodayTimestamp();
+  if (!Number.isFinite(dueTimestamp) || !Number.isFinite(todayTimestamp)) return "-";
+  const diffDays = Math.floor((dueTimestamp - todayTimestamp) / 86400000);
+  return diffDays < 0 ? `${Math.abs(diffDays)}日経過` : diffDays === 0 ? "今日まで" : `期限まで${diffDays}日`;
 }
 
 function getSalesPaymentLabel(sale) {
@@ -5903,6 +5956,11 @@ function mapEstimateItemFromDb(row) {
 }
 
 function mapSaleFromDb(row) {
+  // DB拡張が未適用の場合は以下を実行してください:
+  // alter table sales add column if not exists paid_amount bigint default 0;
+  // alter table sales add column if not exists payment_status text;
+  // alter table sales add column if not exists due_date date;
+  // alter table sales add column if not exists invoice_number text;
   const invoiceAmount = normalizeAmount(row.invoice_amount) ?? 0;
   const paidAmount = normalizeAmount(row.paid_amount) ?? 0;
   const paymentStatus = normalizeSalePaymentStatus(row.payment_status, invoiceAmount, paidAmount);

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="styles.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-    <script src="app.js?v=20260426-daily-report-submit-fix" defer></script>
+    <script src="app.js?v=20260426-payment-control-upgrade" defer></script>
   </head>
   <body>
     <div id="loading-overlay" class="loading-overlay" hidden>
@@ -241,7 +241,7 @@
           </section>
           <section id="unpaid-alert-card" class="unpaid-alert-card case-alert-block" aria-live="polite">
             <div class="unpaid-alert-header">
-              <h3>未入金アラート</h3>
+              <h3>未入金管理</h3>
               <p id="unpaid-alert-period" class="unpaid-alert-period"></p>
             </div>
             <p id="unpaid-alert-summary" class="unpaid-alert-summary"></p>
@@ -250,12 +250,15 @@
               <table class="unpaid-alert-table">
                 <thead>
                   <tr>
-                    <th>対象案件</th>
+                    <th>顧客名</th>
+                    <th>案件名</th>
                     <th>請求額</th>
                     <th>入金額</th>
                     <th>残額</th>
-                    <th>ステータス</th>
                     <th>支払期限</th>
+                    <th>ステータス</th>
+                    <th>日数</th>
+                    <th>編集</th>
                   </tr>
                 </thead>
                 <tbody id="unpaid-alert-body"></tbody>
@@ -333,8 +336,10 @@
                   <th>請求額</th>
                   <th>入金額</th>
                   <th>残額</th>
-                  <th>ステータス</th>
                   <th>支払期限</th>
+                  <th>入金日</th>
+                  <th>ステータス</th>
+                  <th>日数</th>
                   <th>操作</th>
                 </tr>
               </thead>
@@ -684,8 +689,12 @@
               <h2>売上登録</h2>
               <form id="sale-form" class="form">
                 <label>
-                  対象案件 <span class="required">必須</span>
+                  案件 <span class="required">必須</span>
                   <select id="sale-case-id" name="saleCaseId" required></select>
+                </label>
+                <label>
+                  請求番号
+                  <input id="sale-invoice-number" name="invoiceNumber" type="text" readonly />
                 </label>
                 <label>
                   請求額（円） <span class="required">必須</span>
@@ -704,10 +713,10 @@
                   <input id="sale-due-date" name="dueDate" type="date" />
                 </label>
                 <label>
-                  請求書備考（出力用）
+                  備考
                   <textarea id="sale-invoice-memo" name="invoiceMemo" rows="2" maxlength="2000" placeholder="請求書出力時に使用する備考"></textarea>
                 </label>
-                <p class="meta">請求番号は登録時に自動採番されます（形式: S-YYYYMM-001）。</p>
+                <p class="meta">請求番号は自動採番済みの番号を使用します（形式: S-YYYYMM-001）。</p>
                 <button type="submit">売上を登録</button>
               </form>
             </section>
@@ -723,7 +732,25 @@
               </div>
               <p id="sales-filter-count" class="filter-count">表示中 0件 / 全0件</p>
               <div id="sales-empty" class="empty">売上データはまだありません。</div>
-              <ul id="sales-list" class="item-list"></ul>
+              <div id="sales-list-wrap" class="table-wrap" hidden>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>顧客名</th>
+                      <th>案件名</th>
+                      <th>請求額</th>
+                      <th>入金額</th>
+                      <th>残額</th>
+                      <th>入金ステータス</th>
+                      <th>支払期限</th>
+                      <th>入金日</th>
+                      <th>編集</th>
+                      <th>削除</th>
+                    </tr>
+                  </thead>
+                  <tbody id="sales-list-body"></tbody>
+                </table>
+              </div>
             </section>
             <section class="panel subtab-panel" data-parent-tab="sales" data-subtab="unpaid" hidden>
               <h2>未入金</h2>
@@ -937,17 +964,6 @@
         <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
       </li>
     </template>
-
-    <template id="sale-item-template">
-      <li class="item">
-        <div>
-          <p class="title"></p>
-          <p class="meta"></p>
-        </div>
-        <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
-      </li>
-    </template>
-
     <template id="expense-item-template">
       <li class="item">
         <div>

--- a/styles.css
+++ b/styles.css
@@ -632,8 +632,17 @@ button:hover { background: var(--primary-dark); }
   background: #fff7ed;
 }
 
+.sale-row-unpaid td {
+  background: #fefce8;
+}
+
 .sale-status-overdue,
 .sale-status-unpaid {
+  color: #a16207;
+  font-weight: 700;
+}
+
+.sale-status-overdue {
   color: #b91c1c;
   font-weight: 700;
 }


### PR DESCRIPTION
### Motivation
- 請求後の入金漏れ・回収漏れを防ぐため、未入金・一部入金・期限超過を明確に管理できるダッシュボードと売上画面が必要だった。 
- 入金ステータスを手入力から `invoice_amount` / `paid_amount` による自動判定に統一して運用負荷を下げたい。 
- CSV/Excelや今日やること連携などの出力・通知に未入金情報（残額や期限日数）を含めて実務ワークフローに対応したい。 

### Description
- 売上登録フォームを再構成し `案件 / 請求番号（readonly） / 請求額 / 入金額 / 入金日 / 支払期限 / 備考` を表示し、編集時は既存の請求番号を表示、新規時は自動採番表示に統一するための `setSaleInvoiceNumberDisplay` を追加した。 
- 売上一覧をカード表示からテーブル表示へ変更し `顧客名 / 案件名 / 請求額 / 入金額 / 残額 / 入金ステータス / 支払期限 / 入金日 / 編集 / 削除` を表示するように `renderSales` を刷新し、クリックバインディングを `sales-list-body` に合わせて更新した。 
- ダッシュボードの未入金セクションを「未入金管理」に強化し `顧客名 / 案件名 / 請求額 / 入金額 / 残額 / 支払期限 / ステータス / 日数 / 編集` を表示、`今日やること` は支払期限が今日以前で未入金または一部入金の売上のみをタスク化するようにした。 
- 入金ステータス算出を常に `getSalePaymentStatus(invoiceAmount, paidAmount)` に統一し `normalizeSalePaymentStatus` を自動判定優先化、関連する行クラス（`sale-row-overdue` / `sale-row-partial` / `sale-row-unpaid`）と表示クラスを追加し色分け（期限超過: 赤 / 一部入金: オレンジ / 期限前未入金: 黄）を適用した。 
- CSV/Excel/全データバックアップの売上出力に `remaining_amount`（残額）と `customer_name` を追加し、エクスポートヘッダと `saleRows` を更新した。 
- `handleSaleSubmit` の処理流れを要件通りに整理して `event.preventDefault()` → payload作成（自動 `payment_status`）→ `.insert/.update(...).select().single()` → 成功時 `await loadAllData()` → `renderAfterDataChanged()` → 成功時フォームリセット → 売上一覧へ遷移 → `finally` で `forceHideLoading()` を厳守するように変更した。 
- DBに必要なカラムが無い場合の SQL を `mapSaleFromDb` の直上にコメントで追記した（`paid_amount`, `payment_status`, `due_date`, `invoice_number` の追加例）。 

### Testing
- 自動構文チェックとして `node --check app.js` を実行して成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda915541083338ad59ac64136a914)