### PR TITLE
変更履歴表示の日本語化とID短縮表示の追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -3725,22 +3725,33 @@ function renderAfterDataChanged() {
   console.log("RENDER DONE");
 }
 
+function formatShortId(value) {
+  const text = `${value || ""}`.trim();
+  if (!text) return "-";
+  if (text.length <= 16) return text;
+  return `${text.slice(0, 8)}...${text.slice(-6)}`;
+}
+
 function renderChangeLogs() {
   if (!changeLogsBody || !changeLogsEmpty || !changeLogsWrap) return;
   const logs = Array.isArray(state.changeLogs) ? state.changeLogs : [];
+  const actionLabelMap = { create: "登録", update: "更新", delete: "削除" };
+  const tableLabelMap = { sales: "売上", payments: "入金", expenses: "経費" };
   changeLogsBody.innerHTML = "";
   changeLogsEmpty.hidden = logs.length > 0;
   changeLogsWrap.hidden = logs.length === 0;
   logs.forEach((log) => {
     let detail = {};
     try { detail = log?.detail ? JSON.parse(log.detail) : {}; } catch (_) { detail = {}; }
+    const actionType = `${log?.action_type || ""}`.toLowerCase();
+    const targetType = `${log?.target_type || ""}`.toLowerCase();
     const tr = document.createElement("tr");
     tr.innerHTML = `
       <td>${escapeHtml(formatDateTimeValue(log?.created_at || log?.createdAt || ""))}</td>
-      <td>${escapeHtml(log?.user_id || "-")}</td>
-      <td>${escapeHtml(log?.action_type || "-")}</td>
-      <td>${escapeHtml(log?.target_type || "-")}</td>
-      <td>${escapeHtml(log?.target_id || "-")}</td>
+      <td>${escapeHtml(formatShortId(log?.user_id))}</td>
+      <td>${escapeHtml(actionLabelMap[actionType] || (log?.action_type || "-"))}</td>
+      <td>${escapeHtml(tableLabelMap[targetType] || (log?.target_type || "-"))}</td>
+      <td>${escapeHtml(formatShortId(log?.target_id))}</td>
       <td><pre>${escapeHtml(JSON.stringify(detail?.before ?? null, null, 2))}</pre></td>
       <td><pre>${escapeHtml(JSON.stringify(detail?.after ?? null, null, 2))}</pre></td>
     `;

--- a/index.html
+++ b/index.html
@@ -1184,17 +1184,17 @@
             </section>
             <section class="panel">
               <h2>変更履歴</h2>
-              <p class="meta">売上・入金・経費の登録/編集/削除ログを表示します。</p>
+              <p class="meta">売上・入金・経費の登録/更新/削除履歴を表示します。</p>
               <div id="change-logs-empty" class="empty">変更履歴はまだありません。</div>
               <div id="change-logs-wrap" class="table-wrap" hidden>
                 <table>
                   <thead>
                     <tr>
                       <th>日時</th>
-                      <th>user_id</th>
-                      <th>action</th>
-                      <th>table</th>
-                      <th>record_id</th>
+                      <th>操作ユーザー</th>
+                      <th>操作内容</th>
+                      <th>対象</th>
+                      <th>対象ID</th>
                       <th>before</th>
                       <th>after</th>
                     </tr>


### PR DESCRIPTION
### Motivation
- 変更履歴表示を日本語化して読みやすくするため、表示文言と列見出しを改善します。 
- 長い `user_id` / `record_id` を短縮表示して一覧での可読性を向上させます。 
- 表示のみを変更し、DB・保存形式・RLS・ログ記録ロジックや既存処理は一切変更しない方針です。

### Description
- `index.html` の変更履歴セクションの説明文を `売上・入金・経費の登録/更新/削除履歴を表示します。` に更新し、テーブル見出しを `日時 / 操作ユーザー / 操作内容 / 対象 / 対象ID` に日本語化しました. 
- `app.js` に `formatShortId` を追加して長いIDを `先頭8文字...末尾6文字` 形式で短縮表示するようにしました。 
- `renderChangeLogs` を改修し、`action_type` を `create→登録`, `update→更新`, `delete→削除` の日本語ラベルで表示するマッピングを追加しました。 
- 同じく `target_type` (`sales/payments/expenses`) を `売上/入金/経費` にマップする表示ロジックを追加し、マップにない値は既存の値をそのまま表示するフォールバックを維持しています（影響はUI表示のみ）。

### Testing
- `node --check app.js` を実行して構文エラーがないことを確認し、成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e028417c83339b1827553d58de3f)