### PR TITLE
督促記録ボタンで督促情報が更新されない不具合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ alter table sales add column if not exists payment_status text;
 alter table sales add column if not exists due_date date;
 alter table sales add column if not exists invoice_number text;
 alter table sales add column if not exists estimate_id uuid;
+alter table sales add column if not exists reminder_count int default 0;
+alter table sales add column if not exists last_reminder_date date;
+alter table sales add column if not exists reminder_method text;
+alter table sales add column if not exists reminder_memo text;
 ```
 
 ## 複数端末で同じデータを閲覧する条件

--- a/app.js
+++ b/app.js
@@ -384,6 +384,7 @@ function bindEvents() {
   nextActionAlertBody?.addEventListener("click", handleNextActionAlertClick);
   todayTaskBody?.addEventListener("click", handleTodayTaskAction);
   pendingEstimatesBody?.addEventListener("click", handlePendingEstimateAction);
+  document.addEventListener("click", handleReminderRecordClick);
   caseSearchInput?.addEventListener("input", handleCaseSearchInput);
   caseStatusFilterSelect?.addEventListener("change", handleCaseStatusFilterChange);
   caseDeadlineFilterSelect?.addEventListener("change", handleCaseDeadlineFilterChange);
@@ -1380,9 +1381,6 @@ async function handleSalesListAction(event) {
     return;
   }
 
-  if (btn.classList.contains("record-reminder-btn")) {
-    await recordSaleReminder(id);
-  }
 }
 
 async function handleExpensesListAction(event) {
@@ -1415,9 +1413,6 @@ function handleUnpaidListAction(event) {
     editSale(saleId).catch(() => {});
     return;
   }
-  if (btn.classList.contains("record-reminder-btn")) {
-    recordSaleReminder(saleId).catch(() => {});
-  }
 }
 
 function handleTodayTaskAction(event) {
@@ -1434,13 +1429,20 @@ function handleTodayTaskAction(event) {
     editSale(taskId).catch(() => {});
     return;
   }
-  if (target === "sale-reminder") {
-    recordSaleReminder(taskId).catch(() => {});
-    return;
-  }
   if (target === "daily-report") {
     editDailyReport(taskId).catch(() => {});
   }
+}
+
+async function handleReminderRecordClick(event) {
+  const button = event.target.closest(".record-reminder-btn");
+  if (!(button instanceof HTMLButtonElement)) return;
+  const saleId = button.dataset.saleId || button.closest("[data-sale-id]")?.dataset.saleId || button.closest("[data-id]")?.dataset.id;
+  if (!saleId) {
+    showAppMessage("督促対象の売上IDを取得できませんでした。", true);
+    return;
+  }
+  await handleRecordReminder(saleId);
 }
 
 function handleBillingLeakAlertAction(event) {
@@ -1463,49 +1465,48 @@ function handlePendingEstimateAction(event) {
   }
 }
 
-async function recordSaleReminder(saleId) {
+async function handleRecordReminder(saleId) {
   if (!currentUser) {
     showAppMessage("ログイン状態を確認できません。", true);
     return;
   }
-  const target = state.sales.find((entry) => entry.id === saleId);
-  if (!target) {
-    showAppMessage("対象の売上データが見つかりません。", true);
+  const sale = state.sales.find((entry) => entry.id === saleId);
+  if (!sale) {
+    showAppMessage("対象の売上が見つかりません。", true);
     return;
   }
-  if (!isReminderRecordableSale(target)) {
+  if (!isReminderRecordableSale(sale)) {
     showAppMessage("督促記録は未入金または一部入金の売上のみ登録できます。", true);
     return;
   }
 
-  const defaultDate = toDateString(new Date());
-  const reminderDate = window.prompt("督促日を入力してください（YYYY-MM-DD）", target.lastReminderDate || defaultDate);
-  if (reminderDate === null) return;
+  const reminderDate = window.prompt("督促日を入力してください（YYYY-MM-DD）", toDateString(new Date()));
+  if (!reminderDate) return;
   const normalizedReminderDate = parseFlexibleDate(reminderDate);
   if (!normalizedReminderDate) {
     showAppMessage("督促日の形式が不正です。YYYY-MM-DD形式で入力してください。", true);
     return;
   }
 
-  const methodPrompt = `督促方法を入力してください（${REMINDER_METHODS.join(" / ")}）`;
-  const methodInput = window.prompt(methodPrompt, target.reminderMethod || REMINDER_METHODS[0]);
-  if (methodInput === null) return;
-  const normalizedMethod = normalizeReminderMethod(methodInput);
+  const methodPrompt = `督促方法を入力してください（${REMINDER_METHODS.join("・")}）`;
+  const reminderMethod = window.prompt(methodPrompt, sale.reminderMethod || REMINDER_METHODS[0]);
+  if (!reminderMethod) return;
+  const normalizedMethod = normalizeReminderMethod(reminderMethod);
 
-  const memoInput = window.prompt("督促メモを入力してください（任意）", target.reminderMemo || "");
-  if (memoInput === null) return;
-  const normalizedMemo = asTrimmedText(memoInput) || null;
+  const reminderMemo = window.prompt("督促メモを入力してください", sale.reminderMemo || "");
+  if (reminderMemo === null) return;
+  const normalizedMemo = asTrimmedText(reminderMemo) || "";
 
   startLoading("督促記録");
   try {
-    clearAppMessage();
+    const currentCount = Number(sale.reminderCount || 0);
     const payload = {
-      reminder_count: (Number(target.reminderCount) || 0) + 1,
+      reminder_count: currentCount + 1,
       last_reminder_date: normalizedReminderDate,
       reminder_method: normalizedMethod,
       reminder_memo: normalizedMemo,
-      updated_at: new Date().toISOString(),
     };
+    console.log("REMINDER PAYLOAD", saleId, payload);
     const { data, error } = await sbClient
       .from("sales")
       .update(payload)
@@ -1519,7 +1520,8 @@ async function recordSaleReminder(saleId) {
     renderAfterDataChanged();
     showAppMessage("督促記録を保存しました。", false);
   } catch (error) {
-    showAppMessage(`督促記録の保存に失敗しました。${error?.message || ""} ${error?.details || ""} ${error?.hint || ""} ${error?.code || ""}`, true);
+    console.error("督促記録に失敗しました。", error);
+    showAppMessage(`督促記録に失敗しました。${error?.message || ""} ${error?.details || ""} ${error?.hint || ""} ${error?.code || ""}`, true);
   } finally {
     forceHideLoading();
   }
@@ -2833,7 +2835,7 @@ function renderTodayTaskCard() {
         <td>${row.lastReminderDateLabel || "-"}</td>
         <td>${row.reminderCountLabel || "-"}</td>
         <td><button type="button" class="secondary-btn" data-task-target="${row.target}" data-task-id="${row.id}">編集</button></td>
-        <td>${row.showReminderButton ? `<button type="button" class="secondary-btn" data-task-target="sale-reminder" data-task-id="${row.id}">督促記録</button>` : "-"}</td>
+        <td>${row.showReminderButton ? `<button type="button" class="secondary-btn record-reminder-btn" data-sale-id="${row.id}">督促記録</button>` : "-"}</td>
       `;
       todayTaskBody.appendChild(tr);
     });
