### PR TITLE
Add cache-buster and fix startup race for estimate-calculator saved list

### DIFF
--- a/estimate-calculator.js
+++ b/estimate-calculator.js
@@ -27,7 +27,16 @@
     const client=clients.find((c)=>String(c.id)===String(calc.client_id||""));
     return client?.name||client?.companyName||client?.contactName||calc.client_name||calc.customer_name||"-";
   }
-  async function waitForCurrentUser(app, maxMs = 5000) {
+  async function waitForGyoseiApp(maxMs = 10000) {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+      if (window.GyoseiApp) return window.GyoseiApp;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return window.GyoseiApp || null;
+  }
+
+  async function waitForCurrentUser(app, maxMs = 10000) {
     const start = Date.now();
     while (Date.now() - start < maxMs) {
       const u = app?.getCurrentUser?.();
@@ -105,7 +114,9 @@
     <div id="calc-result" class="panel"></div></form>
     <section class="panel" id="calc-saved-list-wrap"><h3>保存済み概算見積</h3><div id="calc-saved-list"></div></section>`;
 
-    const app=window.GyoseiApp; const form=root.querySelector('#estimate-calc-form'); const cs=form.elements.clientId;
+    const app=await waitForGyoseiApp();
+    if(!app) return;
+    const form=root.querySelector('#estimate-calc-form'); const cs=form.elements.clientId;
     const savedList=root.querySelector('#calc-saved-list');
     (app?.getClients?.()||[]).forEach(c=>{const o=document.createElement('option');o.value=c.id;o.textContent=c.name||c.companyName||c.contactName||'未設定';cs.appendChild(o)});
 
@@ -156,11 +167,26 @@
     let localEstimateCalculations=[];
     const loadSavedCalculations=async()=>{
       const sb=app?.getSupabaseClient?.();
+      if(!sb){
+        localEstimateCalculations=[];
+        console.log("LOAD ESTIMATE CALCULATIONS RESULT", { count: localEstimateCalculations.length, reason: "missing_supabase_client" });
+        return;
+      }
+
       const u=await waitForCurrentUser(app);
       console.log("LOAD ESTIMATE CALCULATIONS START", { hasClient: !!sb, userId: u?.id });
-      if(!sb||!u){localEstimateCalculations=[]; console.log("LOAD ESTIMATE CALCULATIONS RESULT", { count: localEstimateCalculations.length }); return;}
+      if(!u?.id){
+        localEstimateCalculations=[];
+        console.log("LOAD ESTIMATE CALCULATIONS RESULT", { count: localEstimateCalculations.length, reason: "missing_user_id" });
+        return;
+      }
+
       try {
-        const { data, error }=await sb.from('estimate_calculations').select('*').eq('user_id', u.id).order('created_at', { ascending: false });
+        const { data, error }=await sb
+          .from('estimate_calculations')
+          .select('*')
+          .eq('user_id', u.id)
+          .order('created_at', { ascending: false });
         if(error){throw error;}
         localEstimateCalculations=Array.isArray(data)?data:[];
         console.log("LOAD ESTIMATE CALCULATIONS RESULT", { count: localEstimateCalculations.length });

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
     <script src="app.js?v=20260426-payment-control-upgrade" defer></script>
-    <script src="estimate-calculator.js" defer></script>
+    <script src="estimate-calculator.js?v=20260507-saved-calculations-load-fix" defer></script>
   </head>
   <body>
     <div id="loading-overlay" class="loading-overlay" hidden>


### PR DESCRIPTION
### Motivation
- 保存済みの概算見積が初回表示で出ない問題は、初期化順やブラウザキャッシュによるタイミングの不整合が原因と考えられるため対応しました。 
- 初期表示で `window.GyoseiApp` と `app.getCurrentUser()` の準備を保証し、確実にユーザーIDで `estimate_calculations` を直接取得する必要がありました。 
- またスクリプトのキャッシュが古いまま残る可能性に対処するため `estimate-calculator.js` にキャッシュバスターを追加しました。 

### Description
- `index.html` の `estimate-calculator.js` 読み込みにクエリ文字列 `?v=20260507-saved-calculations-load-fix` を追加しました（`<script src="estimate-calculator.js?v=20260507-saved-calculations-load-fix" defer></script>`）。
- 新たに `waitForGyoseiApp()` を追加し、`init()` 内で `await waitForGyoseiApp()` して `window.GyoseiApp` が利用可能になるまで待つようにしました。`
- `waitForCurrentUser()` の待機時間を延長し、`loadSavedCalculations()` は Supabase クライアントが存在することと `app.getCurrentUser()` が `id` を返すことを確認してから `sb.from('estimate_calculations').select('*').eq('user_id', u.id).order('created_at', { ascending: false })` で直接取得するようにしました。`
- `loadSavedCalculations()` に不足時の早期リターンとログ出力（`missing_supabase_client` / `missing_user_id`）を追加し、取得後は `localEstimateCalculations` に格納して `renderSavedList()` を呼び出す初期化フローを保証しました。`

### Testing
- `node --check estimate-calculator.js` を実行して構文チェックを行い、問題なく成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfdba11cc833384bc2dd4c0c54063)