### PR TITLE
Fix payment registration to recalc paid_amount from payments history

### DIFF
--- a/app.js
+++ b/app.js
@@ -2261,7 +2261,11 @@ async function handleRecordPayment(saleId) {
   }
 
   const amountInput = window.prompt("入金額を入力してください", "");
-  if (!amountInput) return;
+  if (amountInput === null) return;
+  if (!String(amountInput).trim()) {
+    showAppMessage("入金額を入力してください。", true);
+    return;
+  }
   const amount = Number(String(amountInput).replace(/,/g, "").trim());
   if (!Number.isFinite(amount) || Number.isNaN(amount)) {
     showAppMessage("入金額は数値で入力してください。", true);
@@ -2269,13 +2273,6 @@ async function handleRecordPayment(saleId) {
   }
   if (amount <= 0) {
     showAppMessage("入金額は0より大きい値を入力してください。", true);
-    return;
-  }
-  const currentPaidAmount = Number(sale.paidAmount || 0);
-  const invoiceAmount = Number(sale.invoiceAmount || 0);
-  const remainingAmount = calculateSaleRemainingAmount(invoiceAmount, currentPaidAmount);
-  if (amount > remainingAmount) {
-    showAppMessage(`入金額が残額を超えています。残額: ${formatCurrency(remainingAmount)}`, true);
     return;
   }
 
@@ -2290,6 +2287,28 @@ async function handleRecordPayment(saleId) {
   try {
     await runMutation("入金登録", async () => {
       console.log("PAYMENT START", { saleId, paymentDate, amount, method, memo });
+      const { data: saleRow, error: saleLoadError } = await sbClient
+        .from("sales")
+        .select("invoice_amount")
+        .eq("id", saleId)
+        .eq("user_id", currentUser.id)
+        .single();
+      if (saleLoadError) throw saleLoadError;
+      if (!saleRow) throw new Error("対象売上の取得に失敗しました。");
+      const invoiceAmount = Number(saleRow.invoice_amount || 0);
+
+      const { data: existingPayments, error: paymentLoadError } = await sbClient
+        .from("payments")
+        .select("amount")
+        .eq("sale_id", saleId)
+        .eq("user_id", currentUser.id);
+      if (paymentLoadError) throw paymentLoadError;
+      const currentPaid = (existingPayments || []).reduce((sum, payment) => sum + Number(payment.amount || 0), 0);
+      const currentRemaining = Math.max(invoiceAmount - currentPaid, 0);
+      if (amount > currentRemaining) {
+        throw new Error(`入金額が残額を超えています。残額: ${formatCurrency(currentRemaining)}`);
+      }
+
       const paymentPayload = {
         user_id: currentUser.id,
         sale_id: saleId,
@@ -7252,8 +7271,15 @@ function hydrateSaleWithPayments(sale) {
 
 async function syncSalePaymentSummary(saleId) {
   if (!currentUser || !saleId) return;
-  const sale = state.sales.find((entry) => entry.id === saleId);
-  const invoiceAmount = Number(sale?.invoiceAmount || 0);
+  const { data: sale, error: saleLoadError } = await sbClient
+    .from("sales")
+    .select("invoice_amount")
+    .eq("id", saleId)
+    .eq("user_id", currentUser.id)
+    .single();
+  if (saleLoadError) throw saleLoadError;
+  if (!sale) throw new Error("売上情報の取得に失敗しました。");
+  const invoiceAmount = Number(sale.invoice_amount || 0);
 
   const { data: paymentRows, error: paymentLoadError } = await sbClient
     .from("payments")


### PR DESCRIPTION
### Motivation
- 入金登録時に `sales.paid_amount` が今回入力した入金額で上書きされる不具合を修正し、支払履歴（`payments`）を正しい唯一の情報源として合算するようにするためです。
- 入金バリデーションは現在の残額を履歴ベースで計算して禁止条件（空欄/NaN/<=0/超過入金）を厳格にチェックする必要がありました。

### Description
- `handleRecordPayment` の入力処理を強化し、空欄入力を明確に弾くバリデーションを追加しました（空入力・NaN・0以下を拒否）。
- 登録前に `sales.invoice_amount` をDBから取得し、同 `sale_id` の `payments` を取得して `reduce` で合算した `currentPaid` を基に `currentRemaining` を算出して超過入金を禁止するようにしました。
- `payments` へは従来どおり `insert` を行い、登録後は `syncSalePaymentSummary` を呼んで `payments.amount` の合計・最新 `payment_date` を再計算し、`sales.paid_amount` / `payment_status` / `is_unpaid` / `paid_date` を更新するようにしました（`sales.paid_amount` を今回入金額で直接上書きしない）。
- `syncSalePaymentSummary` を修正して対象売上の `invoice_amount` をDBから取得してから履歴合算を行うようにし、削除処理でも同関数を呼ぶことで履歴再計算を保証しています。

### Testing
- `node --check app.js` を実行して構文チェックが通ることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1dc07fd548333a08756b821bad430)