@@ -4400,7 +4402,7 @@ function renderSales() {
         <td>${lastReminderDateLabel}</td>
         <td>${escapeHtml(reminderMethod)}</td>
         <td>${escapeHtml(reminderMemo)}</td>
-        <td>${canRecordReminder ? '<button type="button" class="secondary-btn record-reminder-btn">督促記録</button>' : '-'}</td>
+        <td>${canRecordReminder ? `<button type="button" class="secondary-btn record-reminder-btn" data-sale-id="${sale.id}">督促記録</button>` : "-"}</td>
         <td><button type="button" class="edit-btn secondary-btn">編集</button></td>
         <td><button type="button" class="danger-btn delete-btn">削除</button></td>
       `;
@@ -6504,9 +6506,9 @@ function mapSaleFromDb(row) {
     paymentStatus: row.payment_status || calculatePaymentStatus(invoiceAmount, paidAmount),
     isUnpaid: row.is_unpaid !== false,
     invoiceNumber: row.invoice_number || "",
-    reminderCount: parseFlexibleInteger(row.reminder_count, 0),
+    reminderCount: Number(row.reminder_count || 0),
     lastReminderDate: row.last_reminder_date || null,
-    reminderMethod: normalizeReminderMethod(row.reminder_method),
+    reminderMethod: row.reminder_method || "",
     reminderMemo: row.reminder_memo || "",
     createdAt: Date.parse(row.created_at) || null,
     updatedAt: Date.parse(row.updated_at) || null,


### PR DESCRIPTION
### Motivation
- 売上一覧・未入金管理・今日やることの「督促記録」ボタンを押してもDBの督促情報が反映されない問題を解消するための修正です。 

### Description
- クリックイベントをドキュメントレベルのイベント委任に統一し、`.record-reminder-btn` のクリックで確実にハンドラが呼ばれるように `document.addEventListener("click", handleReminderRecordClick)` を追加しました。 
- 督促処理を `handleRecordReminder(saleId)` に統一して `saleId` の取得・ログインチェック・対象売上の存在確認・入力受付・更新ペイロード生成・Supabase更新・`loadAllData()` と `renderAfterDataChanged()` による再描画を一連の流れで行うようにしました。 
- 各表示箇所（売上一覧 / 未入金管理 / 今日やること）でボタンに `data-sale-id` を付与して `saleId` 解決を安定化させ、描画側のボタンHTMLを更新しました。 
- `mapSaleFromDb` の督促関連フィールドを明示的に `reminderCount: Number(row.reminder_count || 0)`, `lastReminderDate: row.last_reminder_date || null`, `reminderMethod: row.reminder_method || ""`, `reminderMemo: row.reminder_memo || ""` に揃えてフロント側での値解釈を安定化しました。 
- 更新ペイロードのログ出力（`console.log("REMINDER PAYLOAD", saleId, payload)`）と、失敗時にコンソールへエラー出力する扱いを追加しました。 
- README に Supabase 用の追加SQLを追記して `sales` テーブルに `reminder_count / last_reminder_date / reminder_method / reminder_memo` を作成する手順を明記しました. 

### Testing
- `node --check app.js` を実行して構文エラーがないことを確認しました（成功）。 
- リントやブラウザ上の手動操作はこの自動化環境では実行しておらず、実動環境での操作確認（未入金レコードを作成してボタン押下 → 画面更新なしで反映）が推奨されます。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0aa16f6883339aad0ac947f2784c)