### PR TITLE
Fix case list peripheral document print action wiring

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,10 +130,22 @@ const CLICK_ACTION_HANDLERS = {
   print_purchase_order: handleEstimateListAction,
   print_order_confirmation: handleEstimateListAction,
   print_acceptance_certificate: handleEstimateListAction,
-  print_case_delivery_note: handleCaseListAction,
-  print_case_purchase_order: handleCaseListAction,
-  print_case_order_confirmation: handleCaseListAction,
-  print_case_acceptance_certificate: handleCaseListAction,
+  print_case_delivery_note: (event, button) => {
+    const caseId = button.dataset.caseId;
+    return openCaseBusinessDocumentPrintPreview(caseId, "delivery_note");
+  },
+  print_case_purchase_order: (event, button) => {
+    const caseId = button.dataset.caseId;
+    return openCaseBusinessDocumentPrintPreview(caseId, "purchase_order");
+  },
+  print_case_order_confirmation: (event, button) => {
+    const caseId = button.dataset.caseId;
+    return openCaseBusinessDocumentPrintPreview(caseId, "order_confirmation");
+  },
+  print_case_acceptance_certificate: (event, button) => {
+    const caseId = button.dataset.caseId;
+    return openCaseBusinessDocumentPrintPreview(caseId, "acceptance_certificate");
+  },
   export_estimate_excel: handleEstimateListAction,
   export_invoice_excel_from_estimate: handleEstimateListAction,
   edit_sale: handleSalesListAction,
@@ -1796,10 +1808,10 @@ async function handleCaseListAction(event) {
     exportInvoiceDataForCase(id);
     return;
   }
-  if (listAction === "print_case_delivery_note") return openPeripheralDocumentPrintPreviewFromCase(id, "delivery_note");
-  if (listAction === "print_case_purchase_order") return openPeripheralDocumentPrintPreviewFromCase(id, "purchase_order");
-  if (listAction === "print_case_order_confirmation") return openPeripheralDocumentPrintPreviewFromCase(id, "order_confirmation");
-  if (listAction === "print_case_acceptance_certificate") return openPeripheralDocumentPrintPreviewFromCase(id, "inspection_report");
+  if (listAction === "print_case_delivery_note") return openCaseBusinessDocumentPrintPreview(id, "delivery_note");
+  if (listAction === "print_case_purchase_order") return openCaseBusinessDocumentPrintPreview(id, "purchase_order");
+  if (listAction === "print_case_order_confirmation") return openCaseBusinessDocumentPrintPreview(id, "order_confirmation");
+  if (listAction === "print_case_acceptance_certificate") return openCaseBusinessDocumentPrintPreview(id, "acceptance_certificate");
 
   if (listAction === "delete_case") {
     await deleteCase(id);
@@ -6064,6 +6076,7 @@ function renderCases() {
       btn.className = `secondary-btn ${config.selector.slice(1)}`;
       btn.dataset.action = config.action;
       btn.dataset.listAction = config.action;
+      btn.dataset.caseId = entry.id;
       btn.textContent = config.label;
       rowActions.appendChild(btn);
     });
@@ -6777,6 +6790,10 @@ function openPeripheralDocumentPrintPreviewFromCase(caseId, documentType) {
     const documentData = buildPeripheralDocumentFromCase(foundCase, documentType);
     openBusinessDocumentPrintWindow(documentData, { type: "peripheral" });
   });
+}
+
+function openCaseBusinessDocumentPrintPreview(caseId, documentType) {
+  return openPeripheralDocumentPrintPreviewFromCase(caseId, documentType);
 }
 
 function openBusinessDocumentPrintWindow(documentData, options = { type: "invoice" }) {


### PR DESCRIPTION
### Motivation
- 案件一覧の周辺帳票ボタン（納品書/注文書/注文請書/検収書）を押すと `未登録data-action` エラーが出るため、ボタンの `data-action` と実際のハンドラ登録を一致させる必要があった。 
- 案件側から `caseId` を取得して帳票プレビューを開くフローを明確にし、見積一覧側の既存フローを破壊しないようにする。 

### Description
- `CLICK_ACTION_HANDLERS` に案件一覧用の4つの明示的ハンドラを追加し、それぞれ `button.dataset.caseId` を使って `openCaseBusinessDocumentPrintPreview(caseId, documentType)` を呼ぶようにした。 
- 案件一覧レンダリング時に生成する周辺帳票ボタンに `data-case-id` を設定するように修正した。 
- `handleCaseListAction` 内の周辺帳票分岐を `openCaseBusinessDocumentPrintPreview(...)` を経由する形に統一し、検収書の `documentType` を `acceptance_certificate` に合わせた。 
- `openCaseBusinessDocumentPrintPreview` をラッパーとして追加し、既存の `openPeripheralDocumentPrintPreviewFromCase` を再利用する実装とした。 

### Testing
- 実装後にリポジトリ内で関連文字列を検索して差分を確認するために `rg "print_case_delivery_note|print_case_purchase_order|print_case_order_confirmation|print_case_acceptance_certificate|openCaseBusinessDocumentPrintPreview|data-case-id" -n app.js` を実行し成功を確認した。 
- 変更ファイルの状態確認に `git status --short` を実行して変更が作業ツリーにあることを確認し、`git add app.js && git commit -m "Fix case list peripheral document action handlers"` でコミットが成功した。 
- 直接のユニット/統合テストスイートは実行しておらず、現状はソース上の静的差分確認とコミット成功をもって検証を行った。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ebb168cc8333b0461ef2a87f308e)