### PR TITLE
Refactor button dispatch to explicit data-action handlers across CRUD operations

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,7 +108,45 @@ const CLICK_ACTION_HANDLERS = {
   export_backup_json: handleExportBackupJson,
   add_estimate_item_row: () => addEstimateItemRow(),
   remove_estimate_item_row: handleEstimateItemsClick,
-  global_list_action: handleGlobalListAction,
+  status_summary_filter: handleStatusSummaryClick,
+  deadline_alert_click: handleDeadlineAlertClick,
+  alert_task_edit: handleTodayTaskAction,
+  edit_client: handleClientListAction,
+  delete_client: handleClientListAction,
+  edit_case: handleCaseListAction,
+  delete_case: handleCaseListAction,
+  print_case_invoice: handleCaseListAction,
+  export_case_invoice_excel: handleCaseListAction,
+  edit_work_template: handleWorkTemplateListAction,
+  delete_work_template: handleWorkTemplateListAction,
+  edit_estimate: handleEstimateListAction,
+  delete_estimate: handleEstimateListAction,
+  create_case_from_estimate: handleEstimateListAction,
+  create_invoice_from_estimate: handleEstimateListAction,
+  print_estimate: handleEstimateListAction,
+  print_invoice_from_estimate: handleEstimateListAction,
+  export_estimate_excel: handleEstimateListAction,
+  export_invoice_excel_from_estimate: handleEstimateListAction,
+  edit_sale: handleSalesListAction,
+  delete_sale: handleSalesListAction,
+  record_payment: handleSalesListAction,
+  delete_payment: handleSalesListAction,
+  record_reminder: handleSalesListAction,
+  edit_expense: handleExpensesListAction,
+  delete_expense: handleExpensesListAction,
+  edit_fixed_expense: handleFixedExpensesListAction,
+  toggle_fixed_expense: handleFixedExpensesListAction,
+  delete_fixed_expense: handleFixedExpensesListAction,
+  edit_daily_report: handleDailyReportsListAction,
+  delete_daily_report: handleDailyReportsListAction,
+  edit_case_task: handleCaseTaskListAction,
+  complete_case_task: handleCaseTaskListAction,
+  delete_case_task: handleCaseTaskListAction,
+  register_sale: handleBillingLeakAlertAction,
+  edit_pending_estimate: handlePendingEstimateAction,
+  edit_case_document: handleCaseDocumentsListAction,
+  delete_case_document: handleCaseDocumentsListAction,
+  select_integrity_check: handleDataIntegrityAction,
 };
 
 const authView = document.getElementById("auth-view");
