### PR TITLE
許認可ヒアリング履歴に検索・種別・優先度フィルタを追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,6 +68,9 @@ const state = {
   expensesSearchQuery: "",
   dailyReportSearchQuery: "",
   dailyReportDateFilter: "all",
+  permitHearingSearchQuery: "",
+  permitHearingCategoryFilter: "all",
+  permitHearingUrgencyFilter: "all",
   estimateCustomerQuery: "",
   estimateTitleQuery: "",
   estimateStatusFilter: "all",
@@ -113,6 +116,7 @@ const CLICK_ACTION_HANDLERS = {
   apply_permit_tasks: applyPermitTasksToCase,
   view_saved_permit_hearing: handleViewSavedPermitHearing,
   delete_saved_permit_hearing: handleDeleteSavedPermitHearing,
+  clear_permit_hearing_filters: clearPermitHearingFilters,
   add_estimate_item_row: () => addEstimateItemRow(),
   remove_estimate_item_row: handleEstimateItemsClick,
   status_summary_filter: handleStatusSummaryClick,
@@ -370,6 +374,11 @@ const permitOverwriteHearingBtn = document.getElementById("permit-overwrite-hear
 const permitHearingsBody = document.getElementById("permit-hearings-body");
 const permitHearingsEmpty = document.getElementById("permit-hearings-empty");
 const permitHearingsListWrap = document.getElementById("permit-hearings-list-wrap");
+const permitHearingSearchInput = document.getElementById("permit-hearing-search-input");
+const permitHearingCategoryFilter = document.getElementById("permit-hearing-category-filter");
+const permitHearingUrgencyFilter = document.getElementById("permit-hearing-urgency-filter");
+const permitHearingFilterClearBtn = document.getElementById("permit-hearing-filter-clear-btn");
+const permitHearingFilterCount = document.getElementById("permit-hearing-filter-count");
 let lastPermitGenerated = null;
 let selectedPermitHearingId = null;
 
@@ -586,6 +595,10 @@ function bindEvents() {
   dailyReportSearchInput?.addEventListener("input", handleDailyReportSearchInput);
   dailyReportDateFilterSelect?.addEventListener("change", handleDailyReportDateFilterChange);
   if (dailyReportFilterClearBtn) dailyReportFilterClearBtn.dataset.action = "clear_daily_report_filters";
+  permitHearingSearchInput?.addEventListener("input", handlePermitHearingSearchInput);
+  permitHearingCategoryFilter?.addEventListener("change", handlePermitHearingCategoryFilterChange);
+  permitHearingUrgencyFilter?.addEventListener("change", handlePermitHearingUrgencyFilterChange);
+  if (permitHearingFilterClearBtn) permitHearingFilterClearBtn.dataset.action = "clear_permit_hearing_filters";
   window.addEventListener("pageshow", forceHideLoading);
   window.addEventListener("focus", forceHideLoading);
   document.addEventListener("visibilitychange", () => {
@@ -1036,6 +1049,31 @@ function handleDailyReportSearchInput(event) {
 
 function handleDailyReportDateFilterChange(event) {
   applyDailyReportDateFilter(event?.target?.value || "all");
+}
+
+function handlePermitHearingSearchInput(event) {
+  state.permitHearingSearchQuery = String(event?.target?.value ?? "").trim().toLowerCase();
+  safeRender("permitHearings", renderPermitHearings);
+}
+
+function handlePermitHearingCategoryFilterChange(event) {
+  state.permitHearingCategoryFilter = String(event?.target?.value || "all");
+  safeRender("permitHearings", renderPermitHearings);
+}
+
+function handlePermitHearingUrgencyFilterChange(event) {
+  state.permitHearingUrgencyFilter = String(event?.target?.value || "all");
+  safeRender("permitHearings", renderPermitHearings);
+}
+
+function clearPermitHearingFilters() {
+  state.permitHearingSearchQuery = "";
+  state.permitHearingCategoryFilter = "all";
+  state.permitHearingUrgencyFilter = "all";
+  if (permitHearingSearchInput) permitHearingSearchInput.value = "";
+  if (permitHearingCategoryFilter) permitHearingCategoryFilter.value = "all";
+  if (permitHearingUrgencyFilter) permitHearingUrgencyFilter.value = "all";
+  safeRender("permitHearings", renderPermitHearings);
 }
 
 function applyDailyReportDateFilter(nextFilter) {
@@ -5802,12 +5840,42 @@ function renderCaseDocuments() {
 
 function renderPermitHearings() {
   if (!permitHearingsBody || !permitHearingsEmpty || !permitHearingsListWrap) return;
-  const rows = (Array.isArray(state.permitHearings) ? state.permitHearings : [])
+  const allRows = (Array.isArray(state.permitHearings) ? state.permitHearings : [])
     .slice()
     .sort((a, b) => toSortTimestamp(b.created_at || b.createdAt) - toSortTimestamp(a.created_at || a.createdAt));
+  const categorySet = new Set();
+  allRows.forEach((entry) => {
+    const category = String(entry.permit_category || "未設定");
+    if (category) categorySet.add(category);
+  });
+  if (permitHearingCategoryFilter) {
+    const currentValue = permitHearingCategoryFilter.value || "all";
+    const options = ['<option value="all">すべて</option>']
+      .concat(Array.from(categorySet).sort((a, b) => a.localeCompare(b, "ja")).map((category) => `<option value="${escapeHtml(category)}">${escapeHtml(category)}</option>`))
+      .join("");
+    permitHearingCategoryFilter.innerHTML = options;
+    permitHearingCategoryFilter.value = categorySet.has(currentValue) || currentValue === "all" ? currentValue : "all";
+    state.permitHearingCategoryFilter = permitHearingCategoryFilter.value;
+  }
+  const rows = allRows.filter((entry) => {
+    const linkedCase = state.cases.find((row) => row.id === (entry.case_id ?? entry.caseId));
+    const caseName = String(linkedCase?.caseName ?? linkedCase?.case_name ?? "案件不明");
+    const applicantName = String(entry.applicant_name || "");
+    const permitCategory = String(entry.permit_category || "未設定");
+    const urgency = String(entry.urgency || "通常");
+    const searchableText = [caseName, applicantName, permitCategory, urgency].join(" ").toLowerCase();
+    const matchesQuery = !state.permitHearingSearchQuery || searchableText.includes(state.permitHearingSearchQuery);
+    const matchesCategory = state.permitHearingCategoryFilter === "all" || permitCategory === state.permitHearingCategoryFilter;
+    const matchesUrgency = state.permitHearingUrgencyFilter === "all" || urgency === state.permitHearingUrgencyFilter;
+    return matchesQuery && matchesCategory && matchesUrgency;
+  });
+
   permitHearingsBody.innerHTML = "";
   permitHearingsEmpty.hidden = rows.length > 0;
   permitHearingsListWrap.hidden = rows.length === 0;
+  if (permitHearingFilterCount) {
+    permitHearingFilterCount.textContent = `表示中 ${rows.length}件 / 全${allRows.length}件`;
+  }
   rows.forEach((entry) => {
     const linkedCase = state.cases.find((row) => row.id === (entry.case_id ?? entry.caseId));
     const caseName = linkedCase?.caseName ?? linkedCase?.case_name ?? "案件不明";
@@ -5827,6 +5895,11 @@ function renderPermitHearings() {
     `;
     permitHearingsBody.appendChild(tr);
   });
+  if (!rows.length) {
+    permitHearingsEmpty.textContent = allRows.length === 0
+      ? "保存済みヒアリング履歴はまだありません。"
+      : "条件に一致するヒアリング履歴はありません。";
+  }
 }
 
 function renderWorkTemplateOptions() {

--- a/index.html
+++ b/index.html
@@ -875,6 +875,28 @@
               </div>
               <div class="permit-history-wrap">
                 <h3>保存済みヒアリング履歴</h3>
+                <div class="search-filter-bar">
+                  <label class="inline-field" for="permit-hearing-search-input">
+                    検索
+                    <input id="permit-hearing-search-input" type="search" placeholder="案件名・申請者名・許認可種別・優先度で検索" />
+                  </label>
+                  <label class="inline-field" for="permit-hearing-category-filter">
+                    許認可種別
+                    <select id="permit-hearing-category-filter">
+                      <option value="all">すべて</option>
+                    </select>
+                  </label>
+                  <label class="inline-field" for="permit-hearing-urgency-filter">
+                    優先度
+                    <select id="permit-hearing-urgency-filter">
+                      <option value="all">すべて</option>
+                      <option value="通常">通常</option>
+                      <option value="急ぎ">急ぎ</option>
+                    </select>
+                  </label>
+                  <button id="permit-hearing-filter-clear-btn" type="button" class="secondary-btn">条件クリア</button>
+                </div>
+                <p id="permit-hearing-filter-count" class="filter-count">表示中 0件 / 全0件</p>
                 <div id="permit-hearings-empty" class="empty">保存済みヒアリング履歴はまだありません。</div>
                 <div id="permit-hearings-list-wrap" class="table-wrap" hidden>
                   <table>


### PR DESCRIPTION
### Motivation
- 保存済み許認可ヒアリング履歴が増えたときに目的の履歴を見つけやすくするため、検索と絞り込み機能を追加する。
- 既存の表示・上書き保存・削除の操作は維持しつつ、一覧は検索・フィルタ結果のみ表示する要件に対応する。

### Description
- `index.html` に許認可ヒアリング履歴セクション上部の検索入力（`permit-hearing-search-input`）、許認可種別セレクト（`permit-hearing-category-filter`）、優先度セレクト（`permit-hearing-urgency-filter`）、条件クリアボタン（`permit-hearing-filter-clear-btn`）および件数表示（`permit-hearing-filter-count`）を追加した。 
- `app.js` に検索語・許認可種別・優先度の状態（`state.permitHearingSearchQuery` / `state.permitHearingCategoryFilter` / `state.permitHearingUrgencyFilter`）とそれらを更新するハンドラを追加し、バインド処理を組み込んだ。 
- `renderPermitHearings` を拡張して保存データから許認可種別の候補を動的生成し、キーワード検索（案件名・申請者名・許認可種別・優先度）と種別/優先度フィルタを組み合わせた結果のみを表示するようにした。 
- 絞り込み結果件数を `表示中 X件 / 全Y件` で表示し、該当なしの場合は「保存済みヒアリング履歴はまだありません。」と「条件に一致するヒアリング履歴はありません。」を切り替えるロジックを追加した。 
- 影響範囲は許認可ヒアリング履歴の表示部分のみで、`case_documents` / `case_tasks` には触れておらず、DBスキーマ変更は行っていない。 

### Testing
- `node --check app.js` を実行して構文チェックを行い、エラーは発生しなかった（成功）。
- 自動テストは他に無く、今回の変更は静的チェックと既存のイベントバインド・レンダリングフローに統合しているため、動作はブラウザ上で既存のUIと整合することを確認することを想定している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f67d1c2083338398a9811376b0ad)