### PR TITLE
Add 日報『アラート』サブタブ and include overdue daily_reports.next_action_date in next-action alerts

### DIFF
--- a/app.js
+++ b/app.js
@@ -377,6 +377,9 @@ const dailyReportSubmitBtn = document.getElementById("daily-report-submit-btn");
 const dailyReportsBody = document.getElementById("daily-reports-body");
 const dailyReportsEmpty = document.getElementById("daily-reports-empty");
 const dailyReportsListWrap = document.getElementById("daily-reports-list-wrap");
+const dailyReportAlertBody = document.getElementById("daily-report-alert-body");
+const dailyReportAlertEmpty = document.getElementById("daily-report-alert-empty");
+const dailyReportAlertListWrap = document.getElementById("daily-report-alert-list-wrap");
 const dailyReportSummaryList = document.getElementById("daily-report-summary-list");
 const dailyReportSearchInput = document.getElementById("daily-report-search-input");
 const dailyReportDateFilterSelect = document.getElementById("daily-report-date-filter");
@@ -4221,6 +4224,7 @@ function renderDashboard() {
   renderUnpaidList();
   renderAnalyticsSection();
   renderPendingEstimates();
+  renderDailyReportAlerts();
   renderDataIntegrityCheck();
 }
 
@@ -4709,20 +4713,44 @@ function renderNextActionAlertCard() {
         <td>${escapeHtml(entry.caseName)}</td>
         <td>${formatDate(entry.nextActionDate)}</td>
         <td>${escapeHtml(entry.nextAction || "未設定")}</td>
-        <td><button type="button" class="secondary-btn" data-action="edit_case" data-list-action="edit_case" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button></td>
+        <td>${entry.sourceType === "daily-report"
+        ? `<button type="button" class="secondary-btn" data-action="edit_daily_report" data-list-action="edit_daily_report" data-daily-report-id="${entry.id}">編集</button>`
+        : `<button type="button" class="secondary-btn" data-action="edit_case" data-list-action="edit_case" data-task-target="case" data-task-id="${entry.id}" data-case-id="${entry.id}">編集</button>`}</td>
       `;
       nextActionAlertBody.appendChild(tr);
     });
 }
 
 function getNextActionAlertTargets() {
-  return state.cases
+  const caseTargets = state.cases
     .map((entry) => {
       const info = getNextActionInfo(entry);
       if (!info) return null;
-      return { ...entry, ...info };
+      return { ...entry, ...info, sourceType: "case" };
     })
     .filter((entry) => entry && entry.remainingDays <= 0 && getStatusCategory(entry.status) !== "完了");
+
+  const dailyReportTargets = state.dailyReports
+    .map((entry) => {
+      const info = getNextActionInfo(entry);
+      if (!info) return null;
+      const hasContext = String(entry?.nextAction || "").trim()
+        || String(entry?.workContent || "").trim()
+        || String(entry?.memo || "").trim();
+      if (!hasContext || info.remainingDays >= 0) return null;
+      const linkedCase = state.cases.find((caseEntry) => caseEntry.id === entry.caseId);
+      return {
+        ...entry,
+        ...info,
+        sourceType: "daily-report",
+        customerName: linkedCase?.customerName || "日報",
+        caseName: linkedCase?.caseName || "日報",
+        status: "対応期限超過",
+      };
+    })
+    .filter(Boolean);
+
+  return [...caseTargets, ...dailyReportTargets];
 }
 
 function getNextActionInfo(entry) {
@@ -4733,6 +4761,29 @@ function getNextActionInfo(entry) {
   const remainingDays = Math.floor((nextActionTimestamp - todayTimestamp) / 86400000);
   const urgencyClass = remainingDays <= 0 ? "next-action-overdue" : remainingDays <= 3 ? "next-action-within3" : remainingDays <= 7 ? "next-action-within7" : "";
   return { remainingDays, urgencyClass };
+}
+
+
+function renderDailyReportAlerts() {
+  if (!dailyReportAlertBody || !dailyReportAlertEmpty || !dailyReportAlertListWrap) return;
+  const targets = getNextActionAlertTargets();
+  dailyReportAlertBody.innerHTML = "";
+  dailyReportAlertEmpty.hidden = targets.length > 0;
+  dailyReportAlertListWrap.hidden = targets.length === 0;
+  targets
+    .slice()
+    .sort((a, b) => (a.remainingDays || 0) - (b.remainingDays || 0))
+    .forEach((entry) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>次回対応</td>
+        <td>${escapeHtml(entry.sourceType === "daily-report" ? (entry.caseName || "日報") : `${entry.customerName || "顧客不明"} / ${entry.caseName || "案件なし"}`)}</td>
+        <td>${formatDate(entry.nextActionDate)}</td>
+        <td>${escapeHtml(entry.sourceType === "daily-report" ? "対応期限超過" : "次回対応期限超過")}</td>
+        <td>${escapeHtml(entry.nextAction || "-")}</td>
+      `;
+      dailyReportAlertBody.appendChild(tr);
+    });
 }
 
 function truncateText(value, maxLength = 80) {

--- a/index.html
+++ b/index.html
@@ -1102,6 +1102,7 @@
             <button type="button" class="subtab-btn active" data-parent-tab="daily-reports" data-subtab="entry">日報登録</button>
             <button type="button" class="subtab-btn" data-parent-tab="daily-reports" data-subtab="list">日報一覧</button>
             <button type="button" class="subtab-btn" data-parent-tab="daily-reports" data-subtab="summary">日報集計</button>
+            <button type="button" class="subtab-btn" data-parent-tab="daily-reports" data-subtab="alerts">アラート</button>
           </nav>
           <div class="layout two-col">
             <section class="panel subtab-panel" data-parent-tab="daily-reports" data-subtab="entry">
@@ -1158,6 +1159,26 @@
             <section class="panel subtab-panel" data-parent-tab="daily-reports" data-subtab="summary" hidden>
               <h2>日報集計</h2>
               <ul id="daily-report-summary-list" class="item-list compact-list"></ul>
+            </section>
+
+
+            <section class="panel subtab-panel" data-parent-tab="daily-reports" data-subtab="alerts" hidden>
+              <h2>未処理アラート一覧</h2>
+              <div id="daily-report-alert-empty" class="empty">未処理アラートはありません。</div>
+              <div id="daily-report-alert-list-wrap" class="table-wrap" hidden>
+                <table>
+                  <thead>
+                    <tr>
+                      <th>分類</th>
+                      <th>対象名</th>
+                      <th>期限/日付</th>
+                      <th>状態</th>
+                      <th>次にやること</th>
+                    </tr>
+                  </thead>
+                  <tbody id="daily-report-alert-body"></tbody>
+                </table>
+              </div>
             </section>
 
             <section class="panel report-list-panel subtab-panel" data-parent-tab="daily-reports" data-subtab="list" hidden>


### PR DESCRIPTION
### Motivation
- 日報の未処理アラート機能で、日報側の過去の `next_action_date` が次回対応アラートに出ない不具合を修正するため。 
- 日報タブに専用の「アラート」サブタブを追加して、未処理アラート一覧を日報画面から確認できるようにするため。 
- 既存の案件側アラートの挙動は維持しつつ、日報由来の期限超過も警告対象に含めるため。 

### Description
- `index.html` に日報のサブタブ `アラート` を追加し、未処理アラート一覧用のテーブルパネルを追加した（`daily-report-alert-body` 等の DOM 要素を追加）。
- `app.js` に日報アラート用 DOM 参照を追加し、ダッシュボード描画時に `renderDailyReportAlerts()` を呼ぶように接続した（既存構成を壊さないように実装）。
- `getNextActionAlertTargets()` を拡張して、従来の案件由来の `next_action_date` を維持しつつ、日報 (`state.dailyReports`) の `nextActionDate` が過去で、かつ `nextAction` または `workContent` または `memo` が存在する場合をアラート対象に追加した（エントリに `sourceType:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f4b45ea8833384cf50f23b0df634)