### PR TITLE
許認可ヒアリング履歴一覧と再表示機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -768,6 +768,7 @@ async function handlePermitHearingSubmit(event) {
   });
   if (error) return showAppMessage(`許認可ヒアリング保存エラー: ${formatSupabaseError(error)}`, true);
   await loadPermitHearings();
+  renderPermitHearings();
 }
 
 function renderPermitGeneratedResult(payload) {

--- a/app.js
+++ b/app.js
@@ -111,6 +111,7 @@ const CLICK_ACTION_HANDLERS = {
   export_backup_json: handleExportBackupJson,
   apply_permit_documents: applyPermitDocumentsToCase,
   apply_permit_tasks: applyPermitTasksToCase,
+  view_saved_permit_hearing: handleViewSavedPermitHearing,
   add_estimate_item_row: () => addEstimateItemRow(),
   remove_estimate_item_row: handleEstimateItemsClick,
   status_summary_filter: handleStatusSummaryClick,
@@ -362,6 +363,9 @@ const permitDocumentsList = document.getElementById("permit-documents-list");
 const permitTasksList = document.getElementById("permit-tasks-list");
 const permitApplyDocumentsBtn = document.getElementById("permit-apply-documents-btn");
 const permitApplyTasksBtn = document.getElementById("permit-apply-tasks-btn");
+const permitHearingsBody = document.getElementById("permit-hearings-body");
+const permitHearingsEmpty = document.getElementById("permit-hearings-empty");
+const permitHearingsListWrap = document.getElementById("permit-hearings-list-wrap");
 let lastPermitGenerated = null;
 
 const saleForm = document.getElementById("sale-form");
@@ -734,10 +738,11 @@ async function handlePermitHearingSubmit(event) {
   const qualifiedCount = Number(formData.get("permitQualifiedCount") || 0);
   const online = String(formData.get("permitOnlineApplication") || "false") === "true" ? "希望する" : "希望しない";
   const urgency = String(formData.get("permitUrgency") || "通常");
-  permitSummary.textContent = `${scenario.label} / 申請者: ${applicantName} / 所在地: ${officeAddress} / 人員: ${officerCount}名 / 有資格者: ${qualifiedCount}名 / 電子申請: ${online} / 優先度: ${urgency}`;
-  permitDocumentsList.innerHTML = scenario.docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
-  permitTasksList.innerHTML = scenario.tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
-  permitResult.hidden = false;
+  renderPermitGeneratedResult({
+    summary: `${scenario.label} / 申請者: ${applicantName} / 所在地: ${officeAddress} / 人員: ${officerCount}名 / 有資格者: ${qualifiedCount}名 / 電子申請: ${online} / 優先度: ${urgency}`,
+    docs: scenario.docs,
+    tasks: scenario.tasks,
+  });
   const linkedCustomerName = linkedCase.customer_name ?? linkedCase.customerName ?? "";
   const linkedCaseName = linkedCase.case_name ?? linkedCase.caseName ?? "";
   const linkedClientId = linkedCase.client_id ?? linkedCase.clientId ?? null;
@@ -763,6 +768,36 @@ async function handlePermitHearingSubmit(event) {
   });
   if (error) return showAppMessage(`許認可ヒアリング保存エラー: ${formatSupabaseError(error)}`, true);
   await loadPermitHearings();
+}
+
+function renderPermitGeneratedResult(payload) {
+  if (!payload || !permitSummary || !permitDocumentsList || !permitTasksList || !permitResult) return;
+  const summary = payload.summary || "";
+  const docs = Array.isArray(payload.docs) ? payload.docs : [];
+  const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+  permitSummary.textContent = summary;
+  permitDocumentsList.innerHTML = docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
+  permitTasksList.innerHTML = tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
+  permitResult.hidden = false;
+}
+
+function handleViewSavedPermitHearing(event, button) {
+  const hearingId = button?.dataset?.permitHearingId;
+  if (!hearingId) return;
+  const hearing = (Array.isArray(state.permitHearings) ? state.permitHearings : []).find((entry) => String(entry.id) === String(hearingId));
+  if (!hearing) return;
+  const linkedCase = state.cases.find((entry) => entry.id === (hearing.case_id ?? hearing.caseId));
+  const docs = Array.isArray(hearing.generated_documents) ? hearing.generated_documents : [];
+  const tasks = Array.isArray(hearing.generated_tasks) ? hearing.generated_tasks : [];
+  const summary = `${hearing.permit_category || "許認可未設定"} / 申請者: ${hearing.applicant_name || "（未入力）"} / 所在地: ${hearing.office_address || "（未入力）"} / 人員: ${Number(hearing.officer_count || 0)}名 / 有資格者: ${Number(hearing.qualified_person_count || 0)}名 / 電子申請: ${hearing.online_application ? "希望する" : "希望しない"} / 優先度: ${hearing.urgency || "通常"}`;
+  renderPermitGeneratedResult({ summary, docs, tasks });
+  lastPermitGenerated = {
+    case_id: hearing.case_id ?? hearing.caseId ?? "",
+    customer_name: linkedCase?.customerName ?? linkedCase?.customer_name ?? "",
+    case_name: linkedCase?.caseName ?? linkedCase?.case_name ?? "",
+    docs: [...docs],
+    tasks: [...tasks],
+  };
 }
 
 async function applyPermitDocumentsToCase() {
@@ -5631,6 +5666,30 @@ function renderCaseDocuments() {
   });
 }
 
