### PR TITLE
Unify loading timer reset and force-hide behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -8532,9 +8532,8 @@ function startLoading(label = "処理中") {
   document.body.classList.add("is-loading");
   console.log("LOADING START", label, loadingCount);
 
-  if (loadingTimer) {
-    clearTimeout(loadingTimer);
-  }
+  clearTimeout(loadingTimer);
+  loadingTimer = null;
 
   loadingTimer = setTimeout(() => {
     console.warn("LOADING FORCE TIMEOUT", label);
@@ -8544,11 +8543,8 @@ function startLoading(label = "処理中") {
 
 function forceHideLoading() {
   loadingCount = 0;
-
-  if (loadingTimer) {
-    clearTimeout(loadingTimer);
-    loadingTimer = null;
-  }
+  clearTimeout(loadingTimer);
+  loadingTimer = null;
 
   if (loadingOverlay) {
     loadingOverlay.hidden = true;


### PR DESCRIPTION
### Motivation
- Prevent the loading overlay from remaining visible after operations or tab/background transitions by ensuring timer handling and the final hide routine are consistent and always perform full cleanup.

### Description
- In `app.js` updated `startLoading` to unconditionally `clearTimeout(loadingTimer)` and set `loadingTimer = null` before creating a new timeout, and preserved the timeout handler that calls `forceHideLoading` after 8s.
- In `app.js` updated `forceHideLoading` to always set `loadingCount = 0`, `clearTimeout(loadingTimer)`, `loadingTimer = null`, hide the `loadingOverlay`, and remove the `is-loading` class from `body` so it is the single final cleanup routine.
- No other logic or UI/SQL/database code was changed and existing global event handlers (`pageshow`/`focus`/`visibilitychange`) and `finally`-based calls to `forceHideLoading` were left intact.

### Testing
- Ran `node --check app.js`, which completed successfully.
- Used `rg` searches to confirm `withLoading`, `runMutation`, `applyAuthState`, and `onAuthStateChange` code paths and global event listeners (`pageshow`, `focus`, `visibilitychange`) still call `forceHideLoading`, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d024c7e88333b070061423892ed1)