### PR TITLE
Add print_cumulative_receipt click handler and cumulative print preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,6 +132,10 @@ const CLICK_ACTION_HANDLERS = {
   record_payment: handleSalesListAction,
   delete_payment: handleSalesListAction,
   print_receipt: handleSalesListAction,
+  print_cumulative_receipt: (event, button) => {
+    const saleId = button.dataset.saleId;
+    return openCumulativeReceiptPrintPreview(saleId);
+  },
   record_reminder: handleSalesListAction,
   edit_expense: handleExpensesListAction,
   delete_expense: handleExpensesListAction,
@@ -6446,6 +6450,14 @@ function openReceiptPrintPreview(saleId, paymentId, options = {}) {
     const documentData = buildReceiptDocumentData(sale, payment);
     openBusinessDocumentPrintWindow(documentData, { type: "receipt" });
   });
+}
+
+function openCumulativeReceiptPrintPreview(saleId) {
+  if (!saleId) {
+    showAppMessage("出力対象データIDを取得できませんでした。", true);
+    return;
+  }
+  return openReceiptPrintPreview(saleId, null, { cumulative: true });
 }
 
 function buildReceiptPaymentFromSale(sale, options = {}) {


### PR DESCRIPTION
### Motivation
- `renderSales` renders a button with `data-action="print_cumulative_receipt"` but no matching handler existed, causing console errors and no action when the 累計領収書 button is clicked.

### Description
- Register `print_cumulative_receipt` in `CLICK_ACTION_HANDLERS` with signature `(event, button)` that reads `button.dataset.saleId` and call `openCumulativeReceiptPrintPreview(saleId)`, and add `openCumulativeReceiptPrintPreview(saleId)` which delegates to `openReceiptPrintPreview(saleId, null, { cumulative: true })`, leaving individual receipt logic and other systems unchanged.

### Testing
- Ran a syntax check with `node --check app.js` which passed, and inspected the code diff to confirm only the handler registration and the cumulative preview wrapper were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d5837dd88333971c5126a281bbef)