### PR TITLE
Fix missing estimate_calculations ALTER columns in README SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ alter table estimate_calculations add column if not exists sengi_level text;
 alter table estimate_calculations add column if not exists zaisan_level text;
 alter table estimate_calculations add column if not exists visit_required boolean default false;
 alter table estimate_calculations add column if not exists agent_required boolean default false;
+alter table estimate_calculations add column if not exists memo text;
+alter table estimate_calculations add column if not exists base_fee bigint default 0;
+alter table estimate_calculations add column if not exists addon_fee bigint default 0;
+alter table estimate_calculations add column if not exists taxable_subtotal bigint default 0;
+alter table estimate_calculations add column if not exists tax bigint default 0;
+alter table estimate_calculations add column if not exists total bigint default 0;
+alter table estimate_calculations add column if not exists expense_amount bigint default 0;
+alter table estimate_calculations add column if not exists discount_amount bigint default 0;
 alter table estimate_calculations add column if not exists addon_breakdown text;
 
 alter table estimate_calculations enable row level security;


### PR DESCRIPTION
### Motivation
- PR #162 introduced additional fields used by the estimate auto-calculation payload but the README ALTER snippet for existing `estimate_calculations` tables omitted several columns, causing Supabase schema-cache errors such as `Could not find the 'memo' column of 'estimate_calculations' in the schema cache`.

### Description
- Updated the README section "見積自動算出機能の追加SQL" to add `ALTER TABLE` statements for the missing columns: `memo`, `base_fee`, `addon_fee`, `taxable_subtotal`, `tax`, `total`, `expense_amount`, and `discount_amount`.
- The changes were applied to the existing-table migration snippet so existing deployments can add the missing columns with `ALTER TABLE` and avoid runtime schema mismatches.
- The change was committed with message `Fix estimate_calculations ALTER SQL for missing payload columns`.

### Testing
- Verified the README now contains the new `ALTER TABLE` lines using `rg -n` which succeeded. 
- Inspected the updated section with `sed`/`nl` to confirm the inserted lines, which succeeded. 
- Confirmed repository status and commit using `git status --short` and the commit operation, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad2d8fd8883338433af6bff288f49)