### PR TITLE
許認可ヒアリング履歴の削除機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,6 +112,7 @@ const CLICK_ACTION_HANDLERS = {
   apply_permit_documents: applyPermitDocumentsToCase,
   apply_permit_tasks: applyPermitTasksToCase,
   view_saved_permit_hearing: handleViewSavedPermitHearing,
+  delete_saved_permit_hearing: handleDeleteSavedPermitHearing,
   add_estimate_item_row: () => addEstimateItemRow(),
   remove_estimate_item_row: handleEstimateItemsClick,
   status_summary_filter: handleStatusSummaryClick,
@@ -789,6 +790,17 @@ function setPermitOverwriteButtonState(enabled) {
   permitOverwriteHearingBtn.disabled = !enabled;
 }
 
+function clearPermitGeneratedResult() {
+  if (!permitSummary || !permitDocumentsList || !permitTasksList || !permitResult) return;
+  permitSummary.textContent = "";
+  permitDocumentsList.innerHTML = "";
+  permitTasksList.innerHTML = "";
+  permitResult.hidden = true;
+  lastPermitGenerated = null;
+  selectedPermitHearingId = null;
+  setPermitOverwriteButtonState(false);
+}
+
 function renderPermitGeneratedResult(payload) {
   if (!payload || !permitSummary || !permitDocumentsList || !permitTasksList || !permitResult) return;
   const summary = payload.summary || "";
@@ -871,6 +883,27 @@ function handleViewSavedPermitHearing(event, button) {
   };
   selectedPermitHearingId = hearing.id;
   setPermitOverwriteButtonState(true);
+}
+
+async function handleDeleteSavedPermitHearing(event, button) {
+  const hearingId = button?.dataset?.permitHearingId;
+  if (!currentUser || !hearingId) return;
+  const hearing = (Array.isArray(state.permitHearings) ? state.permitHearings : []).find((entry) => String(entry.id) === String(hearingId));
+  if (!hearing) return showAppMessage("対象のヒアリング履歴が見つかりません。", true);
+  const confirmed = window.confirm("この保存済みヒアリング履歴を削除しますか？");
+  if (!confirmed) return;
+  const { error } = await sbClient
+    .from("permit_hearings")
+    .delete()
+    .eq("id", hearingId)
+    .eq("user_id", currentUser.id);
+  if (error) return showAppMessage(`ヒアリング履歴削除エラー: ${formatSupabaseError(error)}`, true);
+  await loadPermitHearings();
+  renderPermitHearings();
+  if (String(selectedPermitHearingId) === String(hearingId)) {
+    clearPermitGeneratedResult();
+  }
+  showAppMessage("ヒアリング履歴を削除しました。", false);
 }
 
 
@@ -5785,7 +5818,12 @@ function renderPermitHearings() {
       <td>${escapeHtml(entry.applicant_name || "（未入力）")}</td>
       <td>${escapeHtml(entry.permit_category || "未設定")}</td>
       <td>${escapeHtml(entry.urgency || "通常")}</td>
-      <td><button type="button" class="secondary-btn" data-action="view_saved_permit_hearing" data-permit-hearing-id="${entry.id}">表示</button></td>
+      <td>
+        <div class="btn-inline-group">
+          <button type="button" class="secondary-btn" data-action="view_saved_permit_hearing" data-permit-hearing-id="${entry.id}">表示</button>
+          <button type="button" class="danger-btn" data-action="delete_saved_permit_hearing" data-permit-hearing-id="${entry.id}">削除</button>
+        </div>
+      </td>
     `;
     permitHearingsBody.appendChild(tr);
   });


### PR DESCRIPTION
### Motivation
- 保存済みの許認可ヒアリング履歴をユーザが不要時に削除できるようにするための機能追加です。

### Description
- `app.js` に削除ボタンを追加して一覧に `削除` 操作を表示するようにしました（`renderPermitHearings` を更新）。
- クリック処理のハンドラマップに `delete_saved_permit_hearing` を追加し、`handleDeleteSavedPermitHearing` を実装して `permit_hearings` テーブルの該当レコードを削除する処理を追加しました。 
- 削除前に `window.confirm` で確認を取り、削除後に `loadPermitHearings()` と `renderPermitHearings()` を実行するようにしました。 
- 表示中の履歴を削除した場合に生成結果エリアをクリアして上書き保存ボタンを無効化するための `clearPermitGeneratedResult()` を追加し、`lastPermitGenerated` と `selectedPermitHearingId` を解除します。 
- `case_documents` / `case_tasks`（案件書類・案件タスク）は削除しないようにしており、JSONバックアップ関連処理やDBスキーマには変更を加えていません。 

### Testing
- `node --check app.js` を実行して構文チェックが通ることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f3f2a9d88333877d74a73920d481)