+function renderPermitHearings() {
+  if (!permitHearingsBody || !permitHearingsEmpty || !permitHearingsListWrap) return;
+  const rows = (Array.isArray(state.permitHearings) ? state.permitHearings : [])
+    .slice()
+    .sort((a, b) => toSortTimestamp(b.created_at || b.createdAt) - toSortTimestamp(a.created_at || a.createdAt));
+  permitHearingsBody.innerHTML = "";
+  permitHearingsEmpty.hidden = rows.length > 0;
+  permitHearingsListWrap.hidden = rows.length === 0;
+  rows.forEach((entry) => {
+    const linkedCase = state.cases.find((row) => row.id === (entry.case_id ?? entry.caseId));
+    const caseName = linkedCase?.caseName ?? linkedCase?.case_name ?? "案件不明";
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${formatDate(entry.created_at || entry.createdAt)}</td>
+      <td>${escapeHtml(caseName)}</td>
+      <td>${escapeHtml(entry.applicant_name || "（未入力）")}</td>
+      <td>${escapeHtml(entry.permit_category || "未設定")}</td>
+      <td>${escapeHtml(entry.urgency || "通常")}</td>
+      <td><button type="button" class="secondary-btn" data-action="view_saved_permit_hearing" data-permit-hearing-id="${entry.id}">表示</button></td>
+    `;
+    permitHearingsBody.appendChild(tr);
+  });
+}
+
 function renderWorkTemplateOptions() {
   if (!caseTemplateSelect) return;
   const currentValue = caseTemplateSelect.value;
@@ -6519,6 +6578,7 @@ function renderCases() {
   } else {
     caseEmpty.textContent = "案件はまだ登録されていません。";
   }
+  renderPermitHearings();
 }
 
 function renderCaseProfitList(filter = {}) {

--- a/index.html
+++ b/index.html
@@ -866,6 +866,25 @@
                   <button id="permit-apply-tasks-btn" type="button">案件タスクに反映</button>
                 </div>
               </div>
+              <div class="permit-history-wrap">
+                <h3>保存済みヒアリング履歴</h3>
+                <div id="permit-hearings-empty" class="empty">保存済みヒアリング履歴はまだありません。</div>
+                <div id="permit-hearings-list-wrap" class="table-wrap" hidden>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>作成日</th>
+                        <th>案件名</th>
+                        <th>申請者名</th>
+                        <th>許認可種別</th>
+                        <th>優先度</th>
+                        <th>表示</th>
+                      </tr>
+                    </thead>
+                    <tbody id="permit-hearings-body"></tbody>
+                  </table>
+                </div>
+              </div>
             </section>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- permit_hearings に保存されたヒアリング履歴を案件タブ > 許認可ヒアリング画面で参照・再利用できるようにするため。
- 保存済みの `generated_documents` / `generated_tasks` を画面に再表示し、既存の書類/タスク反映処理を再利用できるようにするため。

### Description
- 画面：`index.html` に「保存済みヒアリング履歴」テーブルを追加し、`作成日 / 案件名 / 申請者名 / 許認可種別 / 優先度 / 表示` を表示するUIを実装した。 (`#permit-hearings-list-wrap`, `#permit-hearings-body`)。
- 描画：`app.js` に `renderPermitHearings()` を追加して `state.permitHearings` を一覧表示するようにした（新しい順、空状態表示あり）。
- 再表示：`handleViewSavedPermitHearing` ハンドラを追加し、履歴の「表示」ボタンで保存済みの `generated_documents` / `generated_tasks` を `renderPermitGeneratedResult` を通じて再表示し、`lastPermitGenerated` を復元して既存の `applyPermitDocumentsToCase` / `applyPermitTasksToCase` をそのまま使えるようにした。
- 統合：クリックハンドラマップに `view_saved_permit_hearing` を登録し、`renderCases()` の末尾で `renderPermitHearings()` を呼ぶよう連携して既存描画フローを壊さないようにした。
- 既存ロジック：重複追加防止（同名書類/タスクのチェック）やDBスキーマはそのまま維持し、破壊的なDB変更は行っていない。

### Testing
- 実行：`node --check app.js` を実行し、構文エラーがないことを確認済み（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d8732ca883339a9b6f156278f25e)