### PR TITLE
Render permit hearing 'v1対象業務' select from PERMIT_SCENARIO_MASTER

### DIFF
--- a/app.js
+++ b/app.js
@@ -363,6 +363,7 @@ const caseDocumentsEmpty = document.getElementById("case-documents-empty");
 const caseDocumentsListWrap = document.getElementById("case-documents-list-wrap");
 const permitHearingForm = document.getElementById("permit-hearing-form");
 const permitCaseSelect = document.getElementById("permit-case-id");
+const permitScenarioSelect = document.getElementById("permit-scenario");
 const permitResult = document.getElementById("permit-hearing-result");
 const permitSummary = document.getElementById("permit-summary");
 const permitWarningWrap = document.getElementById("permit-warning-wrap");
@@ -1112,6 +1113,7 @@ function handleViewSavedPermitHearing(event, button) {
 
 function restorePermitHearingFormValues(hearing) {
   if (!permitHearingForm || !hearing) return;
+  renderPermitScenarioOptions();
   const answers = hearing.answers && typeof hearing.answers === "object" ? hearing.answers : {};
   const setValue = (name, value) => {
     const field = permitHearingForm.elements.namedItem(name);
@@ -6033,7 +6035,26 @@ function renderSaleCumulativeReceiptButton(sale) {
   return ' <button type="button" class="secondary-btn" data-action="print_cumulative_receipt" data-list-action="print_cumulative_receipt" data-sale-id="' + escapeHtml(sale.id) + '">累計領収書</button>';
 }
 
+function renderPermitScenarioOptions() {
+  if (!permitScenarioSelect) return;
+  const scenarioEntries = Object.entries(PERMIT_SCENARIO_MASTER || {});
+  const currentValue = permitScenarioSelect.value;
+  permitScenarioSelect.innerHTML = "";
+  scenarioEntries.forEach(([key, scenario]) => {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = String(scenario?.label || key);
+    permitScenarioSelect.append(option);
+  });
+  if (currentValue && PERMIT_SCENARIO_MASTER[currentValue]) {
+    permitScenarioSelect.value = currentValue;
+  } else if (scenarioEntries.length > 0) {
+    permitScenarioSelect.value = scenarioEntries[0][0];
+  }
+}
+
 function renderCaseOptions() {
+  renderPermitScenarioOptions();
   if (!saleCaseSelect || !expenseCaseSelect || !reportCaseSelect) return;
   const options = state.cases
     .slice()

--- a/index.html
+++ b/index.html
@@ -827,14 +827,7 @@
                 </label>
                 <label>
                   v1対象業務
-                  <select id="permit-scenario" name="permitScenario" required>
-                    <option value="construction_corp">大阪府 建設業許可 知事許可 新規 法人</option>
-                    <option value="construction_solo">大阪府 建設業許可 知事許可 新規 個人</option>
-                    <option value="takken_corp">大阪府 宅建業免許 新規 法人</option>
-                    <option value="takken_solo">大阪府 宅建業免許 新規 個人</option>
-                    <option value="kobutsu_corp">大阪府警 古物商許可 新規 法人</option>
-                    <option value="kobutsu_solo">大阪府警 古物商許可 新規 個人</option>
-                  </select>
+                  <select id="permit-scenario" name="permitScenario" required></select>
                 </label>
                 <label>法人/個人
                   <select id="permit-applicant-type" name="permitApplicantType">


### PR DESCRIPTION
### Motivation
- `PERMIT_SCENARIO_MASTER` に追加した業務テンプレートが、許認可ヒアリング画面の「v1対象業務」セレクトに反映されていなかったため、選択肢をマスターから自動生成する必要がありました。

### Description
- `index.html` の `#permit-scenario` から固定の `<option>` を削除し、空の `<select>` に変更しました。 
- `app.js` に `permitScenarioSelect` の要素参照を追加しました。 
- `renderPermitScenarioOptions()` を実装して `PERMIT_SCENARIO_MASTER` のエントリを列挙し `option.value` にキー、`option.textContent` に `scenario.label` を設定するようにしました。 
- `renderCaseOptions()` と `restorePermitHearingFormValues()` から `renderPermitScenarioOptions()` を呼び出すようにして、画面表示時および保存済み履歴復元時に最新のマスターが反映されるようにしました。

### Testing
- 自動チェックとして `node --check app.js` を実行し、構文エラーなしで成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6209f5a1c83339c15846181054f46)