### PR TITLE
許認可ヒアリング生成結果の編集UIを追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -361,6 +361,8 @@ const permitResult = document.getElementById("permit-hearing-result");
 const permitSummary = document.getElementById("permit-summary");
 const permitDocumentsList = document.getElementById("permit-documents-list");
 const permitTasksList = document.getElementById("permit-tasks-list");
+const permitAddDocumentBtn = document.getElementById("permit-add-document-btn");
+const permitAddTaskBtn = document.getElementById("permit-add-task-btn");
 const permitApplyDocumentsBtn = document.getElementById("permit-apply-documents-btn");
 const permitApplyTasksBtn = document.getElementById("permit-apply-tasks-btn");
 const permitHearingsBody = document.getElementById("permit-hearings-body");
@@ -541,6 +543,12 @@ function bindEvents() {
   caseTaskForm?.addEventListener("submit", handleCaseTaskSubmit);
   caseDocumentForm?.addEventListener("submit", handleCaseDocumentSubmit);
   permitHearingForm?.addEventListener("submit", handlePermitHearingSubmit);
+  permitDocumentsList?.addEventListener("input", syncPermitGeneratedFromInputs);
+  permitTasksList?.addEventListener("input", syncPermitGeneratedFromInputs);
+  permitDocumentsList?.addEventListener("click", handlePermitGeneratedListClick);
+  permitTasksList?.addEventListener("click", handlePermitGeneratedListClick);
+  permitAddDocumentBtn?.addEventListener("click", () => addPermitGeneratedItem("docs"));
+  permitAddTaskBtn?.addEventListener("click", () => addPermitGeneratedItem("tasks"));
   if (permitApplyDocumentsBtn) permitApplyDocumentsBtn.dataset.action = "apply_permit_documents";
   if (permitApplyTasksBtn) permitApplyTasksBtn.dataset.action = "apply_permit_tasks";
   workTemplateForm?.addEventListener("submit", handleWorkTemplateSubmit);
@@ -778,12 +786,53 @@ function renderPermitGeneratedResult(payload) {
   const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
   permitSummary.textContent = summary;
   permitDocumentsList.innerHTML = docs.length
-    ? docs.map((doc) => `<li>${escapeHtml(doc)}</li>`).join("")
+    ? docs.map((doc) => `<li class="permit-edit-row"><input type="text" data-permit-field="docs" value="${escapeHtml(doc)}" /><button type="button" class="danger-btn" data-permit-delete="docs">削除</button></li>`).join("")
     : "<li>保存済み書類がありません。</li>";
   permitTasksList.innerHTML = tasks.length
-    ? tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join("")
+    ? tasks.map((task) => `<li class=\"permit-edit-row\"><input type=\"text\" data-permit-field=\"tasks\" value=\"${escapeHtml(task)}\" /><button type=\"button\" class=\"danger-btn\" data-permit-delete=\"tasks\">削除</button></li>`).join("")
     : "<li>保存済みタスクがありません。</li>";
   permitResult.hidden = false;
+  syncPermitGeneratedFromInputs();
+}
+
+function collectPermitGeneratedValues(type) {
+  const root = type === "docs" ? permitDocumentsList : permitTasksList;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll(`input[data-permit-field="${type}"]`))
+    .map((input) => String(input.value || "").trim())
+    .filter(Boolean);
+}
+
+function syncPermitGeneratedFromInputs() {
+  if (!lastPermitGenerated) return;
+  lastPermitGenerated.docs = collectPermitGeneratedValues("docs");
+  lastPermitGenerated.tasks = collectPermitGeneratedValues("tasks");
+}
+
+function addPermitGeneratedItem(type) {
+  const root = type === "docs" ? permitDocumentsList : permitTasksList;
+  if (!root) return;
+  const emptyLabel = type === "docs" ? "保存済み書類がありません。" : "保存済みタスクがありません。";
+  if (root.children.length === 1 && !root.querySelector(`input[data-permit-field="${type}"]`) && root.textContent.includes(emptyLabel)) root.innerHTML = "";
+  const li = document.createElement("li");
+  li.className = "permit-edit-row";
+  li.innerHTML = `<input type="text" data-permit-field="${type}" value="" /><button type="button" class="danger-btn" data-permit-delete="${type}">削除</button>`;
+  root.appendChild(li);
+  syncPermitGeneratedFromInputs();
+  li.querySelector("input")?.focus();
+}
+
+function handlePermitGeneratedListClick(event) {
+  const button = event.target.closest("button[data-permit-delete]");
+  if (!(button instanceof HTMLButtonElement)) return;
+  const targetType = button.dataset.permitDelete;
+  const li = button.closest("li");
+  if (li) li.remove();
+  const root = targetType === "docs" ? permitDocumentsList : permitTasksList;
+  if (root && !root.querySelector(`input[data-permit-field="${targetType}"]`)) {
+    root.innerHTML = `<li>${targetType === "docs" ? "保存済み書類がありません。" : "保存済みタスクがありません。"}</li>`;
+  }
+  syncPermitGeneratedFromInputs();
 }
 
 function handleViewSavedPermitHearing(event, button) {
@@ -814,10 +863,11 @@ function handleViewSavedPermitHearing(event, button) {
 
 async function applyPermitDocumentsToCase() {
   if (!currentUser || !lastPermitGenerated?.case_id) return;
+  syncPermitGeneratedFromInputs();
   const existing = new Set(state.caseDocuments
     .filter((d) => (d.case_id ?? d.caseId) === lastPermitGenerated.case_id)
     .map((d) => String((d.document_name ?? d.documentName) || "").trim()));
-  const payload = lastPermitGenerated.docs.filter((name) => !existing.has(name)).map((name) => ({
+  const payload = lastPermitGenerated.docs.filter((name) => name && !existing.has(name)).map((name) => ({
     user_id: currentUser.id,
     case_id: lastPermitGenerated.case_id,
     document_name: name,
@@ -836,11 +886,12 @@ async function applyPermitDocumentsToCase() {
 
 async function applyPermitTasksToCase() {
   if (!currentUser || !lastPermitGenerated?.case_id) return;
+  syncPermitGeneratedFromInputs();
   const existing = new Set(state.caseTasks
     .filter((t) => (t.case_id ?? t.caseId) === lastPermitGenerated.case_id)
     .map((t) => String((t.task_title ?? t.taskTitle) || "").trim()));
   // case_tasks の実カラム名は task_title（既存の登録・表示・CSV・取込処理と同一）
-  const payload = lastPermitGenerated.tasks.filter((title) => !existing.has(title)).map((title) => ({
+  const payload = lastPermitGenerated.tasks.filter((title) => title && !existing.has(title)).map((title) => ({
     user_id: currentUser.id,
     case_id: lastPermitGenerated.case_id,
     task_title: title,

--- a/app.js
+++ b/app.js
@@ -789,7 +789,7 @@ function renderPermitGeneratedResult(payload) {
     ? docs.map((doc) => `<li class="permit-edit-row"><input type="text" data-permit-field="docs" value="${escapeHtml(doc)}" /><button type="button" class="danger-btn" data-permit-delete="docs">削除</button></li>`).join("")
     : "<li>保存済み書類がありません。</li>";
   permitTasksList.innerHTML = tasks.length
-    ? tasks.map((task) => `<li class=\"permit-edit-row\"><input type=\"text\" data-permit-field=\"tasks\" value=\"${escapeHtml(task)}\" /><button type=\"button\" class=\"danger-btn\" data-permit-delete=\"tasks\">削除</button></li>`).join("")
+    ? tasks.map((task) => `<li class="permit-edit-row"><input type="text" data-permit-field="tasks" value="${escapeHtml(task)}" /><button type="button" class="danger-btn" data-permit-delete="tasks">削除</button></li>`).join("")
     : "<li>保存済みタスクがありません。</li>";
   permitResult.hidden = false;
   syncPermitGeneratedFromInputs();

--- a/index.html
+++ b/index.html
@@ -858,8 +858,14 @@
                 <h3>生成結果</h3>
                 <p id="permit-summary"></p>
                 <h4>必要書類</h4>
+                <div class="permit-edit-actions">
+                  <button id="permit-add-document-btn" type="button" class="secondary-btn">書類を追加</button>
+                </div>
                 <ul id="permit-documents-list" class="item-list compact-list"></ul>
                 <h4>想定タスク</h4>
+                <div class="permit-edit-actions">
+                  <button id="permit-add-task-btn" type="button" class="secondary-btn">タスクを追加</button>
+                </div>
                 <ul id="permit-tasks-list" class="item-list compact-list"></ul>
                 <div class="csv-actions">
                   <button id="permit-apply-documents-btn" type="button">案件書類に反映</button>

--- a/styles.css
+++ b/styles.css
@@ -1160,5 +1160,13 @@ input[type="number"] {
 }
 
 .permit-result { margin-top: 16px; }
+.permit-edit-actions { margin: 8px 0; }
+.permit-edit-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.permit-edit-row input[type="text"] {
+  flex: 1;
+}
 .compact-list li { margin: 4px 0; }
-


### PR DESCRIPTION
### Motivation
- 保存済みヒアリングの表示結果（必要書類・想定タスク）を画面上で編集できるようにして、編集後の内容を案件の書類／タスクへ反映できるようにする。 
- 既存の重複防止・空行除外ロジックやDBスキーマは維持し、保存済みヒアリング自体のDBは今回更新しない。

### Description
- `index.html` に「書類を追加」「タスクを追加」ボタンを追加して、編集行の追加を可能にしました。 
- `app.js` の `renderPermitGeneratedResult()` を変更し、表示専用の `<li>` から1行1入力の `input` 行（削除ボタン付き）へ置換して編集可能にしました。 
- 編集内容を `lastPermitGenerated.docs` / `lastPermitGenerated.tasks` に同期する `syncPermitGeneratedFromInputs()` と、行追加 (`addPermitGeneratedItem`)・行削除ハンドラ (`handlePermitGeneratedListClick`) を追加しました。 
- 「案件書類に反映」「案件タスクに反映」処理は編集後の配列を使用するようにし、空行は除外、既存の同名重複チェックは従来どおり適用しています（`case_documents` / `case_tasks` への送信項目は従来通りで `customer_name` / `case_name` は送らない）。 
- `styles.css` に編集行用の最小スタイルを追加し、既存の書類／タスク管理機能を壊さないようイベントバインドを最小限に実装しました. 
- 変更対象ファイル: `app.js`, `index.html`, `styles.css`.

### Testing
- `node --check app.js` を実行して構文チェックを行い、エラーは発生しませんでした（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e0888240833395cde6e933b14013)