### PR TITLE
統合アラートエンジンを実装 — ダッシュボード「今日やること」を一元化

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ const state = {
   estimateTitleQuery: "",
   estimateStatusFilter: "all",
   estimateExpiredFilter: "all",
+  alerts: [],
   isInitialDataReady: false,
 };
 const editState = { clientId: null, caseId: null, workTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null };
@@ -1500,6 +1501,12 @@ function handleUnpaidListAction(event) {
 function handleTodayTaskAction(event) {
   const btn = event.target.closest("button");
   if (!(btn instanceof HTMLButtonElement)) return;
+  if (btn.classList.contains("record-reminder-btn")) {
+    const saleId = btn.dataset.saleId;
+    if (!saleId) return;
+    handleRecordReminder(saleId).catch(() => {});
+    return;
+  }
   const taskId = btn.dataset.taskId;
   const target = btn.dataset.taskTarget;
   if (!taskId || !target) return;
@@ -2854,7 +2861,31 @@ function renderPayments() {
 
 function renderTodayTasks() {
   if (!todayTaskCard || !todayTaskSummary || !todayTaskBody || !todayTaskEmpty || !todayTaskListWrap) return;
-  renderTodayTaskCard();
+  safeRender("todayTaskCard", () => {
+    const alerts = buildIntegratedAlerts();
+    state.alerts = alerts;
+    todayTaskCard.classList.toggle("has-alert", alerts.length > 0);
+    todayTaskSummary.textContent = `対象 ${alerts.length}件`;
+    todayTaskBody.innerHTML = "";
+    todayTaskEmpty.hidden = alerts.length > 0;
+    todayTaskListWrap.hidden = alerts.length === 0;
+    if (!alerts.length) return;
+    alerts.forEach((alert) => {
+      const tr = document.createElement("tr");
+      tr.className = `task-priority-${alert.priority || "low"}`;
+      tr.innerHTML = `
+        <td>${escapeHtml(alert.typeLabel || "通知")}</td>
+        <td>${escapeHtml(alert.clientName || "顧客不明")}</td>
+        <td>${escapeHtml(alert.caseName || "案件なし")}</td>
+        <td>${escapeHtml(alert.title || "-")}</td>
+        <td>${escapeHtml(alert.dateLabel || "-")}</td>
+        <td>${escapeHtml(alert.subInfo || "-")}</td>
+        <td><button type="button" class="secondary-btn" data-task-target="${alert.target || "case"}" data-task-id="${alert.id || ""}">編集</button></td>
+        <td>${alert.actionButtonHtml || "-"}</td>
+      `;
+      todayTaskBody.appendChild(tr);
+    });
+  });
 }
 
 function renderCaseTasks() {
@@ -3041,30 +3072,111 @@ function renderDashboard() {
 }
 
 function renderTodayTaskCard() {
-  if (!todayTaskCard || !todayTaskSummary || !todayTaskBody || !todayTaskEmpty || !todayTaskListWrap) return;
-  const rows = buildTodayTasks();
-  todayTaskCard.classList.toggle("has-alert", rows.length > 0);
-  todayTaskSummary.textContent = `対象 ${rows.length}件`;
-  todayTaskBody.innerHTML = "";
-  todayTaskEmpty.hidden = rows.length > 0;
-  todayTaskListWrap.hidden = rows.length === 0;
-  if (!rows.length) return;
-  rows
-    .sort((a, b) => toSortTimestamp(a.date) - toSortTimestamp(b.date))
-    .forEach((row) => {
-      const tr = document.createElement("tr");
-      tr.className = row.urgencyClass;
-      tr.innerHTML = `
-        <td>${escapeHtml(row.type)}</td>
-        <td>${escapeHtml(row.customerName)}</td>
-        <td>${escapeHtml(row.caseName)}</td>
-        <td>${escapeHtml(row.taskTitle || "-")}</td>
-        <td>${row.dueDateLabel || formatDate(row.date)}</td>
-        <td>${escapeHtml(row.subInfo || "-")}</td>
-        <td><button type="button" class="secondary-btn" data-task-target="${row.target}" data-task-id="${row.id}">編集</button></td>
-        <td>${row.actionButtonHtml || (row.showReminderButton ? `<button type="button" class="secondary-btn record-reminder-btn" data-sale-id="${row.id}">督促記録</button>` : "-")}</td>
-      `;
-      todayTaskBody.appendChild(tr);
+  renderTodayTasks();
+}
+
+function buildIntegratedAlerts() {
+  const todayTs = getTodayTimestamp();
+  const threeDaysLater = todayTs + (3 * 86400000);
+  const priorityOrder = { high: 0, medium: 1, low: 2 };
+  const alerts = [];
+  const caseMap = new Map((Array.isArray(state.cases) ? state.cases : []).map((entry) => [entry.id, entry]));
+  const clientMap = new Map((Array.isArray(state.clients) ? state.clients : []).map((entry) => [entry.id, entry]));
+
+  (Array.isArray(state.caseTasks) ? state.caseTasks : []).forEach((task) => {
+    const dueTs = toDateOnlyTimestamp(task?.dueDate);
+    if (task?.status === "完了" || !Number.isFinite(dueTs) || dueTs > todayTs) return;
+    const linkedCase = task?.caseId ? caseMap.get(task.caseId) : null;
+    const linkedClient = linkedCase?.clientId ? clientMap.get(linkedCase.clientId) : null;
+    alerts.push({
+      id: task?.id,
+      type: "task",
+      typeLabel: "案件タスク",
+      priority: "high",
+      title: task?.taskTitle || "未設定",
+      clientName: linkedClient?.name || linkedCase?.customerName || "顧客不明",
+      caseName: linkedCase?.caseName || "案件なし",
+      dueDate: task?.dueDate || "",
+      dateSort: dueTs,
+      dateLabel: task?.dueDate ? formatDate(task.dueDate) : "未設定",
+      subInfo: dueTs < todayTs ? "期限切れ" : "本日期限",
+      target: "case-task",
+      actionButtonHtml: `<button type="button" class="secondary-btn" data-task-target="case-task-complete" data-task-id="${task?.id || ""}">完了</button>`,
+    });
+  });
+
+  (Array.isArray(state.sales) ? state.sales : []).forEach((sale) => {
+    const dueTs = toDateOnlyTimestamp(sale?.dueDate);
+    const isUnpaid = sale?.paymentStatus !== "入金済";
+    if (!isUnpaid || !Number.isFinite(dueTs)) return;
+    const linkedCase = sale?.caseId ? caseMap.get(sale.caseId) : null;
+    const linkedClient = linkedCase?.clientId ? clientMap.get(linkedCase.clientId) : null;
+    if (dueTs <= todayTs) {
+      alerts.push({
+        id: sale?.id,
+        type: "payment",
+        typeLabel: "未入金",
+        priority: "high",
+        title: "未入金",
+        amount: getRemainingAmount(sale),
+        clientName: linkedClient?.name || linkedCase?.customerName || "顧客不明",
+        caseName: linkedCase?.caseName || "案件なし",
+        dueDate: sale?.dueDate || "",
+        dateSort: dueTs,
+        dateLabel: sale?.dueDate ? formatDate(sale.dueDate) : "未設定",
+        subInfo: `残額: ${formatCurrency(getRemainingAmount(sale))}`,
+        target: "sale",
+        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
+      });
+    }
+    const reminderTs = toDateOnlyTimestamp(sale?.lastReminderDate);
+    const reminderElapsed = Number.isFinite(reminderTs) && ((todayTs - reminderTs) / 86400000 >= 7);
+    if (reminderElapsed) {
+      alerts.push({
+        id: sale?.id,
+        type: "reminder",
+        typeLabel: "督促",
+        priority: "medium",
+        title: "督促必要",
+        clientName: linkedClient?.name || linkedCase?.customerName || "顧客不明",
+        caseName: linkedCase?.caseName || "案件なし",
+        lastReminderDate: sale?.lastReminderDate || "",
+        dateSort: reminderTs,
+        dateLabel: sale?.lastReminderDate ? `最終督促: ${formatDate(sale.lastReminderDate)}` : "最終督促日なし",
+        subInfo: `残額: ${formatCurrency(getRemainingAmount(sale))}`,
+        target: "sale",
+        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
+      });
+    }
+  });
+
+  (Array.isArray(state.cases) ? state.cases : []).forEach((caseRow) => {
+    if (getStatusCategory(caseRow?.status) === "完了") return;
+    const dueTs = toDateOnlyTimestamp(caseRow?.dueDate);
+    if (!Number.isFinite(dueTs) || dueTs > threeDaysLater) return;
+    const linkedClient = caseRow?.clientId ? clientMap.get(caseRow.clientId) : null;
+    alerts.push({
+      id: caseRow?.id,
+      type: "deadline",
+      typeLabel: "期限",
+      priority: "medium",
+      title: "期限間近",
+      clientName: linkedClient?.name || caseRow?.customerName || "顧客不明",
+      caseName: caseRow?.caseName || "案件なし",
+      dueDate: caseRow?.dueDate || "",
+      dateSort: dueTs,
+      dateLabel: caseRow?.dueDate ? formatDate(caseRow.dueDate) : "未設定",
+      subInfo: formatRemainingDays(Math.floor((dueTs - todayTs) / 86400000)),
+      target: "case",
+    });
+  });
+
+  return alerts
+    .slice()
+    .sort((a, b) => {
+      const priorityDiff = (priorityOrder[a.priority] ?? 99) - (priorityOrder[b.priority] ?? 99);
+      if (priorityDiff !== 0) return priorityDiff;
+      return (a.dateSort || 0) - (b.dateSort || 0);
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -328,6 +328,11 @@ button:hover { background: var(--primary-dark); }
   padding: 0.8rem;
 }
 
+.today-task-card.has-alert {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.12);
+}
+
 .pending-estimates-card {
   border: 1px solid #fde68a;
   background: #fffbeb;
@@ -378,6 +383,18 @@ button:hover { background: var(--primary-dark); }
 }
 
 .task-reminder-upcoming {
+  background: #fef9c3;
+}
+
+.task-priority-high td {
+  background: #fee2e2;
+}
+
+.task-priority-medium td {
+  background: #ffedd5;
+}
+
+.task-priority-low td {
   background: #fef9c3;
 }
 


### PR DESCRIPTION
### Motivation
- ダッシュボードの「今日やること」を案件タスク・未入金・督促・期限を単一のエンジンで抽出・管理できるようにして、優先度順で表示するため。

### Description
- `state.alerts` を追加して統合アラートの結果を保持するようにしました。
- `renderTodayTasks` を safeRender 内で全面書き換えし、`buildIntegratedAlerts` を導入して case_tasks / sales / cases / clients から①案件タスク（未完了かつ期限<=今日）②未入金（入金済以外かつ期限<=今日）③督促（最終督促から7日以上）④期限接近（案件期限<=3日）を生成、priority（high/medium/low）と日付でソートして表示します。
- 既存の操作導線は維持するため行要素に `data-task-target` / `data-task-id` を出力し、`handleTodayTaskAction` に `record-reminder-btn` の分岐を追加して「督促記録」ボタンが機能するようにしました。
- UI を優先度別に色分け（high=赤 / medium=オレンジ / low=黄）し、`today-task-card.has-alert` の強調スタイルを追加しました。欠損データ時はフォールバック表示（`案件なし` / `顧客不明`）を行います。 

### Testing
- `node --check app.js` を実行し構文エラーがないことを確認しました（成功）。
- 変更はレンダリング周りとイベントハンドラの拡張のみで既存の編集導線に影響しないよう実装しており、静的構文チェックは通過しています（自動 UI スナップショットは未実施）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef7d8058083339d979e9d797c401a)