### PR TITLE
許認可ヒアリングサブタブと書類・タスク生成を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,42 @@ alter table work_templates add column if not exists task_list text;
 - 保存要件チェック追加
 - 変更履歴ログ追加
 - バックアップJSON/Excel出力確認済み
+
+## 許認可ヒアリング機能の追加SQL
+
+```sql
+create table if not exists permit_hearings (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  case_id uuid,
+  client_id uuid,
+  permit_category text not null,
+  application_type text not null,
+  jurisdiction_prefecture text,
+  jurisdiction_city text,
+  applicant_type text,
+  applicant_name text,
+  office_address text,
+  officer_count int default 0,
+  qualified_person_count int default 0,
+  online_application boolean default false,
+  urgency text,
+  answers jsonb default '{}'::jsonb,
+  generated_documents jsonb default '[]'::jsonb,
+  generated_tasks jsonb default '[]'::jsonb,
+  source_urls jsonb default '[]'::jsonb,
+  source_checked_at date,
+  memo text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table permit_hearings enable row level security;
+
+drop policy if exists "permit_hearings_own" on permit_hearings;
+
+create policy "permit_hearings_own" on permit_hearings
+for all
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+```

--- a/app.js
+++ b/app.js
@@ -783,6 +783,7 @@ async function applyPermitTasksToCase() {
   const existing = new Set(state.caseTasks
     .filter((t) => (t.case_id ?? t.caseId) === lastPermitGenerated.case_id)
     .map((t) => String((t.task_title ?? t.taskTitle) || "").trim()));
+  // case_tasks の実カラム名は task_title（既存の登録・表示・CSV・取込処理と同一）
   const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.case_id, customer_name: lastPermitGenerated.customer_name, case_name: lastPermitGenerated.case_name, task_title: title, status: "未着手" }));
   if (!payload.length) return showAppMessage("同一案件に同名タスクがあるため追加対象はありません。", false);
   const { error } = await sbClient.from("case_tasks").insert(payload);

--- a/app.js
+++ b/app.js
@@ -738,11 +738,14 @@ async function handlePermitHearingSubmit(event) {
   permitDocumentsList.innerHTML = scenario.docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
   permitTasksList.innerHTML = scenario.tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
   permitResult.hidden = false;
-  lastPermitGenerated = { caseId, customerName: linkedCase.customerName, caseName: linkedCase.caseName, docs: [...scenario.docs], tasks: [...scenario.tasks] };
+  const linkedCustomerName = linkedCase.customer_name ?? linkedCase.customerName ?? "";
+  const linkedCaseName = linkedCase.case_name ?? linkedCase.caseName ?? "";
+  const linkedClientId = linkedCase.client_id ?? linkedCase.clientId ?? null;
+  lastPermitGenerated = { case_id: caseId, customer_name: linkedCustomerName, case_name: linkedCaseName, docs: [...scenario.docs], tasks: [...scenario.tasks] };
   const { error } = await sbClient.from("permit_hearings").insert({
     user_id: currentUser.id,
     case_id: caseId,
-    client_id: linkedCase.clientId || null,
+    client_id: linkedClientId,
     permit_category: scenario.label,
     application_type: "新規",
     jurisdiction_prefecture: "大阪府",
@@ -763,9 +766,11 @@ async function handlePermitHearingSubmit(event) {
 }
 
 async function applyPermitDocumentsToCase() {
-  if (!currentUser || !lastPermitGenerated?.caseId) return;
-  const existing = new Set(state.caseDocuments.filter((d) => d.caseId === lastPermitGenerated.caseId).map((d) => String(d.documentName || "").trim()));
-  const payload = lastPermitGenerated.docs.filter((name) => !existing.has(name)).map((name) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, document_name: name, status: "未回収" }));
+  if (!currentUser || !lastPermitGenerated?.case_id) return;
+  const existing = new Set(state.caseDocuments
+    .filter((d) => (d.case_id ?? d.caseId) === lastPermitGenerated.case_id)
+    .map((d) => String((d.document_name ?? d.documentName) || "").trim()));
+  const payload = lastPermitGenerated.docs.filter((name) => !existing.has(name)).map((name) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.case_id, customer_name: lastPermitGenerated.customer_name, case_name: lastPermitGenerated.case_name, document_name: name, status: "未回収" }));
   if (!payload.length) return showAppMessage("同一案件に同名書類があるため追加対象はありません。", false);
   const { error } = await sbClient.from("case_documents").insert(payload);
   if (error) return showAppMessage(`書類反映エラー: ${formatSupabaseError(error)}`, true);
