### PR TITLE
Fix about:blank in permit print preview by using Blob URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -1019,11 +1019,11 @@ dl { display:grid; grid-template-columns: 180px 1fr; gap: 4px 10px; margin: 0; }
 <h2>確認が必要な項目</h2><ul>${warnings.map((w) => `<li>${escapeHtml(w)}</li>`).join("")}</ul>
 <h2>必要書類一覧</h2><ul>${docs.map((d) => `<li>${escapeHtml(d)}</li>`).join("")}</ul>
 <h2>想定タスク一覧</h2><ul>${tasks.map((t) => `<li>${escapeHtml(t)}</li>`).join("")}</ul><script>window.print();</script></body></html>`;
-  const printWindow = window.open("", "_blank", "noopener,noreferrer");
+  const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const printWindow = window.open(url, "_blank");
   if (!printWindow) return showAppMessage("印刷プレビューを開けませんでした。ポップアップ設定をご確認ください。", true);
-  printWindow.document.open();
-  printWindow.document.write(html);
-  printWindow.document.close();
+  setTimeout(() => URL.revokeObjectURL(url), 60000);
 }
 
 function handleViewSavedPermitHearing(event, button) {


### PR DESCRIPTION
### Motivation
- In Chrome, opening a blank tab with `window.open("", "_blank", "noopener,noreferrer")` and then using `document.write(html)` can leave the new tab at `about:blank`, preventing the printable HTML and `window.print()` from appearing.

### Description
- Replace `openPermitPrintPreview()` to build a `Blob` from the existing printable `html` and open it via `URL.createObjectURL(blob)` with `window.open(url, "_blank")`, remove the `document.write` calls, preserve the printable HTML (including `<script>window.print();</script>`), keep the existing popup-block error handling when `window.open` returns `null`, and delay cleanup with `setTimeout(() => URL.revokeObjectURL(url), 60000)`.

### Testing
- Ran `node --check app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60b8d3a0c8333a4ca4f803495c479)