### PR TITLE
README: add ALTERs for existing estimate_calculations columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,24 @@ create table if not exists estimate_calculations (
   updated_at timestamptz default now()
 );
 
+-- 既存テーブルに対しても、保存payloadで使うカラムを不足なく追加
+alter table estimate_calculations add column if not exists project_name text;
+alter table estimate_calculations add column if not exists work_type text;
+alter table estimate_calculations add column if not exists corporate_type text;
+alter table estimate_calculations add column if not exists governor_type text;
+alter table estimate_calculations add column if not exists general_specific text;
+alter table estimate_calculations add column if not exists industry_count integer default 1;
+alter table estimate_calculations add column if not exists officer_count integer default 0;
+alter table estimate_calculations add column if not exists office_count integer default 1;
+alter table estimate_calculations add column if not exists document_level text;
+alter table estimate_calculations add column if not exists urgent boolean default false;
+alter table estimate_calculations add column if not exists keikan_level text;
+alter table estimate_calculations add column if not exists sengi_level text;
+alter table estimate_calculations add column if not exists zaisan_level text;
+alter table estimate_calculations add column if not exists visit_required boolean default false;
+alter table estimate_calculations add column if not exists agent_required boolean default false;
+alter table estimate_calculations add column if not exists addon_breakdown text;
+
 alter table estimate_calculations enable row level security;
 
 drop policy if exists "estimate_calculations_own" on estimate_calculations;


### PR DESCRIPTION
### Motivation
- The existing SQL only used `create table if not exists`, so older `estimate_calculations` tables could miss columns required by the `estimate-calculator.js` payload and cause Supabase POST 400 errors when saving.

### Description
- Added `alter table estimate_calculations add column if not exists ...` statements for the payload columns: `project_name`, `work_type`, `corporate_type`, `governor_type`, `general_specific`, `industry_count`, `officer_count`, `office_count`, `document_level`, `urgent`, `keikan_level`, `sengi_level`, `zaisan_level`, `visit_required`, `agent_required`, and `addon_breakdown` in the README SQL block.
- Applied `default` values to integer/boolean columns to match the table definition (`industry_count`, `officer_count`, `office_count`, `urgent`, `visit_required`, `agent_required`).
- Kept the original `create table if not exists` block and RLS/policy/index statements unchanged and inserted the ALTER statements immediately after the create block in `README.md`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69facfc83ac88333915af89a91e44a5c)