### PR TITLE
README: 旧estimate_calculationsスキーマ互換のSQLを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,15 @@ alter table estimate_calculations add column if not exists total bigint default 
 alter table estimate_calculations add column if not exists expense_amount bigint default 0;
 alter table estimate_calculations add column if not exists discount_amount bigint default 0;
 alter table estimate_calculations add column if not exists addon_breakdown text;
+alter table estimate_calculations add column if not exists business_type text;
+alter table estimate_calculations add column if not exists jurisdiction_type text;
+alter table estimate_calculations add column if not exists applicant_type text;
+alter table estimate_calculations add column if not exists urgency text;
+alter table estimate_calculations add column if not exists document_readiness text;
+
+-- 古い初期SQLで business_type が not null の場合、現行payload保存時にエラーになるため解除
+alter table estimate_calculations
+alter column business_type drop not null;
 
 alter table estimate_calculations enable row level security;
 


### PR DESCRIPTION
### Motivation
- 古い初期SQLで `estimate_calculations.business_type` が `NOT NULL` のまま残っている環境で、現行の保存payload（`estimate-calculator.js`）による保存時に `null value in column "business_type" violates not-null constraint` が発生するため、互換のためのSQLをREADMEに追記します。

### Description
- `README.md` の「見積自動算出機能の追加SQL」セクションに、`business_type`、`jurisdiction_type`、`applicant_type`、`urgency`、`document_readiness` の `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` を追記し、さらに `ALTER TABLE estimate_calculations ALTER COLUMN business_type DROP NOT NULL;` を追記しました。

### Testing
- ドキュメントのみの変更のため自動テストは実行しておらず、変更はREADMEファイルへの追記のみです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad4a4d7388333a54b5efca1c6032f)