### PR TITLE
見積自動算出: 保存済み一覧の初期描画タイミングを修正

### DIFF
--- a/estimate-calculator.js
+++ b/estimate-calculator.js
@@ -77,7 +77,7 @@
     w.focus();
   }
 
-  function init(){
+  async function init(){
     const root=document.getElementById("estimate-calculator-root"); if(!root)return;
     root.innerHTML=`<form id="estimate-calc-form" class="form"><div class="grid cols-2">
       <label>顧客<select name="clientId"></select></label><label>案件名<input name="projectName" /></label>
@@ -188,7 +188,12 @@
       }
     });
 
+    if (app?.reloadAllData) {
+      await app.reloadAllData();
+    }
     renderSavedList();
   }
-  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('DOMContentLoaded', () => {
+    init();
+  });
 })();


### PR DESCRIPTION
### Motivation
- 初回表示時に `renderSavedList()` が `app.js` 側の `state.estimateCalculations` ロード前に実行され、既存データが「保存済みデータはありません」と表示されてしまう問題を解消するための修正です。

### Description
- `estimate-calculator.js` の `init()` を `async` に変更して、初期描画前に `app.reloadAllData()` を `await` するようにしました。
- `DOMContentLoaded` ハンドラは維持しつつ `init()` 呼び出しをラップして非同期初期化に対応させました。
- 保存・削除・見積反映後の `renderSavedList()` 再描画や `data-calc-action` 属性、概算書出力の表示項目（行政書士報酬 / 実費・法定費用 / 消費税 / 合計金額）は既存のまま維持しています。
- 変更箇所: `estimate-calculator.js` の初期化フロー（同期→非同期化と `app.reloadAllData()` 待機）のみ。

### Testing
- 実行: `node --check estimate-calculator.js` は成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae771339483339c2350fb94e63967)