### PR TITLE
ダッシュボードに未処理アラート一覧を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -278,6 +278,12 @@ const nextActionAlertSummary = document.getElementById("next-action-alert-summar
 const nextActionAlertBody = document.getElementById("next-action-alert-body");
 const nextActionAlertEmpty = document.getElementById("next-action-alert-empty");
 const nextActionAlertListWrap = document.getElementById("next-action-alert-list-wrap");
+const pendingAlertCard = document.getElementById("pending-alert-card");
+const pendingAlertSummary = document.getElementById("pending-alert-summary");
+const pendingAlertCounts = document.getElementById("pending-alert-counts");
+const pendingAlertBody = document.getElementById("pending-alert-body");
+const pendingAlertEmpty = document.getElementById("pending-alert-empty");
+const pendingAlertListWrap = document.getElementById("pending-alert-list-wrap");
 const todayTaskCard = document.getElementById("today-task-card");
 const todayTaskSummary = document.getElementById("today-task-summary");
 const todayTaskBody = document.getElementById("today-task-body");
@@ -4193,6 +4199,7 @@ function renderDashboard() {
     summaryGrid.appendChild(div);
   });
   renderTodayTaskCard();
+  renderPendingAlerts();
   renderDocumentAlerts();
   renderNextActionAlertCard();
   renderDeadlineAlertCard();
