### PR TITLE
許認可ヒアリング履歴の上書き保存機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -365,10 +365,12 @@ const permitAddDocumentBtn = document.getElementById("permit-add-document-btn");
 const permitAddTaskBtn = document.getElementById("permit-add-task-btn");
 const permitApplyDocumentsBtn = document.getElementById("permit-apply-documents-btn");
 const permitApplyTasksBtn = document.getElementById("permit-apply-tasks-btn");
+const permitOverwriteHearingBtn = document.getElementById("permit-overwrite-hearing-btn");
 const permitHearingsBody = document.getElementById("permit-hearings-body");
 const permitHearingsEmpty = document.getElementById("permit-hearings-empty");
 const permitHearingsListWrap = document.getElementById("permit-hearings-list-wrap");
 let lastPermitGenerated = null;
+let selectedPermitHearingId = null;
 
 const saleForm = document.getElementById("sale-form");
 const saleCaseSelect = document.getElementById("sale-case-id");
@@ -551,6 +553,7 @@ function bindEvents() {
   permitAddTaskBtn?.addEventListener("click", () => addPermitGeneratedItem("tasks"));
   if (permitApplyDocumentsBtn) permitApplyDocumentsBtn.dataset.action = "apply_permit_documents";
   if (permitApplyTasksBtn) permitApplyTasksBtn.dataset.action = "apply_permit_tasks";
+  if (permitOverwriteHearingBtn) permitOverwriteHearingBtn.addEventListener("click", handleOverwritePermitHearing);
   workTemplateForm?.addEventListener("submit", handleWorkTemplateSubmit);
   console.log("SALE FORM FOUND", !!saleForm);
   console.log("EXPENSE FORM FOUND", !!expenseForm);
@@ -755,6 +758,8 @@ async function handlePermitHearingSubmit(event) {
   const linkedCaseName = linkedCase.case_name ?? linkedCase.caseName ?? "";
   const linkedClientId = linkedCase.client_id ?? linkedCase.clientId ?? null;
   lastPermitGenerated = { case_id: caseId, customer_name: linkedCustomerName, case_name: linkedCaseName, docs: [...scenario.docs], tasks: [...scenario.tasks] };
+  selectedPermitHearingId = null;
+  setPermitOverwriteButtonState(false);
   const { error } = await sbClient.from("permit_hearings").insert({
     user_id: currentUser.id,
     case_id: caseId,
@@ -777,6 +782,11 @@ async function handlePermitHearingSubmit(event) {
   if (error) return showAppMessage(`許認可ヒアリング保存エラー: ${formatSupabaseError(error)}`, true);
   await loadPermitHearings();
   renderPermitHearings();
+}
+
+function setPermitOverwriteButtonState(enabled) {
+  if (!permitOverwriteHearingBtn) return;
+  permitOverwriteHearingBtn.disabled = !enabled;
 }
 
 function renderPermitGeneratedResult(payload) {
@@ -859,8 +869,36 @@ function handleViewSavedPermitHearing(event, button) {
     docs: [...docs],
     tasks: [...tasks],
   };
+  selectedPermitHearingId = hearing.id;
+  setPermitOverwriteButtonState(true);
 }
 
+
+async function handleOverwritePermitHearing() {
+  if (!currentUser || !selectedPermitHearingId) return;
+  if (!lastPermitGenerated) return showAppMessage("上書き対象データがありません。", true);
+  syncPermitGeneratedFromInputs();
+  const docs = Array.isArray(lastPermitGenerated.docs) ? lastPermitGenerated.docs : [];
+  const tasks = Array.isArray(lastPermitGenerated.tasks) ? lastPermitGenerated.tasks : [];
+  const selectedHearing = (Array.isArray(state.permitHearings) ? state.permitHearings : [])
+    .find((entry) => String(entry.id) === String(selectedPermitHearingId));
+  const payload = {
+    generated_documents: docs,
+    generated_tasks: tasks,
+  };
+  if (selectedHearing && Object.prototype.hasOwnProperty.call(selectedHearing, "updated_at")) {
+    payload.updated_at = new Date().toISOString();
+  }
+  const { error } = await sbClient
+    .from("permit_hearings")
+    .update(payload)
+    .eq("id", selectedPermitHearingId)
+    .eq("user_id", currentUser.id);
+  if (error) return showAppMessage(`ヒアリング履歴更新エラー: ${formatSupabaseError(error)}`, true);
+  await loadPermitHearings();
+  renderPermitHearings();
+  showAppMessage("ヒアリング履歴を更新しました。", false);
+}
 async function applyPermitDocumentsToCase() {
   if (!currentUser || !lastPermitGenerated?.case_id) return;
   syncPermitGeneratedFromInputs();

--- a/index.html
+++ b/index.html
@@ -868,6 +868,7 @@
                 </div>
                 <ul id="permit-tasks-list" class="item-list compact-list"></ul>
                 <div class="csv-actions">
+                  <button id="permit-overwrite-hearing-btn" type="button" class="secondary-btn" disabled>この履歴に上書き保存</button>
                   <button id="permit-apply-documents-btn" type="button">案件書類に反映</button>
                   <button id="permit-apply-tasks-btn" type="button">案件タスクに反映</button>
                 </div>


### PR DESCRIPTION
### Motivation
- 保存済みヒアリング履歴を表示して必要書類・想定タスクを編集した後、その編集内容を既存の `permit_hearings` レコードに上書き保存できるようにするため。 
- 新規生成直後は誤って既存レコードを上書きしないようにボタンを無効にし、保存済み履歴を表示したときだけ上書き可能にするため。
- 既存の案件書類反映・案件タスク反映やバックアップ機能、DBスキーマには影響を与えないようにするため。

### Description
- 生成結果エリアに `この履歴に上書き保存` ボタンを追加し初期状態を `disabled` にした（`index.html` を更新）。
- `app.js` にてボタンのDOM参照と `selectedPermitHearingId` 状態を導入し、イベントバインドで `handleOverwritePermitHearing` を紐付けた。 
- 新規生成時は `selectedPermitHearingId` をクリアしてボタンを無効化し、保存済み履歴を表示したときのみ `selectedPermitHearingId` をセットして有効化するロジックを追加した。 
- `handleOverwritePermitHearing` を実装し、編集中の `docs/tasks` を `permit_hearings.generated_documents` / `permit_hearings.generated_tasks` に上書き保存し、該当レコードに `updated_at` カラムが存在する場合のみ更新時刻を付与し、保存後に `loadPermitHearings()` と `renderPermitHearings()` を呼び出して成功メッセージを表示するようにした（変更ファイル: `app.js`, `index.html`）。

### Testing
- `node --check app.js` を実行して構文チェックは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f10b4eec83339299015e03f3d73f)