@@ -774,9 +779,11 @@ async function applyPermitDocumentsToCase() {
 }
 
 async function applyPermitTasksToCase() {
-  if (!currentUser || !lastPermitGenerated?.caseId) return;
-  const existing = new Set(state.caseTasks.filter((t) => t.caseId === lastPermitGenerated.caseId).map((t) => String(t.taskTitle || "").trim()));
-  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, task_title: title, status: "未着手" }));
+  if (!currentUser || !lastPermitGenerated?.case_id) return;
+  const existing = new Set(state.caseTasks
+    .filter((t) => (t.case_id ?? t.caseId) === lastPermitGenerated.case_id)
+    .map((t) => String((t.task_title ?? t.taskTitle) || "").trim()));
+  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.case_id, customer_name: lastPermitGenerated.customer_name, case_name: lastPermitGenerated.case_name, task_title: title, status: "未着手" }));
   if (!payload.length) return showAppMessage("同一案件に同名タスクがあるため追加対象はありません。", false);
   const { error } = await sbClient.from("case_tasks").insert(payload);
   if (error) return showAppMessage(`タスク反映エラー: ${formatSupabaseError(error)}`, true);

--- a/app.js
+++ b/app.js
@@ -775,8 +775,8 @@ async function applyPermitDocumentsToCase() {
 
 async function applyPermitTasksToCase() {
   if (!currentUser || !lastPermitGenerated?.caseId) return;
-  const existing = new Set(state.caseTasks.filter((t) => t.caseId === lastPermitGenerated.caseId).map((t) => String(t.title || "").trim()));
-  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, title, status: "未完了" }));
+  const existing = new Set(state.caseTasks.filter((t) => t.caseId === lastPermitGenerated.caseId).map((t) => String(t.taskTitle || "").trim()));
+  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, task_title: title, status: "未着手" }));
   if (!payload.length) return showAppMessage("同一案件に同名タスクがあるため追加対象はありません。", false);
   const { error } = await sbClient.from("case_tasks").insert(payload);
   if (error) return showAppMessage(`タスク反映エラー: ${formatSupabaseError(error)}`, true);