@@ -527,7 +565,11 @@ function dispatchAction(event) {
   if (!action) return;
   event.preventDefault();
   const handler = CLICK_ACTION_HANDLERS[action];
-  if (typeof handler !== "function") return;
+  if (typeof handler !== "function") {
+    console.error("未登録data-action", action, button);
+    showAppMessage(`未登録の操作です: ${action}`, true);
+    return;
+  }
   Promise.resolve(handler(event, button)).catch((error) => {
     console.error("click action failed", action, error);
     showAppMessage(`操作に失敗しました: ${action}`, true);
@@ -540,17 +582,7 @@ function hydrateActionButtons(root = document) {
 }
 
 function ensureButtonDataAction(button) {
-  if (!(button instanceof HTMLButtonElement) || button.dataset.action) return;
-  const action = inferLegacyClickAction(button);
-  if (action) button.dataset.action = action;
-}
-
-function inferLegacyClickAction(button) {
-  if (button.closest("#estimate-items") && button.dataset.listAction === "remove_estimate_item_row") return "remove_estimate_item_row";
-  if (button.closest("#clients-list, #case-list, #case-tasks-body, #case-documents-body, #work-templates-list, #estimate-list, #expenses-list, #fixed-expenses-list, #daily-reports-body, #sales-list-body, #unpaid-list-body, #unpaid-alert-body, #billing-leak-alert-body, #status-summary-list, #deadline-alert-summary, #deadline-alert-body, #next-action-alert-body, #today-task-body, #document-alert-body, #pending-estimates-body, #data-integrity-list")) {
-    return "global_list_action";
-  }
-  return "";
+  if (!(button instanceof HTMLButtonElement)) return;
 }
 
 function handleAggregationChange(event) {
@@ -1424,7 +1456,7 @@ async function handleCaseListAction(event) {
   const listAction = btn.dataset.listAction;
   const item = btn.closest("[data-id]");
   if (!item || !currentUser) return;
-  const id = item.dataset.id;
+  const id = item?.dataset.id || btn.dataset.caseId || btn.dataset.taskId;
   if (!id) {
     showAppMessage("対象データIDを取得できませんでした。", true);
     return;
@@ -1678,9 +1710,9 @@ async function handleSalesListAction(event) {
   const btn = event.target.closest("button");
   if (!(btn instanceof HTMLButtonElement)) return;
   const listAction = btn.dataset.listAction;
+  if (!currentUser) return;
   const item = btn.closest("[data-id]");
-  if (!item || !currentUser) return;
-  const id = item.dataset.id;
+  const id = item?.dataset.id || btn.dataset.saleId || btn.closest("[data-sale-id]")?.dataset.saleId;
   if (!id) {
     showAppMessage("対象データIDを取得できませんでした。", true);
     return;
@@ -1695,119 +1727,20 @@ async function handleSalesListAction(event) {
     await deleteSale(id);
     return;
   }
+  if (listAction === "record_payment") {
+    await handleRecordPayment(id);
+    return;
+  }
+  if (listAction === "record_reminder") {
+    await handleRecordReminder(id);
+    return;
+  }
   if (listAction === "delete_payment") {
     const paymentId = btn.dataset.paymentId;
     if (!paymentId) return;
     await deletePayment(paymentId);
   }
 
-}
-
-async function handleGlobalListAction(event) {
-  const button = event.target.closest("button");
-  if (!(button instanceof HTMLButtonElement)) return;
-
-  if (button.closest("#status-summary-list")) {
-    handleStatusSummaryClick(event);
-    return;
-  }
-  if (button.closest("#deadline-alert-summary") || button.closest("#deadline-alert-body")) {
-    handleDeadlineAlertClick(event);
-    return;
-  }
-  if (button.closest("#next-action-alert-body")) {
-    handleNextActionAlertClick(event);
-    return;
-  }
-  if (button.closest("#today-task-body")) {
-    handleTodayTaskAction(event);
-    return;
-  }
-  if (button.closest("#document-alert-body")) {
-    handleDocumentAlertAction(event);
-    return;
-  }
-  if (button.closest("#pending-estimates-body")) {
-    handlePendingEstimateAction(event);
-    return;
-  }
-  if (button.closest("#data-integrity-list")) {
-    handleDataIntegrityAction(event);
-    return;
-  }
-  if (button.closest("#clients-list")) {
-    await handleClientListAction(event);
-    return;
-  }
-  if (button.closest("#case-list")) {
-    await handleCaseListAction(event);
-    return;
-  }
-  if (button.closest("#case-tasks-body")) {
-    handleCaseTaskListAction(event);
-    return;
-  }
-  if (button.closest("#case-documents-body")) {
-    await handleCaseDocumentsListAction(event);
-    return;
-  }
-  if (button.closest("#work-templates-list")) {
-    await handleWorkTemplateListAction(event);
-    return;
-  }
-  if (button.closest("#estimate-list")) {
-    await handleEstimateListAction(event);
-    return;
-  }
-  if (button.closest("#expenses-list")) {
-    await handleExpensesListAction(event);
-    return;
-  }
-  if (button.closest("#fixed-expenses-list")) {
-    await handleFixedExpensesListAction(event);
-    return;
-  }
-  if (button.closest("#daily-reports-body")) {
-    await handleDailyReportsListAction(event);
-    return;
-  }
-  if (button.closest("#sales-list-body")) {
-    await handleSalesListAction(event);
-    return;
-  }
-  if (button.closest("#unpaid-list-body") || button.closest("#unpaid-alert-body")) {
-    handleUnpaidListAction(event);
-    return;
-  }
-  if (button.closest("#billing-leak-alert-body")) {
-    handleBillingLeakAlertAction(event);
-    return;
-  }
-
-  if (button.dataset.listAction === "delete_sale") {
-    const saleId = button.dataset.saleId || button.closest("[data-id]")?.dataset.id;
-    console.log("DELETE SALE CLICKED", saleId);
-    if (!saleId) return;
-    await deleteSale(saleId);
-    return;
-  }
-  if (button.dataset.listAction === "edit_sale") {
-    const saleId = button.dataset.saleId || button.closest("[data-id]")?.dataset.id;
-    if (!saleId) return;
-    await editSale(saleId);
-    return;
-  }
-  if (button.dataset.listAction === "record_payment") {
-    const saleId = button.dataset.saleId || button.closest("[data-sale-id]")?.dataset.saleId || button.closest("[data-id]")?.dataset.id;
-    if (!saleId) return;
-    await handleRecordPayment(saleId);
-    return;
-  }
-  if (button.dataset.listAction === "record_reminder") {
-    const saleId = button.dataset.saleId || button.closest("[data-sale-id]")?.dataset.saleId || button.closest("[data-id]")?.dataset.id;
-    if (!saleId) return;
-    await handleRecordReminder(saleId);
-  }
 }
 
 async function handleExpensesListAction(event) {
@@ -3381,7 +3314,7 @@ function renderTodayTasks() {
         <td>${escapeHtml(alert.title || "-")}</td>
         <td>${escapeHtml(alert.dateLabel || "-")}</td>
         <td>${escapeHtml(alert.subInfo || "-")}</td>
-        <td><button type="button" class="secondary-btn" data-action="global_list_action" data-task-target="${alert.target || "case"}" data-task-id="${alert.id || ""}">編集</button></td>
+        <td><button type="button" class="secondary-btn" data-action="alert_task_edit" data-task-target="${alert.target || "case"}" data-task-id="${alert.id || ""}">編集</button></td>
         <td>${alert.actionButtonHtml || "-"}</td>
       `;
       todayTaskBody.appendChild(tr);
@@ -3414,7 +3347,7 @@ function renderDocumentAlerts() {
       <td>${escapeHtml(entry.caseName)}</td>
       <td>${escapeHtml(entry.documentName)}</td>
       <td>${escapeHtml(entry.subInfo)}</td>
-      <td><button type="button" class="secondary-btn" data-action="global_list_action" data-list-action="edit_case_document" data-case-document-id="${entry.id}">編集</button></td>
+      <td><button type="button" class="secondary-btn" data-action="edit_case_document" data-list-action="edit_case_document" data-case-document-id="${entry.id}">編集</button></td>
     `;
     documentAlertBody.appendChild(tr);
   });
@@ -3462,7 +3395,7 @@ function renderPendingEstimates() {
       <td>${escapeHtml(entry.estimateTitle || "未設定")}</td>
       <td>${formatDate(entry.baseDate)}</td>
       <td>${entry.elapsedDays}日</td>
-      <td><button type="button" class="secondary-btn edit-pending-estimate-btn" data-action="global_list_action" data-list-action="edit_pending_estimate" data-estimate-id="${entry.id}">編集</button></td>
+      <td><button type="button" class="secondary-btn edit-pending-estimate-btn" data-action="edit_pending_estimate" data-list-action="edit_pending_estimate" data-estimate-id="${entry.id}">編集</button></td>
     `;
     pendingEstimatesBody.appendChild(tr);
   });
@@ -3484,6 +3417,7 @@ function renderDataIntegrityCheck() {
     button.type = "button";
     button.className = `data-integrity-item severity-${entry.severity}`;
     button.dataset.checkKey = entry.key;
+    button.dataset.action = "select_integrity_check";
     button.innerHTML = `<span>${escapeHtml(entry.label)}</span><span class="count">${entry.items.length}件</span>`;
     dataIntegrityList.appendChild(button);
   });
@@ -3755,7 +3689,7 @@ function buildIntegratedAlerts() {
       dateLabel: task?.dueDate ? formatDate(task.dueDate) : "未設定",
       subInfo: dueTs < todayTs ? "期限切れ" : "本日期限",
       target: "case-task",
-      actionButtonHtml: `<button type="button" class="secondary-btn" data-action="global_list_action" data-list-action="complete_case_task" data-task-target="case-task-complete" data-task-id="${task?.id || ""}">完了</button>`,
+      actionButtonHtml: `<button type="button" class="secondary-btn" data-action="complete_case_task" data-list-action="complete_case_task" data-task-target="case-task-complete" data-task-id="${task?.id || ""}">完了</button>`,
     });
   });
 
@@ -3780,7 +3714,7 @@ function buildIntegratedAlerts() {
         dateLabel: sale?.dueDate ? formatDate(sale.dueDate) : "未設定",
         subInfo: `残額: ${formatCurrency(getRemainingAmount(sale))}`,
         target: "sale",
-        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="global_list_action" data-list-action="record_reminder" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
+        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="record_reminder" data-list-action="record_reminder" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
       });
     }
     const reminderTs = toDateOnlyTimestamp(sale?.lastReminderDate);
@@ -3799,7 +3733,7 @@ function buildIntegratedAlerts() {
         dateLabel: sale?.lastReminderDate ? `最終督促: ${formatDate(sale.lastReminderDate)}` : "最終督促日なし",
         subInfo: `残額: ${formatCurrency(getRemainingAmount(sale))}`,
         target: "sale",
-        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="global_list_action" data-list-action="record_reminder" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
+        actionButtonHtml: isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="record_reminder" data-list-action="record_reminder" data-sale-id="${sale?.id || ""}">督促記録</button>` : "-",
       });
     }
   });
@@ -3927,7 +3861,7 @@ function buildTodayTasks() {
       dueDateLabel: formatDate(entry.dueDate),
       subInfo: entry.status,
       urgencyClass: getCaseTaskUrgencyClass(entry),
-      actionButtonHtml: `<button type="button" class="secondary-btn" data-action="global_list_action" data-list-action="complete_case_task" data-task-target="case-task-complete" data-task-id="${entry.id}">完了</button>`,
+      actionButtonHtml: `<button type="button" class="secondary-btn" data-action="complete_case_task" data-list-action="complete_case_task" data-task-target="case-task-complete" data-task-id="${entry.id}">完了</button>`,
     });
   });
   getBillingLeakCandidates().forEach((entry) => {
@@ -3977,6 +3911,7 @@ function renderDeadlineAlertCard() {
     button.type = "button";
     button.className = `deadline-alert-chip ${entry.key}`;
     button.dataset.deadlineFilter = entry.key;
+    button.dataset.action = "deadline_alert_click";
     button.textContent = `${entry.label}: ${entry.count}件`;
     button.disabled = entry.count === 0;
     deadlineAlertSummary.appendChild(button);
@@ -4007,8 +3942,8 @@ function renderDeadlineAlertCard() {
         <td>${escapeHtml(entry.label || entry.status)}</td>
         <td>${formatRemainingDays(entry.remainingDays)}</td>
         <td>${entry.alertType === "case-task"
-    ? `<button type="button" class="secondary-btn edit-case-task-btn" data-action="global_list_action" data-list-action="edit_case_task" data-task-id="${entry.id}">編集</button>`
-    : `<button type="button" class="secondary-btn" data-action="global_list_action" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button>`}</td>
+    ? `<button type="button" class="secondary-btn edit-case-task-btn" data-action="edit_case_task" data-list-action="edit_case_task" data-task-id="${entry.id}">編集</button>`
+    : `<button type="button" class="secondary-btn" data-action="edit_case" data-list-action="edit_case" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button>`}</td>
       `;
       deadlineAlertBody.appendChild(tr);
     });
@@ -4103,7 +4038,7 @@ function renderNextActionAlertCard() {
         <td>${escapeHtml(entry.caseName)}</td>
         <td>${formatDate(entry.nextActionDate)}</td>
         <td>${escapeHtml(entry.nextAction || "未設定")}</td>
-        <td><button type="button" class="secondary-btn" data-action="global_list_action" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button></td>
+        <td><button type="button" class="secondary-btn" data-action="edit_case" data-list-action="edit_case" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button></td>
       `;
       nextActionAlertBody.appendChild(tr);
     });
@@ -4147,6 +4082,7 @@ function renderStatusSummaryCard() {
     button.type = "button";
     button.className = `status-filter-btn status-${toStatusClassKey(statusKey)}`.trim();
     button.dataset.statusFilter = statusKey;
+    button.dataset.action = "status_summary_filter";
     button.setAttribute("aria-pressed", String(state.caseStatusFilter === statusKey));
     button.innerHTML = `<span>${statusKey}</span><strong>${count}件</strong>`;
     statusSummaryList.appendChild(button);
@@ -4209,9 +4145,9 @@ function renderUnpaidAlert(filter = {}) {
         <td>${escapeHtml(sale.reminderMemo || "-")}</td>
         <td>${paymentHistory}</td>
         <td>
-          <button type="button" class="secondary-btn edit-sale-btn" data-action="global_list_action" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button>
-          <button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="global_list_action" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button>
-          ${isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="global_list_action" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : ""}
+          <button type="button" class="secondary-btn edit-sale-btn" data-action="edit_sale" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button>
+          <button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="record_payment" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button>
+          ${isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="record_reminder" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : ""}
         </td>
       `;
       safeAddClass(tr, getSaleRowClass(sale));
@@ -4245,7 +4181,7 @@ function renderUnpaidList() {
       <td>${escapeHtml(sale.reminderMethod || "-")}</td>
       <td>${escapeHtml(sale.reminderMemo || "-")}</td>
       <td>${paymentHistory}</td>
-      <td><button type="button" class="secondary-btn edit-sale-btn" data-action="global_list_action" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button> <button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="global_list_action" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button> ${isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="global_list_action" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : ""}</td>
+      <td><button type="button" class="secondary-btn edit-sale-btn" data-action="edit_sale" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button> <button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="record_payment" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button> ${isReminderRecordableSale(sale) ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="record_reminder" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : ""}</td>
     `;
     safeAddClass(tr, getSaleRowClass(sale));
     unpaidListBody.appendChild(tr);
@@ -4579,7 +4515,7 @@ function renderBillingLeakAlert() {
       <td>${escapeHtml(entry.caseName)}</td>
       <td>${formatCurrency(entry.estimateAmount)}</td>
       <td>${escapeHtml(entry.status || "完了")}</td>
-      <td><button type="button" class="secondary-btn register-sale-btn" data-action="global_list_action" data-list-action="register_sale" data-case-id="${entry.id}">売上登録</button></td>
+      <td><button type="button" class="secondary-btn register-sale-btn" data-action="register_sale" data-list-action="register_sale" data-case-id="${entry.id}">売上登録</button></td>
     `;
     billingLeakAlertBody.appendChild(tr);
   });
@@ -4608,7 +4544,7 @@ function renderPaymentHistoryInline(saleId) {
   const payments = getSalePayments(saleId);
   if (!payments.length) return "-";
   return payments.map((entry) => (
-    `<div class="payment-history-row">${formatDate(entry.paymentDate)} / ${formatCurrency(entry.amount)} / ${escapeHtml(entry.method || "その他")} ${entry.memo ? `/ ${escapeHtml(entry.memo)}` : ""} <button type="button" class="danger-btn delete-payment-btn" data-action="global_list_action" data-list-action="delete_payment" data-sale-id="${saleId}" data-payment-id="${entry.id}">削除</button></div>`
+    `<div class="payment-history-row">${formatDate(entry.paymentDate)} / ${formatCurrency(entry.amount)} / ${escapeHtml(entry.method || "その他")} ${entry.memo ? `/ ${escapeHtml(entry.memo)}` : ""} <button type="button" class="danger-btn delete-payment-btn" data-action="delete_payment" data-list-action="delete_payment" data-sale-id="${saleId}" data-payment-id="${entry.id}">削除</button></div>`
   )).join("");
 }
 
@@ -4667,9 +4603,9 @@ function renderCaseTasksTable() {
       <td>${formatDate(entry.dueDate)}</td>
       <td>${escapeHtml(entry.status)}</td>
       <td>${formatDate(entry.completedAt)}</td>
-      <td><button type="button" class="secondary-btn edit-case-task-btn" data-action="global_list_action" data-list-action="edit_case_task" data-task-id="${entry.id}">編集</button></td>
-      <td>${entry.status !== "完了" ? `<button type="button" class="secondary-btn complete-case-task-btn" data-action="global_list_action" data-list-action="complete_case_task" data-task-id="${entry.id}">完了</button>` : "-"}</td>
-      <td><button type="button" class="danger-btn delete-case-task-btn" data-action="global_list_action" data-list-action="delete_case_task" data-task-id="${entry.id}">削除</button></td>
+      <td><button type="button" class="secondary-btn edit-case-task-btn" data-action="edit_case_task" data-list-action="edit_case_task" data-task-id="${entry.id}">編集</button></td>
+      <td>${entry.status !== "完了" ? `<button type="button" class="secondary-btn complete-case-task-btn" data-action="complete_case_task" data-list-action="complete_case_task" data-task-id="${entry.id}">完了</button>` : "-"}</td>
+      <td><button type="button" class="danger-btn delete-case-task-btn" data-action="delete_case_task" data-list-action="delete_case_task" data-task-id="${entry.id}">削除</button></td>
     `;
     caseTasksBody.appendChild(tr);
   });
@@ -4698,8 +4634,8 @@ function renderCaseDocuments() {
       <td>${formatDate(entry.checkedDate)}</td>
       <td>${escapeHtml(truncateText(entry.memo || "", 80) || "-")}</td>
       <td>${entry.fileUrl ? `<a href="${escapeHtml(entry.fileUrl)}" target="_blank" rel="noopener noreferrer">開く</a>` : "-"}</td>
-      <td><button type="button" class="secondary-btn edit-btn" data-action="global_list_action" data-list-action="edit_case_document" data-case-document-id="${entry.id}">編集</button></td>
-      <td><button type="button" class="danger-btn delete-btn" data-action="global_list_action" data-list-action="delete_case_document" data-case-document-id="${entry.id}">削除</button></td>
+      <td><button type="button" class="secondary-btn edit-btn" data-action="edit_case_document" data-list-action="edit_case_document" data-case-document-id="${entry.id}">編集</button></td>
+      <td><button type="button" class="danger-btn delete-btn" data-action="delete_case_document" data-list-action="delete_case_document" data-case-document-id="${entry.id}">削除</button></td>
     `;
     caseDocumentsBody.appendChild(tr);
   });
@@ -4795,7 +4731,7 @@ function renderClients() {
         <p class="meta">紹介元: ${escapeHtml(client.referralSource || "未設定")} / メモ: ${escapeHtml(truncateText(client.memo || "未設定", 60))}</p>
         <p class="meta">最終対応日: ${lastInteraction ? formatDate(lastInteraction) : "未設定"} / 次回対応日: ${nextInteraction ? formatDate(nextInteraction) : "未設定"} / 対応履歴件数: ${related.length}件</p>
       </div>
-      <div class="row-actions"><button type="button" class="secondary-btn edit-client-btn" data-action="global_list_action" data-list-action="edit_client">編集</button><button type="button" class="danger-btn delete-client-btn" data-action="global_list_action" data-list-action="delete_client">削除</button></div>
+      <div class="row-actions"><button type="button" class="secondary-btn edit-client-btn" data-action="edit_client" data-list-action="edit_client">編集</button><button type="button" class="danger-btn delete-client-btn" data-action="delete_client" data-list-action="delete_client">削除</button></div>
     `;
     clientsList.appendChild(li);
   });
@@ -4871,8 +4807,8 @@ function renderDailyReports() {
           <p class="daily-report-card-case">対応種別: ${escapeHtml(entry.interactionType || "作業")}</p>
         </div>
         <div class="daily-report-card-actions">
-          <button type="button" class="secondary-btn edit-daily-report-btn" data-action="global_list_action" data-list-action="edit_daily_report">編集</button>
-          <button type="button" class="danger-btn delete-daily-report-btn" data-action="global_list_action" data-list-action="delete_daily_report">削除</button>
+          <button type="button" class="secondary-btn edit-daily-report-btn" data-action="edit_daily_report" data-list-action="edit_daily_report">編集</button>
+          <button type="button" class="danger-btn delete-daily-report-btn" data-action="delete_daily_report" data-list-action="delete_daily_report">削除</button>
         </div>
       </header>
       <dl class="daily-report-card-meta">
@@ -5209,14 +5145,14 @@ function renderEstimates() {
         </div>
       </div>
       <div class="row-actions estimate-card-actions">
-        <button type="button" class="secondary-btn estimate-edit-btn" data-action="global_list_action" data-list-action="edit_estimate">編集</button>
-        <button type="button" class="danger-btn estimate-delete-btn" data-action="global_list_action" data-list-action="delete_estimate">削除</button>
-        <button type="button" class="secondary-btn create-case-btn" data-action="global_list_action" data-list-action="create_case_from_estimate" ${isCaseCreated ? "disabled" : ""}>${isCaseCreated ? "案件化済み" : "案件化"}</button>
-        <button type="button" class="secondary-btn estimate-estimate-print-btn" data-action="global_list_action" data-list-action="print_estimate">見積書出力</button>
-        <button type="button" class="secondary-btn estimate-print-btn" data-action="global_list_action" data-list-action="print_invoice_from_estimate">請求書出力</button>
-        <button type="button" class="secondary-btn estimate-estimate-xlsx-btn" data-action="global_list_action" data-list-action="export_estimate_excel">見積Excel</button>
-        <button type="button" class="secondary-btn estimate-xlsx-btn" data-action="global_list_action" data-list-action="export_invoice_excel_from_estimate">請求Excel</button>
-        <button type="button" class="secondary-btn create-invoice-btn" data-action="global_list_action" data-list-action="create_invoice_from_estimate" ${hasCreatedInvoice ? "disabled" : ""}>${hasCreatedInvoice ? "請求済み" : "請求作成"}</button>
+        <button type="button" class="secondary-btn estimate-edit-btn" data-action="edit_estimate" data-list-action="edit_estimate">編集</button>
+        <button type="button" class="danger-btn estimate-delete-btn" data-action="delete_estimate" data-list-action="delete_estimate">削除</button>
+        <button type="button" class="secondary-btn create-case-btn" data-action="create_case_from_estimate" data-list-action="create_case_from_estimate" ${isCaseCreated ? "disabled" : ""}>${isCaseCreated ? "案件化済み" : "案件化"}</button>
+        <button type="button" class="secondary-btn estimate-estimate-print-btn" data-action="print_estimate" data-list-action="print_estimate">見積書出力</button>
+        <button type="button" class="secondary-btn estimate-print-btn" data-action="print_invoice_from_estimate" data-list-action="print_invoice_from_estimate">請求書出力</button>
+        <button type="button" class="secondary-btn estimate-estimate-xlsx-btn" data-action="export_estimate_excel" data-list-action="export_estimate_excel">見積Excel</button>
+        <button type="button" class="secondary-btn estimate-xlsx-btn" data-action="export_invoice_excel_from_estimate" data-list-action="export_invoice_excel_from_estimate">請求Excel</button>
+        <button type="button" class="secondary-btn create-invoice-btn" data-action="create_invoice_from_estimate" data-list-action="create_invoice_from_estimate" ${hasCreatedInvoice ? "disabled" : ""}>${hasCreatedInvoice ? "請求済み" : "請求作成"}</button>
       </div>
     `;
     estimateList.appendChild(li);
@@ -5542,7 +5478,7 @@ function renderCases() {
       const printBtn = document.createElement("button");
       printBtn.type = "button";
       printBtn.className = "secondary-btn case-print-btn";
-      printBtn.dataset.action = "global_list_action";
+      printBtn.dataset.action = "print_case_invoice";
       printBtn.dataset.listAction = "print_case_invoice";
       printBtn.textContent = "請求書出力";
       rowActions.appendChild(printBtn);
@@ -5551,7 +5487,7 @@ function renderCases() {
       const xlsxBtn = document.createElement("button");
       xlsxBtn.type = "button";
       xlsxBtn.className = "secondary-btn case-xlsx-btn";
-      xlsxBtn.dataset.action = "global_list_action";
+      xlsxBtn.dataset.action = "export_case_invoice_excel";
       xlsxBtn.dataset.listAction = "export_case_invoice_excel";
       xlsxBtn.textContent = "請求Excel";
       rowActions.appendChild(xlsxBtn);
@@ -5707,10 +5643,10 @@ function renderSales() {
         <td>${escapeHtml(reminderMethod)}</td>
         <td>${escapeHtml(reminderMemo)}</td>
         <td>${paymentHistory}</td>
-        <td>${canRecordReminder ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="global_list_action" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : "-"}</td>
-        <td><button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="global_list_action" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button></td>
-        <td><button type="button" class="edit-sale-btn secondary-btn" data-action="global_list_action" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button></td>
-        <td><button type="button" class="danger-btn delete-btn delete-sale-btn" data-action="global_list_action" data-list-action="delete_sale" data-sale-id="${sale.id}">削除</button></td>
+        <td>${canRecordReminder ? `<button type="button" class="secondary-btn record-reminder-btn" data-action="record_reminder" data-list-action="record_reminder" data-sale-id="${sale.id}">督促記録</button>` : "-"}</td>
+        <td><button type="button" class="secondary-btn register-payment-btn record-payment-btn" data-action="record_payment" data-list-action="record_payment" data-sale-id="${sale.id}">入金登録</button></td>
+        <td><button type="button" class="edit-sale-btn secondary-btn" data-action="edit_sale" data-list-action="edit_sale" data-sale-id="${sale.id}">編集</button></td>
+        <td><button type="button" class="danger-btn delete-btn delete-sale-btn" data-action="delete_sale" data-list-action="delete_sale" data-sale-id="${sale.id}">削除</button></td>
       `;
       salesListBody.appendChild(tr);
     } catch (error) {

--- a/index.html
+++ b/index.html
@@ -1195,7 +1195,7 @@
           <p class="meta case-work-meta"></p>
           <p class="meta profit-meta"></p>
         </div>
-        <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
+        <div class="row-actions"><button type="button" class="edit-btn secondary-btn" data-action="edit_case" data-list-action="edit_case">編集</button><button type="button" class="danger-btn delete-btn" data-action="delete_case" data-list-action="delete_case">削除</button></div>
       </li>
     </template>
     <template id="expense-item-template">
@@ -1204,7 +1204,7 @@
           <p class="title"></p>
           <p class="meta"></p>
         </div>
-        <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
+        <div class="row-actions"><button type="button" class="edit-btn secondary-btn" data-action="edit_expense" data-list-action="edit_expense">編集</button><button type="button" class="danger-btn delete-btn" data-action="delete_expense" data-list-action="delete_expense">削除</button></div>
       </li>
     </template>
 
@@ -1215,9 +1215,9 @@
           <p class="meta"></p>
         </div>
         <div class="row-actions">
-          <button type="button" class="toggle-btn secondary-btn">有効/無効</button>
-          <button type="button" class="edit-btn secondary-btn">編集</button>
-          <button type="button" class="danger-btn delete-btn">削除</button>
+          <button type="button" class="toggle-btn secondary-btn" data-action="toggle_fixed_expense" data-list-action="toggle_fixed_expense">有効/無効</button>
+          <button type="button" class="edit-btn secondary-btn" data-action="edit_fixed_expense" data-list-action="edit_fixed_expense">編集</button>
+          <button type="button" class="danger-btn delete-btn" data-action="delete_fixed_expense" data-list-action="delete_fixed_expense">削除</button>
         </div>
       </li>
     </template>
@@ -1229,7 +1229,7 @@
           <p class="meta"></p>
           <p class="meta"></p>
         </div>
-        <div class="row-actions"><button type="button" class="edit-btn secondary-btn">編集</button><button type="button" class="danger-btn delete-btn">削除</button></div>
+        <div class="row-actions"><button type="button" class="edit-btn secondary-btn" data-action="edit_work_template" data-list-action="edit_work_template">編集</button><button type="button" class="danger-btn delete-btn" data-action="delete_work_template" data-list-action="delete_work_template">削除</button></div>
       </li>
     </template>
   </body>


### PR DESCRIPTION
### Motivation
- Eliminate fragile implicit routing via `global_list_action` and class-based inference so buttons reliably invoke the intended handlers. 
- Ensure every interactive button uses an explicit `data-action` that maps to a handler in `CLICK_ACTION_HANDLERS` to avoid no-op clicks. 
- Surface unregistered actions to the user/developer instead of silently ignoring them. 

### Description
- Replaced the `global_list_action` catch-all by expanding `CLICK_ACTION_HANDLERS` to register all list/dashboard actions (clients, cases, work templates, estimates, sales/payments/reminders, expenses, fixed expenses, daily reports, case tasks, documents, integrity checks, exports, etc.).
- Updated `dispatchAction` so unregistered actions now log `console.error` and call `showAppMessage("未登録の操作です: ${action}", true)` instead of returning silently. 
- Removed legacy automatic inference fallback (`inferLegacyClickAction`) and made `ensureButtonDataAction` require explicit `data-action` values. 
- Updated render logic and templates (`app.js` and `index.html`) to set explicit `data-action` on all row/action buttons (including print/xlsx buttons, deadline/status/integrity chips, register/delete payment buttons, edit/delete for clients/cases/estimates/expenses/fixed-expenses/daily-reports/case-tasks/documents, etc.).
- Strengthened ID resolution in list handlers (e.g. `handleCaseListAction`, `handleSalesListAction`) to accept IDs from row `data-id`, `data-case-id`, `data-sale-id`, `data-task-id`, or button attributes so dashboard/alert buttons also work. 

### Testing
- Ran `node --check app.js` and it succeeded with no syntax errors. 
- Searched for legacy routing artifacts with `rg -n "global_list_action|inferLegacyClickAction" app.js index.html` and confirmed there are no remaining matches. 
- Verified mapping completeness by running a script that compares `data-action` usages in `app.js`/`index.html` against keys in `CLICK_ACTION_HANDLERS` and confirmed no missing handlers (empty missing list).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a2fbe3e08333bce3264bd19f5c2c)