### PR TITLE
未処理アラートにステータス一括更新機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,7 @@ const state = {
   appSettings: { ...DEFAULT_APP_SETTINGS },
   changeLogs: [],
   isInitialDataReady: false,
+  pendingAlertSelections: {},
 };
 const editState = { clientId: null, caseId: null, workTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null, caseDocumentId: null };
 
@@ -173,6 +174,13 @@ const CLICK_ACTION_HANDLERS = {
   edit_case_document: handleCaseDocumentsListAction,
   delete_case_document: handleCaseDocumentsListAction,
   select_integrity_check: handleDataIntegrityAction,
+  pending_alert_bulk_clear_next_action_date: () => handlePendingAlertBulkAction("clear_next_action_date"),
+  pending_alert_bulk_complete_cases: () => handlePendingAlertBulkAction("complete_cases"),
+  pending_alert_bulk_complete_tasks: () => handlePendingAlertBulkAction("complete_tasks"),
+  pending_alert_bulk_complete_documents: () => handlePendingAlertBulkAction("complete_documents"),
+  pending_alert_bulk_mark_invoiced_cases: () => handlePendingAlertBulkAction("mark_invoiced_cases"),
+  pending_alert_open_sales: () => handlePendingAlertBulkAction("open_sales"),
+  pending_alert_open_expenses: () => handlePendingAlertBulkAction("open_expenses"),
 };
 
 const authView = document.getElementById("auth-view");
@@ -4243,6 +4251,8 @@ function renderPendingAlerts() {
     amountLabel: "-",
     status: entry.status || "-",
     nextAction: action,
+    rowId: entry?.id,
+    rowType: "case",
   });
 
   state.cases.forEach((entry) => {
@@ -4264,6 +4274,8 @@ function renderPendingAlerts() {
       amountLabel: "-",
       status: entry?.status || "未着手",
       nextAction: "タスクを完了または更新",
+      rowId: entry?.id,
+      rowType: "case-task",
     });
   });
   state.caseDocuments.forEach((entry) => {
@@ -4275,6 +4287,8 @@ function renderPendingAlerts() {
       amountLabel: "-",
       status: entry?.status || "-",
       nextAction: "回収状況を更新",
+      rowId: entry?.id,
+      rowType: "case-document",
     });
   });
   getBillingLeakCandidates().forEach((entry) => {
@@ -4291,6 +4305,8 @@ function renderPendingAlerts() {
         amountLabel: formatCurrency(remaining),
         status: entry?.paymentStatus || "-",
         nextAction: "入金登録または督促",
+        rowId: entry?.id,
+        rowType: "sale-unpaid",
       });
     }
     if (entry?.dueDate && Number.isFinite(dueTs) && dueTs < todayTimestamp && remaining > 0) {
@@ -4311,8 +4327,11 @@ function renderPendingAlerts() {
       amountLabel: formatCurrency(entry?.amount || 0),
       status: "領収書未登録",
       nextAction: "領収書URLを登録",
+      rowId: entry?.id,
+      rowType: "expense-no-receipt",
     });
   });
+  state.pendingAlertSelections = {};
 
   pendingAlertCard.classList.toggle("has-alert", alerts.length > 0);
   pendingAlertSummary.textContent = `対象 ${alerts.length}件`;