--- a/app.js
+++ b/app.js
@@ -351,6 +351,11 @@ const caseDocumentSubmitBtn = document.getElementById("case-document-submit-btn"
 const caseDocumentsBody = document.getElementById("case-documents-body");
 const caseDocumentsEmpty = document.getElementById("case-documents-empty");
 const caseDocumentsListWrap = document.getElementById("case-documents-list-wrap");
+const permitHearingForm = document.getElementById("permit-hearing-form");
+const permitResult = document.getElementById("permit-hearing-result");
+const permitSummary = document.getElementById("permit-summary");
+const permitDocumentsList = document.getElementById("permit-documents-list");
+const permitTasksList = document.getElementById("permit-tasks-list");
 
 const saleForm = document.getElementById("sale-form");
 const saleCaseSelect = document.getElementById("sale-case-id");
@@ -524,6 +529,7 @@ function bindEvents() {
   caseForm.addEventListener("submit", handleCaseSubmit);
   caseTaskForm?.addEventListener("submit", handleCaseTaskSubmit);
   caseDocumentForm?.addEventListener("submit", handleCaseDocumentSubmit);
+  permitHearingForm?.addEventListener("submit", handlePermitHearingSubmit);
   workTemplateForm?.addEventListener("submit", handleWorkTemplateSubmit);
   console.log("SALE FORM FOUND", !!saleForm);
   console.log("EXPENSE FORM FOUND", !!expenseForm);
@@ -691,6 +697,32 @@ function clearCaseFilters() {
   if (caseSearchInput) caseSearchInput.value = "";
   if (caseDeadlineFilterSelect) caseDeadlineFilterSelect.value = "all";
   safeRender("cases", renderCases);
+}
+
+const PERMIT_SCENARIO_MASTER = {
+  construction_corp: { label: "大阪府 建設業許可 知事許可 新規 法人", docs: ["定款", "履歴事項全部証明書", "役員全員の住民票", "営業所写真", "専任技術者の資格証"], tasks: ["要件確認", "必要書類案内", "役員・技術者情報の確認", "申請書作成", "提出・補正対応"] },
+  construction_solo: { label: "大阪府 建設業許可 知事許可 新規 個人", docs: ["本人住民票", "身分証明書", "営業所写真", "専任技術者の資格証", "確定申告書控え"], tasks: ["本人要件確認", "必要書類案内", "技術者要件確認", "申請書作成", "提出・補正対応"] },
+  takken_corp: { label: "大阪府 宅建業免許 新規 法人", docs: ["定款", "履歴事項全部証明書", "専任宅建士の登録証", "事務所使用権限書類", "役員の略歴書"], tasks: ["免許要件確認", "専任宅建士の確認", "必要書類回収", "申請書作成", "提出・審査対応"] },
+  takken_solo: { label: "大阪府 宅建業免許 新規 個人", docs: ["本人住民票", "身分証明書", "専任宅建士の登録証", "事務所使用権限書類", "略歴書"], tasks: ["免許要件確認", "専任宅建士の確認", "必要書類回収", "申請書作成", "提出・審査対応"] },
+  kobutsu_corp: { label: "大阪府警 古物商許可 新規 法人", docs: ["履歴事項全部証明書", "定款", "役員全員の住民票", "URL使用権限疎明資料（該当時）", "営業所の賃貸借契約書"], tasks: ["欠格要件確認", "営業所情報確認", "必要書類回収", "申請書作成", "警察署へ提出"] },
+  kobutsu_solo: { label: "大阪府警 古物商許可 新規 個人", docs: ["本人住民票", "身分証明書", "URL使用権限疎明資料（該当時）", "営業所の賃貸借契約書", "略歴書"], tasks: ["欠格要件確認", "営業所情報確認", "必要書類回収", "申請書作成", "警察署へ提出"] },
+};
+
+function handlePermitHearingSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(event.currentTarget);
+  const scenarioKey = String(formData.get("permitScenario") || "construction_corp");
+  const scenario = PERMIT_SCENARIO_MASTER[scenarioKey] || PERMIT_SCENARIO_MASTER.construction_corp;
+  const applicantName = String(formData.get("permitApplicantName") || "").trim() || "（未入力）";
+  const officeAddress = String(formData.get("permitOfficeAddress") || "").trim() || "（未入力）";
+  const officerCount = Number(formData.get("permitOfficerCount") || 0);
+  const qualifiedCount = Number(formData.get("permitQualifiedCount") || 0);
+  const online = String(formData.get("permitOnlineApplication") || "false") === "true" ? "希望する" : "希望しない";
+  const urgency = String(formData.get("permitUrgency") || "通常");
+  permitSummary.textContent = `${scenario.label} / 申請者: ${applicantName} / 所在地: ${officeAddress} / 人員: ${officerCount}名 / 有資格者: ${qualifiedCount}名 / 電子申請: ${online} / 優先度: ${urgency}`;
+  permitDocumentsList.innerHTML = scenario.docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
+  permitTasksList.innerHTML = scenario.tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
+  permitResult.hidden = false;
 }
 
 function handleDeadlineAlertClick(event) {

--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@ const state = {
   dailyReports: [],
   caseTasks: [],
   caseDocuments: [],
+  permitHearings: [],
   selectedAggregation: "month",
   selectedMonth: toMonthKey(new Date()),
   selectedYear: new Date().getFullYear(),
@@ -108,6 +109,8 @@ const CLICK_ACTION_HANDLERS = {
   export_excel: handleExportExcel,
   export_analysis_excel: handleExportAnalysisExcel,
   export_backup_json: handleExportBackupJson,
+  apply_permit_documents: applyPermitDocumentsToCase,
+  apply_permit_tasks: applyPermitTasksToCase,
   add_estimate_item_row: () => addEstimateItemRow(),
   remove_estimate_item_row: handleEstimateItemsClick,
   status_summary_filter: handleStatusSummaryClick,
@@ -352,10 +355,14 @@ const caseDocumentsBody = document.getElementById("case-documents-body");
 const caseDocumentsEmpty = document.getElementById("case-documents-empty");
 const caseDocumentsListWrap = document.getElementById("case-documents-list-wrap");
 const permitHearingForm = document.getElementById("permit-hearing-form");
+const permitCaseSelect = document.getElementById("permit-case-id");
 const permitResult = document.getElementById("permit-hearing-result");
 const permitSummary = document.getElementById("permit-summary");
 const permitDocumentsList = document.getElementById("permit-documents-list");
 const permitTasksList = document.getElementById("permit-tasks-list");
+const permitApplyDocumentsBtn = document.getElementById("permit-apply-documents-btn");
+const permitApplyTasksBtn = document.getElementById("permit-apply-tasks-btn");
+let lastPermitGenerated = null;
 
 const saleForm = document.getElementById("sale-form");
 const saleCaseSelect = document.getElementById("sale-case-id");
@@ -429,9 +436,9 @@ let eventsBound = false;
 let loadingCount = 0;
 let loadingTimer = null;
 let isApplyingAuthState = false;
-const BACKUP_TABLE_KEYS = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_INSERT_ORDER = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "sales", "expenses", "fixed_expenses", "daily_reports", "case_documents", "case_tasks", "estimates", "cases", "work_templates", "clients", "app_settings"];
+const BACKUP_TABLE_KEYS = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_INSERT_ORDER = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "sales", "expenses", "fixed_expenses", "daily_reports", "permit_hearings", "case_documents", "case_tasks", "estimates", "cases", "work_templates", "clients", "app_settings"];
 const CASE_MUTATION_COLUMNS = [
   "user_id",
   "client_id",
@@ -530,6 +537,8 @@ function bindEvents() {
   caseTaskForm?.addEventListener("submit", handleCaseTaskSubmit);
   caseDocumentForm?.addEventListener("submit", handleCaseDocumentSubmit);
   permitHearingForm?.addEventListener("submit", handlePermitHearingSubmit);
+  if (permitApplyDocumentsBtn) permitApplyDocumentsBtn.dataset.action = "apply_permit_documents";
+  if (permitApplyTasksBtn) permitApplyTasksBtn.dataset.action = "apply_permit_tasks";
   workTemplateForm?.addEventListener("submit", handleWorkTemplateSubmit);
   console.log("SALE FORM FOUND", !!saleForm);
   console.log("EXPENSE FORM FOUND", !!expenseForm);
@@ -708,9 +717,15 @@ const PERMIT_SCENARIO_MASTER = {
   kobutsu_solo: { label: "大阪府警 古物商許可 新規 個人", docs: ["本人住民票", "身分証明書", "URL使用権限疎明資料（該当時）", "営業所の賃貸借契約書", "略歴書"], tasks: ["欠格要件確認", "営業所情報確認", "必要書類回収", "申請書作成", "警察署へ提出"] },
 };
 
-function handlePermitHearingSubmit(event) {
+async function handlePermitHearingSubmit(event) {
   event.preventDefault();
   const formData = new FormData(event.currentTarget);
+  const caseId = String(formData.get("permitCaseId") || "");
+  const linkedCase = state.cases.find((entry) => entry.id === caseId);
+  if (!currentUser || !caseId || !linkedCase) {
+    showAppMessage("案件選択は必須です。", true);
+    return;
+  }
   const scenarioKey = String(formData.get("permitScenario") || "construction_corp");
   const scenario = PERMIT_SCENARIO_MASTER[scenarioKey] || PERMIT_SCENARIO_MASTER.construction_corp;
   const applicantName = String(formData.get("permitApplicantName") || "").trim() || "（未入力）";
@@ -723,6 +738,50 @@ function handlePermitHearingSubmit(event) {
   permitDocumentsList.innerHTML = scenario.docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
   permitTasksList.innerHTML = scenario.tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
   permitResult.hidden = false;
+  lastPermitGenerated = { caseId, customerName: linkedCase.customerName, caseName: linkedCase.caseName, docs: [...scenario.docs], tasks: [...scenario.tasks] };
+  const { error } = await sbClient.from("permit_hearings").insert({
+    user_id: currentUser.id,
+    case_id: caseId,
+    client_id: linkedCase.clientId || null,
+    permit_category: scenario.label,
+    application_type: "新規",
+    jurisdiction_prefecture: "大阪府",
+    applicant_type: scenarioKey.endsWith("_corp") ? "法人" : "個人",
+    applicant_name: applicantName === "（未入力）" ? null : applicantName,
+    office_address: officeAddress === "（未入力）" ? null : officeAddress,
+    officer_count: officerCount,
+    qualified_person_count: qualifiedCount,
+    online_application: online === "希望する",
+    urgency,
+    answers: { permitScenario: scenarioKey, permitApplicantName: applicantName, permitOfficeAddress: officeAddress },
+    generated_documents: scenario.docs,
+    generated_tasks: scenario.tasks,
+    source_urls: [],
+  });
+  if (error) return showAppMessage(`許認可ヒアリング保存エラー: ${formatSupabaseError(error)}`, true);
+  await loadPermitHearings();
+}
+
+async function applyPermitDocumentsToCase() {
+  if (!currentUser || !lastPermitGenerated?.caseId) return;
+  const existing = new Set(state.caseDocuments.filter((d) => d.caseId === lastPermitGenerated.caseId).map((d) => String(d.documentName || "").trim()));
+  const payload = lastPermitGenerated.docs.filter((name) => !existing.has(name)).map((name) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, document_name: name, status: "未回収" }));
+  if (!payload.length) return showAppMessage("同一案件に同名書類があるため追加対象はありません。", false);
+  const { error } = await sbClient.from("case_documents").insert(payload);
+  if (error) return showAppMessage(`書類反映エラー: ${formatSupabaseError(error)}`, true);
+  await loadCaseDocuments();
+  safeRender("cases", renderCaseDocuments);
+}
+
+async function applyPermitTasksToCase() {
+  if (!currentUser || !lastPermitGenerated?.caseId) return;
+  const existing = new Set(state.caseTasks.filter((t) => t.caseId === lastPermitGenerated.caseId).map((t) => String(t.title || "").trim()));
+  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({ user_id: currentUser.id, case_id: lastPermitGenerated.caseId, customer_name: lastPermitGenerated.customerName, case_name: lastPermitGenerated.caseName, title, status: "未完了" }));
+  if (!payload.length) return showAppMessage("同一案件に同名タスクがあるため追加対象はありません。", false);
+  const { error } = await sbClient.from("case_tasks").insert(payload);
+  if (error) return showAppMessage(`タスク反映エラー: ${formatSupabaseError(error)}`, true);
+  await loadCaseTasks();
+  safeRender("cases", renderCaseTasks);
 }
 
 function handleDeadlineAlertClick(event) {
@@ -1019,6 +1078,25 @@ async function loadCaseDocuments() {
   }
 }
 
+async function loadPermitHearings() {
+  if (!currentUser || isLoggingOut) {
+    state.permitHearings = [];
+    return;
+  }
+  try {
+    const { data, error } = await sbClient.from("permit_hearings").select("*").eq("user_id", currentUser.id);
+    if (error) {
+      console.error("LOAD permitHearings ERROR", error);
+      state.permitHearings = [];
+      return;
+    }
+    state.permitHearings = data || [];
+  } catch (error) {
+    console.error("LOAD permitHearings ERROR", error);
+    state.permitHearings = [];
+  }
+}
+
 async function loadEstimates() {
   if (!currentUser || isLoggingOut) {
     state.estimates = [];
@@ -1213,6 +1291,7 @@ async function loadAllDataSafely() {
     ["cases", loadCases],
     ["caseTasks", loadCaseTasks],
     ["caseDocuments", loadCaseDocuments],
+    ["permitHearings", loadPermitHearings],
     ["estimates", loadEstimates],
     ["estimateItems", loadEstimateItems],
     ["sales", loadSales],
@@ -3599,6 +3678,7 @@ function handleExportBackupJson(event) {
       expenses: backup.data.expenses.length,
       daily_reports: backup.data.daily_reports.length,
       case_documents: backup.data.case_documents.length,
+      permit_hearings: backup.data.permit_hearings.length,
       payments: backup.data.payments.length,
       case_tasks: backup.data.case_tasks.length,
       app_settings: backup.data.app_settings.length,
@@ -3668,6 +3748,7 @@ function buildBackupJson() {
       work_templates: Array.isArray(state.workTemplates) ? state.workTemplates : [],
       case_tasks: Array.isArray(state.caseTasks) ? state.caseTasks : [],
       case_documents: Array.isArray(state.caseDocuments) ? state.caseDocuments : [],
+      permit_hearings: Array.isArray(state.permitHearings) ? state.permitHearings : [],
       app_settings: state.appSettings?.id ? [{
         id: state.appSettings.id,
         user_id: currentUser?.id || state.appSettings.userId || null,
@@ -5447,6 +5528,11 @@ function renderCaseOptions() {
     const currentValue = caseDocumentCaseSelect.value;
     caseDocumentCaseSelect.innerHTML = `<option value="">案件なし</option>${options}`;
     if (currentValue) caseDocumentCaseSelect.value = currentValue;
+  }
+  if (permitCaseSelect) {
+    const currentValue = permitCaseSelect.value;
+    permitCaseSelect.innerHTML = `<option value="">案件を選択してください</option>${options}`;
+    if (currentValue) permitCaseSelect.value = currentValue;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -822,6 +822,10 @@
               <h2>許認可ヒアリング</h2>
               <form id="permit-hearing-form" class="form">
                 <label>
+                  案件選択
+                  <select id="permit-case-id" name="permitCaseId"></select>
+                </label>
+                <label>
                   v1対象業務
                   <select id="permit-scenario" name="permitScenario" required>
                     <option value="construction_corp">大阪府 建設業許可 知事許可 新規 法人</option>
@@ -857,6 +861,10 @@
                 <ul id="permit-documents-list" class="item-list compact-list"></ul>
                 <h4>想定タスク</h4>
                 <ul id="permit-tasks-list" class="item-list compact-list"></ul>
+                <div class="csv-actions">
+                  <button id="permit-apply-documents-btn" type="button">案件書類に反映</button>
+                  <button id="permit-apply-tasks-btn" type="button">案件タスクに反映</button>
+                </div>
               </div>
             </section>
           </div>

--- a/index.html
+++ b/index.html
@@ -588,6 +588,7 @@
             <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="alerts">アラート</button>
             <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="tasks">タスク管理</button>
             <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="documents">書類管理</button>
+            <button type="button" class="subtab-btn" data-parent-tab="cases" data-subtab="permit-hearing">許認可ヒアリング</button>
           </nav>
           <div class="layout two-col">
             <section class="panel subtab-panel" data-parent-tab="cases" data-subtab="entry" hidden>
@@ -815,6 +816,47 @@
                   </thead>
                   <tbody id="case-documents-body"></tbody>
                 </table>
+              </div>
+            </section>
+            <section class="panel subtab-panel" data-parent-tab="cases" data-subtab="permit-hearing" hidden>
+              <h2>許認可ヒアリング</h2>
+              <form id="permit-hearing-form" class="form">
+                <label>
+                  v1対象業務
+                  <select id="permit-scenario" name="permitScenario" required>
+                    <option value="construction_corp">大阪府 建設業許可 知事許可 新規 法人</option>
+                    <option value="construction_solo">大阪府 建設業許可 知事許可 新規 個人</option>
+                    <option value="takken_corp">大阪府 宅建業免許 新規 法人</option>
+                    <option value="takken_solo">大阪府 宅建業免許 新規 個人</option>
+                    <option value="kobutsu_corp">大阪府警 古物商許可 新規 法人</option>
+                    <option value="kobutsu_solo">大阪府警 古物商許可 新規 個人</option>
+                  </select>
+                </label>
+                <label>申請者名<input id="permit-applicant-name" name="permitApplicantName" type="text" maxlength="120" /></label>
+                <label>営業所所在地<input id="permit-office-address" name="permitOfficeAddress" type="text" maxlength="200" /></label>
+                <label>役員・従業員数<input id="permit-officer-count" name="permitOfficerCount" type="number" min="0" value="0" /></label>
+                <label>有資格者数<input id="permit-qualified-count" name="permitQualifiedCount" type="number" min="0" value="0" /></label>
+                <label>オンライン申請希望
+                  <select id="permit-online-application" name="permitOnlineApplication">
+                    <option value="false">希望しない</option>
+                    <option value="true">希望する</option>
+                  </select>
+                </label>
+                <label>優先度
+                  <select id="permit-urgency" name="permitUrgency">
+                    <option value="通常">通常</option>
+                    <option value="急ぎ">急ぎ</option>
+                  </select>
+                </label>
+                <button id="permit-generate-btn" type="submit">必要書類・タスクを生成</button>
+              </form>
+              <div id="permit-hearing-result" class="permit-result" hidden>
+                <h3>生成結果</h3>
+                <p id="permit-summary"></p>
+                <h4>必要書類</h4>
+                <ul id="permit-documents-list" class="item-list compact-list"></ul>
+                <h4>想定タスク</h4>
+                <ul id="permit-tasks-list" class="item-list compact-list"></ul>
               </div>
             </section>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1158,3 +1158,7 @@ input[type="number"] {
   .daily-report-card-actions { width: 100%; justify-content: flex-start; }
   .daily-report-card-actions button { flex: 1 1 auto; }
 }
+
+.permit-result { margin-top: 16px; }
+.compact-list li { margin: 4px 0; }
+


### PR DESCRIPTION
### Motivation
- 既存の案件管理内に許認可向けヒアリング機能を追加し、v1対象（建設業許可・宅建業免許・古物商許可の法人/個人 計6パターン）で必要書類および想定タスクを簡易生成できるようにするための変更です。 
- 既存機能やDBを破壊せずに、案件ワークフロー内でヒアリング→書類/タスク生成までを手早く行えるUIを提供するためです。

### Description
- `index.html` に `cases` タブのサブタブとして `許認可ヒアリング` を追加し、対象業務選択・申請者情報入力・オンライン申請や優先度などのフォームと生成結果表示領域を追加しました。 
- `app.js` にDOM参照とイベントバインドを追加し、`PERMIT_SCENARIO_MASTER`（v1の6パターンのラベル・必要書類・想定タスク）と `handlePermitHearingSubmit` を実装して、入力に応じた要約文と書類/タスクリストを生成・表示する処理を追加しました。 
- `styles.css` に生成結果表示用の軽微なスタイル（`.permit-result`, `.compact-list`）を追加しました。 
- 指定の `permit_hearings` テーブル作成SQL と RLSポリシーを `README.md` に追記しました（DBの既存テーブルやカラムは破壊的に変更していません）。

### Testing
- `node --check app.js` を実行し、構文エラーがないことを確認しました（成功）。
- 本変更に関する自動化されたユニットテストは追加しておらず、UI動作はブラウザ上での確認が必要です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5451008c88333bfdcced6a8aaec36)