### PR TITLE
保存済みヒアリング表示のUX改善とフィールド互換対応

### DIFF
--- a/app.js
+++ b/app.js
@@ -777,8 +777,12 @@ function renderPermitGeneratedResult(payload) {
   const docs = Array.isArray(payload.docs) ? payload.docs : [];
   const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
   permitSummary.textContent = summary;
-  permitDocumentsList.innerHTML = docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("");
-  permitTasksList.innerHTML = tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("");
+  permitDocumentsList.innerHTML = docs.length
+    ? docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("")
+    : "<li>保存済み書類がありません。</li>";
+  permitTasksList.innerHTML = tasks.length
+    ? tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("")
+    : "<li>保存済みタスクがありません。</li>";
   permitResult.hidden = false;
 }
 
@@ -786,14 +790,21 @@ function handleViewSavedPermitHearing(event, button) {
   const hearingId = button?.dataset?.permitHearingId;
   if (!hearingId) return;
   const hearing = (Array.isArray(state.permitHearings) ? state.permitHearings : []).find((entry) => String(entry.id) === String(hearingId));
-  if (!hearing) return;
-  const linkedCase = state.cases.find((entry) => entry.id === (hearing.case_id ?? hearing.caseId));
-  const docs = Array.isArray(hearing.generated_documents) ? hearing.generated_documents : [];
-  const tasks = Array.isArray(hearing.generated_tasks) ? hearing.generated_tasks : [];
+  if (!hearing) return showAppMessage("対象のヒアリング履歴が見つかりません。", true);
+  const hearingCaseId = hearing.case_id ?? hearing.caseId;
+  const linkedCase = state.cases.find((entry) => String(entry.id) === String(hearingCaseId));
+  const docs = Array.isArray(hearing.generated_documents)
+    ? hearing.generated_documents
+    : (Array.isArray(hearing.generatedDocuments) ? hearing.generatedDocuments : []);
+  const tasks = Array.isArray(hearing.generated_tasks)
+    ? hearing.generated_tasks
+    : (Array.isArray(hearing.generatedTasks) ? hearing.generatedTasks : []);
   const summary = `${hearing.permit_category || "許認可未設定"} / 申請者: ${hearing.applicant_name || "（未入力）"} / 所在地: ${hearing.office_address || "（未入力）"} / 人員: ${Number(hearing.officer_count || 0)}名 / 有資格者: ${Number(hearing.qualified_person_count || 0)}名 / 電子申請: ${hearing.online_application ? "希望する" : "希望しない"} / 優先度: ${hearing.urgency || "通常"}`;
   renderPermitGeneratedResult({ summary, docs, tasks });
+  permitResult?.scrollIntoView({ behavior: "smooth", block: "start" });
+  showAppMessage("保存済みヒアリングを表示しました。", false);
   lastPermitGenerated = {
-    case_id: hearing.case_id ?? hearing.caseId ?? "",
+    case_id: hearingCaseId ?? "",
     customer_name: linkedCase?.customerName ?? linkedCase?.customer_name ?? "",
     case_name: linkedCase?.caseName ?? linkedCase?.case_name ?? "",
     docs: [...docs],


### PR DESCRIPTION
### Motivation
- 保存済みヒアリングの「表示」操作で画面に反応が分かりにくかったため、表示フィードバックとデータキー互換性を改善する変更を行いました。

### Description
- `app.js` の `handleViewSavedPermitHearing()` を更新し、`generated_documents` / `generatedDocuments` と `generated_tasks` / `generatedTasks` の両方を受け取れるようにしました。 
- `case_id` / `caseId` の両方に対応するようケースID取得ロジックを追加しました。 
- 「表示」押下後に `renderPermitGeneratedResult()` で再描画したあとに `permitResult.scrollIntoView({ behavior: "smooth", block: "start" })` を実行し、成功メッセージ `showAppMessage("保存済みヒアリングを表示しました。", false)` を表示するようにしました。 
- `renderPermitGeneratedResult()` を修正して、docs/tasks が空の場合でも `保存済み書類がありません。` / `保存済みタスクがありません。` を表示するようにして無反応にならないようにしました。 
- 既存の書類・タスク反映処理および重複防止ロジック（`applyPermitDocumentsToCase` / `applyPermitTasksToCase`）は変更していません。 
- 変更ファイル: `app.js` の該当箇所（`handleViewSavedPermitHearing`, `renderPermitGeneratedResult`）。

### Testing
- `node --check app.js` による構文チェックを実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5de4076e88333ac1369e4d794ed41)