@@ -4323,6 +4342,7 @@ function renderPendingAlerts() {
   alerts.forEach((entry) => {
     const tr = document.createElement("tr");
     tr.innerHTML = `
+      <td><input type="checkbox" class="pending-alert-checkbox" data-pending-alert-id="${escapeHtml(`${entry.category}:${entry.rowType || "case"}:${entry.rowId || entry.targetName}`)}"></td>
       <td>${escapeHtml(entry.category)}</td>
       <td>${escapeHtml(entry.targetName)}</td>
       <td>${escapeHtml(entry.dateLabel ? formatDate(entry.dateLabel) : "-")}</td>
@@ -4330,8 +4350,71 @@ function renderPendingAlerts() {
       <td>${escapeHtml(entry.status || "-")}</td>
       <td>${escapeHtml(entry.nextAction || "-")}</td>
     `;
+    const checkbox = tr.querySelector(".pending-alert-checkbox");
+    if (checkbox) {
+      const key = checkbox.dataset.pendingAlertId;
+      if (key) {
+        checkbox.dataset.rowType = entry.rowType || "";
+        checkbox.dataset.rowId = entry.rowId || "";
+        checkbox.dataset.category = entry.category || "";
+        checkbox.addEventListener("change", () => {
+          state.pendingAlertSelections[key] = checkbox.checked ? {
+            rowType: checkbox.dataset.rowType || "",
+            rowId: checkbox.dataset.rowId || "",
+            category: checkbox.dataset.category || "",
+          } : null;
+          if (!checkbox.checked) delete state.pendingAlertSelections[key];
+        });
+      }
+    }
     pendingAlertBody.appendChild(tr);
   });
+}
+
+async function handlePendingAlertBulkAction(action) {
+  const selected = Object.values(state.pendingAlertSelections || {}).filter(Boolean);
+  if (action === "open_sales") {
+    subtabState.sales = "list";
+    activateTab("sales");
+    showAppMessage("売上一覧へ移動しました。未入金/一部入金の確認を行ってください。", false);
+    return;
+  }
+  if (action === "open_expenses") {
+    subtabState.expenses = "list";
+    activateTab("expenses");
+    showAppMessage("経費一覧へ移動しました。証憑URL未登録の確認を行ってください。", false);
+    return;
+  }
+  if (!currentUser || !selected.length) {
+    showAppMessage("一括更新対象を選択してください。", true);
+    return;
+  }
+  try {
+    if (action === "clear_next_action_date" || action === "complete_cases" || action === "mark_invoiced_cases") {
+      const caseIds = [...new Set(selected.filter((entry) => entry.category === "次回対応日を過ぎた案件" || entry.category === "未請求の案件").map((entry) => entry.rowId).filter(Boolean))];
+      if (!caseIds.length) return showAppMessage("対象分類の案件が選択されていません。", true);
+      const payload = action === "clear_next_action_date" ? { next_action_date: null } : action === "complete_cases" ? { status: "完了" } : null;
+      if (action === "mark_invoiced_cases") {
+        const targets = state.cases.filter((entry) => caseIds.includes(entry.id) && asTrimmedText(entry.invoiceUrl));
+        if (!targets.length) return showAppMessage("invoice_url がある未請求案件が選択されていません。", true);
+        await Promise.all(targets.map((entry) => sbClient.from("cases").update({ status: "完了" }).eq("id", entry.id).eq("user_id", currentUser.id)));
+      } else {
+        await sbClient.from("cases").update(payload).in("id", caseIds).eq("user_id", currentUser.id);
+      }
+    } else if (action === "complete_tasks") {
+      const ids = [...new Set(selected.filter((entry) => entry.rowType === "case-task").map((entry) => entry.rowId).filter(Boolean))];
+      if (!ids.length) return showAppMessage("未完了タスクが選択されていません。", true);
+      await sbClient.from("case_tasks").update({ status: "完了", completed_at: toDateString(new Date()) }).in("id", ids).eq("user_id", currentUser.id);
+    } else if (action === "complete_documents") {
+      const ids = [...new Set(selected.filter((entry) => entry.rowType === "case-document").map((entry) => entry.rowId).filter(Boolean))];
+      if (!ids.length) return showAppMessage("未回収書類が選択されていません。", true);
+      await sbClient.from("case_documents").update({ status: "回収済" }).in("id", ids).eq("user_id", currentUser.id);
+    }
+    await loadAllData();
+    showAppMessage("一括処理を実行しました。", false);
+  } catch (error) {
+    showAppMessage(`一括処理に失敗しました。${formatSupabaseError(error)}`, true);
+  }
 }
 
 function renderTodayTaskCard() {

--- a/index.html
+++ b/index.html
@@ -180,12 +180,22 @@
               <h3>未処理アラート</h3>
               <p id="pending-alert-summary" class="pending-alert-summary">対象 0件</p>
             </div>
+            <div id="pending-alert-bulk-actions" class="pending-alert-bulk-actions">
+              <button type="button" class="secondary-btn" data-action="pending_alert_bulk_clear_next_action_date">次回対応日を空にする</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_bulk_complete_cases">案件を対応済みにする</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_bulk_complete_tasks">タスクを完了にする</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_bulk_complete_documents">書類を回収済みにする</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_bulk_mark_invoiced_cases">請求済み扱いにする（invoice_url有）</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_open_sales">売上一覧を開く（未入金/一部入金確認）</button>
+              <button type="button" class="secondary-btn" data-action="pending_alert_open_expenses">経費一覧を開く（証憑URL未登録確認）</button>
+            </div>
             <div id="pending-alert-counts" class="pending-alert-counts"></div>
             <div id="pending-alert-empty" class="empty">未処理アラートはありません。</div>
             <div id="pending-alert-list-wrap" class="table-wrap" hidden>
               <table class="pending-alert-table">
                 <thead>
                   <tr>
+                    <th>選択</th>
                     <th>分類</th>
                     <th>対象名</th>
                     <th>期限/日付</th>

--- a/styles.css
+++ b/styles.css
@@ -375,6 +375,13 @@ button:hover { background: var(--primary-dark); }
   background: #fff;
 }
 
+.pending-alert-bulk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
 .pending-estimates-card {
   border: 1px solid #fde68a;
   background: #fffbeb;


### PR DESCRIPTION
### Motivation
- 未処理アラートで見つかった案件・タスク・書類・売上・経費について、複数行を選択して分類ごとにまとめて処理できるようにするための最小限の機能追加です。 
- 要件に合わせてDBスキーマ・RLS・金額/入金ロジック変更や大幅UI変更を行わず、安全に運用可能な範囲で対応します。

### Description
- `index.html` に未処理アラートブロック上部の一括操作ボタン群と一覧のチェックボックス列を追加しました（ボタンはそれぞれ `data-action` 属性で識別）。
- `app.js` に `state.pendingAlertSelections` を追加して選択状態を管理し、`handlePendingAlertBulkAction` を実装して分類ごとの処理を行うようにしました。 
- 一括処理で実行する更新は限定的で、`case_tasks` は `status = "完了"` と `completed_at`、`case_documents` は `status = "回収済"`、`cases` は次回対応日クリアまたは `status = "完了"`（`invoice_url` がある未請求案件のみ）を投げる実装とし、該当するIDへバッチで `update` を実行します。 
- 未入金/一部入金の売上および `receipt_url` 空の経費については自動変更を行わず、該当一覧へ遷移するだけの挙動とし、表示用の最小スタイルを `styles.css` に追加しました。

### Testing
- 自動構文チェックとして `node --check app.js` を実行し問題ありませんでした。 
- 変更差分を確認するために `git diff` を確認し、該当ファイル (`index.html`, `app.js`, `styles.css`) の差分をコミットしました。 
- PR作成前にローカルでの簡易確認（ファイル変更・コミット）を行い正常に適用されました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f7f356708333941a2b651973b580)