@@ -4215,6 +4222,112 @@ function renderDashboard() {
   renderAnalyticsSection();
   renderPendingEstimates();
   renderDataIntegrityCheck();
+}
+
+function renderPendingAlerts() {
+  if (!pendingAlertCard || !pendingAlertSummary || !pendingAlertCounts || !pendingAlertBody || !pendingAlertEmpty || !pendingAlertListWrap) return;
+  const todayTimestamp = getTodayTimestamp();
+  const alerts = [];
+  const countMap = new Map();
+  const addAlert = (category, entry) => {
+    alerts.push({ category, ...entry });
+    countMap.set(category, (countMap.get(category) || 0) + 1);
+  };
+  const addCaseAlert = (category, entry, action) => addAlert(category, {
+    targetName: `${entry.customerName || "顧客不明"} / ${entry.caseName || "案件なし"}`,
+    dateLabel: entry.dueDate || entry.nextActionDate || "-",
+    amountLabel: "-",
+    status: entry.status || "-",
+    nextAction: action,
+  });
+
+  state.cases.forEach((entry) => {
+    const dueTs = toDateOnlyTimestamp(entry?.dueDate);
+    if (entry?.dueDate && Number.isFinite(dueTs) && dueTs < todayTimestamp && getStatusCategory(entry.status) !== "完了") {
+      addCaseAlert("期限日を過ぎた案件", entry, "案件の期限・進捗を更新");
+    }
+    const nextTs = toDateOnlyTimestamp(entry?.nextActionDate);
+    if (entry?.nextActionDate && Number.isFinite(nextTs) && nextTs < todayTimestamp && getStatusCategory(entry.status) !== "完了") {
+      addCaseAlert("次回対応日を過ぎた案件", entry, entry.nextAction || "次回対応を実施");
+    }
+  });
+  state.caseTasks.forEach((entry) => {
+    if (entry?.status === "完了") return;
+    const linkedCase = state.cases.find((row) => row.id === entry.caseId);
+    addAlert("未完了タスク", {
+      targetName: `${linkedCase?.customerName || "顧客不明"} / ${(entry.taskTitle || "タスク未設定")}`,
+      dateLabel: entry?.dueDate || "-",
+      amountLabel: "-",
+      status: entry?.status || "未着手",
+      nextAction: "タスクを完了または更新",
+    });
+  });
+  state.caseDocuments.forEach((entry) => {
+    if (entry?.status !== "未回収") return;
+    const linkedCase = state.cases.find((row) => row.id === entry.caseId);
+    addAlert("未回収書類", {
+      targetName: `${linkedCase?.customerName || "顧客不明"} / ${entry?.documentName || "書類名未設定"}`,
+      dateLabel: entry?.dueDate || "-",
+      amountLabel: "-",
+      status: entry?.status || "-",
+      nextAction: "回収状況を更新",
+    });
+  });
+  getBillingLeakCandidates().forEach((entry) => {
+    addCaseAlert("未請求の案件", entry, "売上を登録");
+  });
+  state.sales.forEach((entry) => {
+    const remaining = getRemainingAmount(entry);
+    const dueTs = toDateOnlyTimestamp(entry?.dueDate);
+    const name = `${entry?.customerName || "顧客不明"} / ${entry?.caseName || "案件なし"}`;
+    if (["未入金", "一部入金"].includes(entry?.paymentStatus) && remaining > 0) {
+      addAlert("未入金・一部入金の売上", {
+        targetName: name,
+        dateLabel: entry?.dueDate || "-",
+        amountLabel: formatCurrency(remaining),
+        status: entry?.paymentStatus || "-",
+        nextAction: "入金登録または督促",
+      });
+    }
+    if (entry?.dueDate && Number.isFinite(dueTs) && dueTs < todayTimestamp && remaining > 0) {
+      addAlert("支払期限を過ぎた売上", {
+        targetName: name,
+        dateLabel: entry?.dueDate,
+        amountLabel: formatCurrency(remaining),
+        status: entry?.paymentStatus || "-",
+        nextAction: "期限超過分を督促",
+      });
+    }
+  });
+  state.expenses.forEach((entry) => {
+    if (String(entry?.receiptUrl || "").trim()) return;
+    addAlert("receipt_url が空の経費", {
+      targetName: `${entry?.category || "分類未設定"} / ${entry?.description || "内容未設定"}`,
+      dateLabel: entry?.date || "-",
+      amountLabel: formatCurrency(entry?.amount || 0),
+      status: "領収書未登録",
+      nextAction: "領収書URLを登録",
+    });
+  });
+
+  pendingAlertCard.classList.toggle("has-alert", alerts.length > 0);
+  pendingAlertSummary.textContent = `対象 ${alerts.length}件`;
+  pendingAlertCounts.innerHTML = Array.from(countMap.entries()).map(([category, count]) => `<span class="pending-alert-chip">${escapeHtml(category)}: ${count}件</span>`).join("");
+  pendingAlertBody.innerHTML = "";
+  pendingAlertEmpty.hidden = alerts.length > 0;
+  pendingAlertListWrap.hidden = alerts.length === 0;
+  alerts.forEach((entry) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${escapeHtml(entry.category)}</td>
+      <td>${escapeHtml(entry.targetName)}</td>
+      <td>${escapeHtml(entry.dateLabel ? formatDate(entry.dateLabel) : "-")}</td>
+      <td>${escapeHtml(entry.amountLabel || "-")}</td>
+      <td>${escapeHtml(entry.status || "-")}</td>
+      <td>${escapeHtml(entry.nextAction || "-")}</td>
+    `;
+    pendingAlertBody.appendChild(tr);
+  });
 }
 
 function renderTodayTaskCard() {

--- a/index.html
+++ b/index.html
@@ -175,6 +175,29 @@
               </table>
             </div>
           </section>
+          <section id="pending-alert-card" class="pending-alert-card case-alert-block" aria-live="polite">
+            <div class="pending-alert-header">
+              <h3>未処理アラート</h3>
+              <p id="pending-alert-summary" class="pending-alert-summary">対象 0件</p>
+            </div>
+            <div id="pending-alert-counts" class="pending-alert-counts"></div>
+            <div id="pending-alert-empty" class="empty">未処理アラートはありません。</div>
+            <div id="pending-alert-list-wrap" class="table-wrap" hidden>
+              <table class="pending-alert-table">
+                <thead>
+                  <tr>
+                    <th>分類</th>
+                    <th>対象名</th>
+                    <th>期限/日付</th>
+                    <th>金額</th>
+                    <th>状態</th>
+                    <th>次にやること</th>
+                  </tr>
+                </thead>
+                <tbody id="pending-alert-body"></tbody>
+              </table>
+            </div>
+          </section>
           <section id="document-alert-card" class="deadline-alert-card case-alert-block" aria-live="polite">
             <div class="deadline-alert-header">
               <h3>書類アラート</h3>

--- a/styles.css
+++ b/styles.css
@@ -333,6 +333,48 @@ button:hover { background: var(--primary-dark); }
   box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.12);
 }
 
+.pending-alert-card {
+  border: 1px solid #fca5a5;
+  background: #fff1f2;
+  border-radius: 10px;
+  padding: 0.8rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.pending-alert-card.has-alert {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.12);
+}
+
+.pending-alert-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: center;
+  margin-bottom: 0.45rem;
+}
+
+.pending-alert-header h3,
+.pending-alert-summary {
+  margin: 0;
+}
+
+.pending-alert-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+}
+
+.pending-alert-chip {
+  border: 1px solid #fecaca;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.84rem;
+  background: #fff;
+}
+
 .pending-estimates-card {
   border: 1px solid #fde68a;
   background: #fffbeb;


### PR DESCRIPTION
### Motivation
- 業務利用時の見落としを防ぐために、既存のデータを参照してフロントで「未処理アラート」一覧を表示するUIを追加する。 

### Description
- ダッシュボード上部に `未処理アラート` カードを追加し、件数サマリーと一覧表示用の領域を `index.html` に追加しました。 
- 新しい表示ロジック `renderPendingAlerts()` を `app.js` に実装し、`renderDashboard()` 内で呼び出すようにしました。 
- `renderPendingAlerts()` は既存の `state` 配列と既存ヘルパー（例: `getBillingLeakCandidates()`, `getRemainingAmount()`, `toDateOnlyTimestamp()` 等）を参照して以下8分類を集計して一覧化します: 期限日を過ぎた案件、次回対応日を過ぎた案件、未完了タスク、未回収書類、未請求の案件、未入金・一部入金の売上、支払期限を過ぎた売上、`receipt_url` が空の経費。 
- 見た目の最小限スタイルを `styles.css` に追加し、既存のUIや保存/計算ロジック、DBスキーマ、RLS等には変更を加えていません。 

### Testing
- `node --check app.js` を実行して構文エラーがないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ed6fc5388333a93d6e6bdab4dc61)