### PR TITLE
入金処理: 履歴追加方式へ変更し売上の入金集計を再計算する

### DIFF
--- a/app.js
+++ b/app.js
@@ -2253,9 +2253,20 @@ async function handleRecordPayment(saleId) {
 
   const amountInput = window.prompt("入金額を入力してください", "");
   if (!amountInput) return;
-  const amount = parseNumberInput(amountInput);
-  if (!amount || amount <= 0) {
-    showAppMessage("入金額を正しく入力してください。", true);
+  const amount = Number(String(amountInput).replace(/,/g, "").trim());
+  if (!Number.isFinite(amount) || Number.isNaN(amount)) {
+    showAppMessage("入金額は数値で入力してください。", true);
+    return;
+  }
+  if (amount <= 0) {
+    showAppMessage("入金額は0より大きい値を入力してください。", true);
+    return;
+  }
+  const currentPaidAmount = Number(sale.paidAmount || 0);
+  const invoiceAmount = Number(sale.invoiceAmount || 0);
+  const remainingAmount = Math.max(0, invoiceAmount - currentPaidAmount);
+  if (amount > remainingAmount) {
+    showAppMessage(`入金額が残額を超えています。残額: ${formatCurrency(remainingAmount)}`, true);
     return;
   }
 
@@ -2281,16 +2292,8 @@ async function handleRecordPayment(saleId) {
       const { data: paymentData, error: paymentError } = await sbClient.from("payments").insert(paymentPayload).select().single();
       if (paymentError) throw paymentError;
       if (!paymentData) throw new Error("入金登録結果を取得できませんでした。");
-      const existingPayments = (state.payments || []).filter((entry) => entry.saleId === saleId);
-      const existingPaidAmount = existingPayments.reduce((sum, entry) => sum + Number(entry.amount || 0), 0);
-      const newPaidAmount = existingPaidAmount + amount;
-      const invoiceAmount = Number(sale.invoiceAmount || 0);
-      const paymentStatus = calculatePaymentStatus(invoiceAmount, newPaidAmount);
-      const salePayload = { paid_amount: newPaidAmount, paid_date: paymentDate, payment_status: paymentStatus, is_unpaid: paymentStatus !== "入金済" };
-      const { data: saleData, error: saleError } = await sbClient.from("sales").update(salePayload).eq("id", saleId).eq("user_id", currentUser.id).select().single();
-      if (saleError) throw saleError;
-      if (!saleData) throw new Error("売上の入金情報を更新できませんでした。");
-      return saleData;
+      await syncSalePaymentSummary(saleId);
+      return paymentData;
     }, { successMessage: "入金を登録しました。" });
   } catch (error) {
     console.error("入金登録に失敗しました。", error);
@@ -7236,16 +7239,28 @@ function hydrateSaleWithPayments(sale) {
 
 async function syncSalePaymentSummary(saleId) {
   if (!currentUser || !saleId) return;
-  const paidAmount = getSalePaidAmountByPayments(saleId);
   const sale = state.sales.find((entry) => entry.id === saleId);
   const invoiceAmount = Number(sale?.invoiceAmount || 0);
+
+  const { data: paymentRows, error: paymentLoadError } = await sbClient
+    .from("payments")
+    .select("amount,payment_date")
+    .eq("sale_id", saleId)
+    .eq("user_id", currentUser.id);
+  if (paymentLoadError) throw paymentLoadError;
+
+  const paidAmount = (paymentRows || []).reduce((sum, entry) => sum + (Number(entry.amount) || 0), 0);
+  const latestPaymentDate = (paymentRows || [])
+    .map((entry) => entry?.payment_date || null)
+    .filter((value) => !!value)
+    .sort((a, b) => toSortTimestamp(b) - toSortTimestamp(a))[0] || null;
   const paymentStatus = calculatePaymentStatus(invoiceAmount, paidAmount);
-  const latestPayment = getSalePayments(saleId)[0];
+
   const payload = {
     paid_amount: paidAmount,
-    paid_date: latestPayment?.paymentDate || null,
+    paid_date: paidAmount > 0 ? latestPaymentDate : null,
     payment_status: paymentStatus,
-    is_unpaid: paymentStatus !== "入金済",
+    is_unpaid: paidAmount < invoiceAmount,
   };
   const { data, error } = await sbClient.from("sales").update(payload).eq("id", saleId).eq("user_id", currentUser.id).select().single();
   if (error) throw error;


### PR DESCRIPTION
### Motivation
- 既存の入金処理が今回入金額で `sales.paid_amount` を上書きしており、入金履歴を保持しないため残額計算が不正になっていたため修正する。 
- 入金は必ず `payments` テーブルへ1件追加し、そこから売上の入金合計を再計算する履歴ベースの仕組みに統一する必要がある。

### Description
- `handleRecordPayment` を修正し、入金時は `payments` に1件挿入した後に `syncSalePaymentSummary(saleId)` を呼んで履歴ベースで再集計するように変更した（`sales.paid_amount` を今回入金額で直接上書きしない）。
- 入金入力のバリデーションを強化し、数値チェック（NaN禁止）、`> 0` 要件、および `今回入金額 <= 残額`（超過入金禁止）を実装した。 
- `syncSalePaymentSummary` を修正して対象 `sale_id` の `payments` をDBから取得し、`paid_amount` を `payments.amount` の合計で算出し、`payment_status` / `is_unpaid` / `paid_date`（合計が0の場合は null、それ以外は最新入金日）を正しく更新するようにした。 
- `deletePayment` 処理は既存の流れを維持し、削除後に同じ再集計ロジックを呼んで売上サマリの整合性を保つようにしている。 

### Testing
- `node --check app.js` を実行し構文チェックが成功したことを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17614b45483339374b732afaa002a)