### PR TITLE
紹介元別分析の強化（利益率・判定・CSV項目拡張）

### DIFF
--- a/app.js
+++ b/app.js
@@ -2127,11 +2127,15 @@ function handleExportReferralAnalysisCsv() {
     referral_source: row.referralSource,
     client_count: row.clientCount,
     case_count: row.caseCount,
-    sales_total: row.salesTotal,
+    total_sales: row.salesTotal,
+    total_expenses: row.expenseTotal,
     profit: row.profit,
-    unpaid_total: row.unpaidTotal,
+    unpaid_amount: row.unpaidTotal,
+    average_price: row.averagePrice,
+    profit_margin: row.profitMargin,
+    comment: row.comment,
   }));
-  downloadCsvFile("referral_analysis.csv", ["referral_source", "client_count", "case_count", "sales_total", "profit", "unpaid_total"], rows);
+  downloadCsvFile("referral_analysis.csv", ["referral_source", "client_count", "case_count", "total_sales", "total_expenses", "profit", "unpaid_amount", "average_price", "profit_margin", "comment"], rows);
 }
 
 async function handleCsvImportSubmit(event) {
@@ -2299,9 +2303,13 @@ function exportAnalysisExcel() {
       referral_source: row.referralSource,
       client_count: row.clientCount,
       case_count: row.caseCount,
-      sales_total: row.salesTotal,
+      total_sales: row.salesTotal,
+      total_expenses: row.expenseTotal,
       profit: row.profit,
-      unpaid_total: row.unpaidTotal,
+      unpaid_amount: row.unpaidTotal,
+      average_price: row.averagePrice,
+      profit_margin: row.profitMargin,
+      comment: row.comment,
     }));
     XLSX.utils.book_append_sheet(
       workbook,
@@ -2310,7 +2318,7 @@ function exportAnalysisExcel() {
     );
     XLSX.utils.book_append_sheet(
       workbook,
-      createExcelSheet(referralRows, ["referral_source", "client_count", "case_count", "sales_total", "profit", "unpaid_total"]),
+      createExcelSheet(referralRows, ["referral_source", "client_count", "case_count", "total_sales", "total_expenses", "profit", "unpaid_amount", "average_price", "profit_margin", "comment"]),
       "紹介元別分析",
     );
     XLSX.writeFile(workbook, "gyosei-analysis-export.xlsx");
@@ -3047,6 +3055,26 @@ function toSafeNumber(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
+function normalizeReferralSourceLabel(value, fallback = "未設定") {
+  const normalized = asTrimmedText(value);
+  return normalized || fallback;
+}
+
+function calculateProfitMarginPercent(salesTotal, expenseTotal) {
+  const safeSales = toSafeNumber(salesTotal);
+  if (safeSales <= 0) return 0;
+  return ((safeSales - toSafeNumber(expenseTotal)) / safeSales) * 100;
+}
+
+function classifyReferralProfitability(row) {
+  if (!row || row.clientCount <= 0 || row.caseCount <= 0) return "データ不足：継続観察";
+  if (row.profit < 0) return "赤字：対応範囲見直し";
+  if (row.caseCount >= 3 && row.averagePrice < 50000) return "案件数多いが売上低い：メニュー見直し";
+  if (row.salesTotal > 0 && row.profitMargin >= 0 && row.profitMargin < 30) return "売上あり利益低い：単価見直し";
+  if (row.profitMargin >= 30) return "高利益：重点営業";
+  return "データ不足：継続観察";
+}
+
 function resolveClientForCase(caseEntry, clientById, clientsByNameKey) {
   const byId = caseEntry.clientId ? clientById.get(caseEntry.clientId) : null;
   if (byId) return byId;
@@ -3056,6 +3084,7 @@ function resolveClientForCase(caseEntry, clientById, clientsByNameKey) {
 
 function buildClientAndReferralAnalytics(filter = {}) {
   const clientById = new Map(state.clients.map((client) => [client.id, client]));
+  const knownClientNames = new Set(state.clients.map((client) => String(client.name || "")));
   const clientsByNameKey = new Map();
   state.clients.forEach((client) => {
     const key = normalizeNameKey(client.name);
@@ -3102,25 +3131,22 @@ function buildClientAndReferralAnalytics(filter = {}) {
 
   state.sales.forEach((sale) => {
     const linkedCase = caseById.get(sale.caseId);
-    if (!linkedCase) return;
     if (!isWithinFilterDate(sale.paidDate || sale.createdAt, filter)) return;
-    const client = resolveClientForCase(linkedCase, clientById, clientsByNameKey);
-    const clientName = client?.name || linkedCase.customerName || "未設定";
+    const client = linkedCase ? resolveClientForCase(linkedCase, clientById, clientsByNameKey) : null;
+    const clientName = client?.name || linkedCase?.customerName || "不明";
     const row = ensureClientRow(clientName);
-    row.referralSource = client?.referralSource || row.referralSource || "未設定";
+    row.referralSource = normalizeReferralSourceLabel(client?.referralSource, linkedCase ? "未設定" : "不明");
     row.salesTotal += toSafeNumber(sale.invoiceAmount);
     row.unpaidTotal += toSafeNumber(getRemainingAmount(sale));
   });
 
   state.expenses.forEach((expense) => {
-    if (!expense.caseId) return;
     const linkedCase = caseById.get(expense.caseId);
-    if (!linkedCase) return;
     if (!isWithinFilterDate(expense.date, filter)) return;
-    const client = resolveClientForCase(linkedCase, clientById, clientsByNameKey);
-    const clientName = client?.name || linkedCase.customerName || "未設定";
+    const client = linkedCase ? resolveClientForCase(linkedCase, clientById, clientsByNameKey) : null;
+    const clientName = client?.name || linkedCase?.customerName || "不明";
     const row = ensureClientRow(clientName);
-    row.referralSource = client?.referralSource || row.referralSource || "未設定";
+    row.referralSource = normalizeReferralSourceLabel(client?.referralSource, linkedCase ? "未設定" : "不明");
     row.expenseTotal += toSafeNumber(expense.amount);
   });
 
@@ -3142,7 +3168,7 @@ function buildClientAndReferralAnalytics(filter = {}) {
       salesTotal: toSafeNumber(row.salesTotal),
       expenseTotal: toSafeNumber(row.expenseTotal),
       unpaidTotal: toSafeNumber(row.unpaidTotal),
-      referralSource: row.referralSource || "未設定",
+      referralSource: normalizeReferralSourceLabel(row.referralSource),
       profit: toSafeNumber(row.salesTotal) - toSafeNumber(row.expenseTotal),
       rank: getClientRank(toSafeNumber(row.salesTotal)),
       lastContactDate: row.lastContactDate || row.lastCreatedCaseDate || null,
@@ -3157,13 +3183,20 @@ function buildClientAndReferralAnalytics(filter = {}) {
     });
 
   const referralMap = new Map();
+  state.clients.forEach((client) => {
+    const key = normalizeReferralSourceLabel(client?.referralSource);
+    if (!referralMap.has(key)) {
+      referralMap.set(key, { referralSource: key, clientCount: 0, caseCount: 0, salesTotal: 0, expenseTotal: 0, unpaidTotal: 0 });
+    }
+    referralMap.get(key).clientCount += 1;
+  });
   clientRows.forEach((row) => {
-    const key = row.referralSource || "未設定";
+    const key = normalizeReferralSourceLabel(row.referralSource);
     if (!referralMap.has(key)) {
       referralMap.set(key, { referralSource: key, clientCount: 0, caseCount: 0, salesTotal: 0, expenseTotal: 0, unpaidTotal: 0 });
     }
     const current = referralMap.get(key);
-    current.clientCount += 1;
+    if (!knownClientNames.has(String(row.clientName || ""))) current.clientCount += 1;
     current.caseCount += row.caseCount;
     current.salesTotal += row.salesTotal;
     current.expenseTotal += row.expenseTotal;
@@ -3171,7 +3204,28 @@ function buildClientAndReferralAnalytics(filter = {}) {
   });
 
   const referralRows = Array.from(referralMap.values())
-    .map((row) => ({ ...row, profit: row.salesTotal - row.expenseTotal }))
+    .map((row) => {
+      const salesTotal = toSafeNumber(row.salesTotal);
+      const expenseTotal = toSafeNumber(row.expenseTotal);
+      const caseCount = toSafeNumber(row.caseCount);
+      const profit = salesTotal - expenseTotal;
+      const averagePrice = caseCount > 0 ? salesTotal / caseCount : 0;
+      const profitMargin = calculateProfitMarginPercent(salesTotal, expenseTotal);
+      const rowWithMetrics = {
+        ...row,
+        salesTotal,
+        expenseTotal,
+        caseCount,
+        unpaidTotal: toSafeNumber(row.unpaidTotal),
+        profit,
+        averagePrice,
+        profitMargin,
+      };
+      return {
+        ...rowWithMetrics,
+        comment: classifyReferralProfitability(rowWithMetrics),
+      };
+    })
     .sort((a, b) => b.profit - a.profit);
 
   return { clientRows, referralRows };
@@ -3207,14 +3261,19 @@ function renderAnalyticsSection() {
   if (referralAnalysisWrap) referralAnalysisWrap.hidden = referralRows.length === 0;
   if (referralAnalysisEmpty) referralAnalysisEmpty.hidden = referralRows.length > 0;
   referralRows.forEach((row) => {
+    const marginClass = row.profit < 0 ? "referral-margin-negative" : row.profitMargin >= 30 ? "referral-margin-good" : "referral-margin-normal";
     const tr = document.createElement("tr");
     tr.innerHTML = `
       <td>${escapeHtml(row.referralSource || "未設定")}</td>
       <td>${row.clientCount}件</td>
       <td>${row.caseCount}件</td>
       <td>${formatCurrency(row.salesTotal)}</td>
+      <td>${formatCurrency(row.expenseTotal)}</td>
       <td class="${row.profit < 0 ? "loss-text" : ""}">${formatCurrency(row.profit)}</td>
       <td class="${row.unpaidTotal > 0 ? "analysis-unpaid-text" : ""}">${formatCurrency(row.unpaidTotal)}${row.unpaidTotal > 0 ? " ⚠️" : ""}</td>
+      <td>${formatCurrency(row.averagePrice)}</td>
+      <td class="${marginClass}">${row.profitMargin.toFixed(1)}%</td>
+      <td>${escapeHtml(row.comment)}</td>
     `;
     referralAnalysisBody.appendChild(tr);
   });

--- a/index.html
+++ b/index.html
@@ -403,8 +403,12 @@
                     <th>顧客数</th>
                     <th>案件数</th>
                     <th>売上合計</th>
+                    <th>経費合計</th>
                     <th>利益</th>
                     <th>未入金額</th>
+                    <th>平均単価</th>
+                    <th>利益率</th>
+                    <th>判定</th>
                   </tr>
                 </thead>
                 <tbody id="referral-analysis-body"></tbody>
@@ -437,7 +441,23 @@
                 <label>住所<input id="client-address" name="clientAddress" type="text" maxlength="200" /></label>
                 <label>電話番号<input id="client-tel" name="clientTel" type="text" maxlength="40" /></label>
                 <label>メール<input id="client-email" name="clientEmail" type="email" maxlength="120" /></label>
-                <label>紹介元<input id="client-referral-source" name="clientReferralSource" type="text" maxlength="120" /></label>
+                <label>紹介元
+                  <input id="client-referral-source" name="clientReferralSource" type="text" maxlength="120" list="client-referral-source-options" placeholder="紹介元を選択または入力" />
+                  <datalist id="client-referral-source-options">
+                    <option value="紹介"></option>
+                    <option value="商工会議所"></option>
+                    <option value="D-Biz"></option>
+                    <option value="ミツモア"></option>
+                    <option value="ココナラ"></option>
+                    <option value="ホームページ"></option>
+                    <option value="SNS"></option>
+                    <option value="チラシ"></option>
+                    <option value="飛び込み営業"></option>
+                    <option value="既存顧客"></option>
+                    <option value="家族/知人"></option>
+                    <option value="その他"></option>
+                  </datalist>
+                </label>
                 <label>メモ<textarea id="client-memo" name="clientMemo" rows="3" maxlength="2000"></textarea></label>
                 <button id="client-submit-btn" type="submit">顧客を登録</button>
               </form>

--- a/styles.css
+++ b/styles.css
@@ -751,6 +751,21 @@ tbody tr:last-child td {
   font-weight: 700;
 }
 
+.referral-margin-good {
+  color: #15803d;
+  font-weight: 700;
+}
+
+.referral-margin-normal {
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.referral-margin-negative {
+  color: var(--danger);
+  font-weight: 700;
+}
+
 .client-rank-badge {
   display: inline-block;
   min-width: 1.6rem;


### PR DESCRIPTION
### Motivation
- 営業ルートごとの費用対効果を可視化し、どの紹介元に注力すべきか判断できるようにするため。 
- 欠損データがあっても画面が落ちない耐性を高めるため。

### Description
- 顧客登録フォームの「紹介元」を候補付き入力に変更し、指定候補（紹介／商工会議所／D-Biz／ミツモア／ココナラ／ホームページ／SNS／チラシ／飛び込み営業／既存顧客／家族/知人／その他）を `datalist` で追加しつつ自由入力を許可した（`index.html` を変更）。
- 紹介元別分析テーブルに `経費合計`、`平均単価`、`利益率`、`判定` 列を追加して画面表示を拡張した（`index.html` / `app.js` のレンダリング部分を変更）。
- 集計ロジックを拡張し、`利益 = 売上合計 - 経費合計`、`平均単価 = 売上合計 / 案件数`（案件数0は0扱い）、`利益率 = 利益 / 売上合計 × 100`（売上0は0%）を計算して `referralRows` に格納し、利益降順でソートするようにした（`app.js` の `buildClientAndReferralAnalytics` を変更）。
- 営業判断コメントを自動生成するロジックを追加し、利益率に応じた色分けクラス（良好/普通/要注意）と判定文言（例：重点営業、単価見直し、対応範囲見直し、メニュー見直し、継続観察）を出力するようにした（`app.js` / `styles.css` にスタイル追加）。
- 紹介元別分析の CSV/Excel 出力項目を拡張し、`total_sales`, `total_expenses`, `profit`, `unpaid_amount`, `average_price`, `profit_margin`, `comment` を含めるようにした（`app.js` のエクスポート処理を変更）。
- 案件に紐づかない売上・経費についても集計対象とし、紐付かない場合は紹介元を `不明` として扱うなどの欠損耐性を強化した（`app.js` の集計で処理）。

### Testing
- 自動静的チェックで `node --check app.js` を実行し構文エラーは発生しませんでした（成功）。
- 既存の画面・機能を壊さないよう既存レンダリングフローを維持しつつ変更を加えていますが、ブラウザでの視覚確認（スクリーンショット等）はこの環境では未実行です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc10f536083338dd5dfdfb7a4eef0)