### PR TITLE
保存済み概算見積の反映状態管理と再反映確認を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ alter table estimate_calculations add column if not exists total bigint default 
 alter table estimate_calculations add column if not exists expense_amount bigint default 0;
 alter table estimate_calculations add column if not exists discount_amount bigint default 0;
 alter table estimate_calculations add column if not exists addon_breakdown text;
+alter table estimate_calculations add column if not exists reflected_estimate_id uuid;
+alter table estimate_calculations add column if not exists reflected_at timestamptz;
 alter table estimate_calculations add column if not exists business_type text;
 alter table estimate_calculations add column if not exists jurisdiction_type text;
 alter table estimate_calculations add column if not exists applicant_type text;
@@ -465,7 +467,6 @@ for all
 using (auth.uid() = user_id)
 with check (auth.uid() = user_id);
 ```
-
 
 
 

--- a/estimate-calculator.js
+++ b/estimate-calculator.js
@@ -148,8 +148,20 @@
       run();
     };
 
+    const getReflectionInfo=(calc)=>{
+      const reflectedAt=calc?.reflected_at||null;
+      const reflectedEstimateId=calc?.reflected_estimate_id||null;
+      return { reflectedAt, reflectedEstimateId, isReflected: !!(reflectedAt||reflectedEstimateId) };
+    };
+
     const reflectToEstimate=async(calc)=>{
       const sb=app?.getSupabaseClient?.(); const u=app?.getCurrentUser?.(); if(!sb||!u)return;
+      const reflectionInfo=getReflectionInfo(calc);
+      if(reflectionInfo.isReflected){
+        const reflectedDate=reflectionInfo.reflectedAt?fmtDate(reflectionInfo.reflectedAt):'日時未記録';
+        const shouldContinue=confirm(`この概算見積はすでに見積へ反映済みです。（反映日: ${reflectedDate}）\n再反映しますか？`);
+        if(!shouldContinue) return false;
+      }
       const clients=app?.getClients?.()||[]; const selected=clients.find(c=>String(c.id)===String(calc.client_id||''));
       const customerName=(selected?.name||selected?.companyName||selected?.contactName||calc.project_name||'自動算出');
       const est={user_id:u.id,client_id:calc.client_id||null,customer_name:customerName,estimate_title:calc.project_name||'見積自動算出',estimate_date:new Date().toISOString().slice(0,10),status:'未回答',memo:calc.memo||null,subtotal:n(calc.taxable_subtotal)+n(calc.expense_amount),tax:n(calc.tax),total:n(calc.total)};
@@ -157,6 +169,10 @@
       const e=await sb.from('estimates').insert(est).select('id').single(); if(e.error){app.showMessage('見積登録に失敗しました。'+e.error.message,true);return false;}
       const items=[{item_name:'基本報酬',quantity:1,unit_price:n(calc.base_fee),amount:n(calc.base_fee),sort_order:1},{item_name:'加算',quantity:1,unit_price:n(calc.addon_fee),amount:n(calc.addon_fee),sort_order:2},{item_name:'値引き',quantity:1,unit_price:-n(calc.discount_amount),amount:-n(calc.discount_amount),sort_order:3},{item_name:'実費(非課税)',quantity:1,unit_price:n(calc.expense_amount),amount:n(calc.expense_amount),sort_order:4}].map(i=>({...i,user_id:u.id,estimate_id:e.data.id}));
       const ir=await sb.from('estimate_items').insert(items); if(ir.error){app.showMessage('見積明細登録に失敗しました。'+ir.error.message,true);return false;}
+      if(calc?.id){
+        const reflected=await sb.from('estimate_calculations').update({reflected_estimate_id:e.data.id,reflected_at:new Date().toISOString()}).eq('id',calc.id).eq('user_id',u.id);
+        if(reflected.error){app.showMessage('反映済み情報の保存に失敗しました。'+reflected.error.message,true);return false;}
+      }
       await app.reloadAllData();
       await loadSavedCalculations();
       renderSavedList();
@@ -209,7 +225,7 @@
       const calcs=sourceCalcs.slice().sort((a,b)=>new Date(b.created_at||0)-new Date(a.created_at||0));
       if(!calcs.length){savedList.innerHTML='<p class="meta">保存済みデータはありません。</p>'; return;}
       savedList.innerHTML=`<div class="saved-calc-list">${calcs.map(c=>`<article class="panel saved-calc-card">
-        <div class="saved-calc-header"><strong>${h(c.project_name||"-")}</strong> / <span>${h(c.work_type||"-")}</span> / <strong>${h(yen(c.total||0))}</strong></div>
+        <div class="saved-calc-header"><strong>${h(c.project_name||"-")}</strong> / <span>${h(c.work_type||"-")}</span> / <strong>${h(yen(c.total||0))}</strong> ${getReflectionInfo(c).isReflected?`<span class="status-badge">反映済み</span>`:''}</div>
         <div class="saved-calc-meta">作成日: ${h(fmtDate(c.created_at))} / 顧客名: ${h(c.client_name||c.customer_name||"-")} / 申請区分: ${h(c.application_type||"-")}</div>
         <div class="saved-calc-money">基本報酬: ${h(yen(c.base_fee||0))} / 加算: ${h(yen(c.addon_fee||0))} / 実費: ${h(yen(c.expense_amount||0))} / 消費税: ${h(yen(c.tax||0))}</div>
         <div class="saved-calc-note">メモ: ${h(c.memo||"-")}</div>


### PR DESCRIPTION
### Motivation
- 保存済みの概算見積が既に見積へ反映済みかどうかを一覧から判別できるようにし、誤操作での二重反映を防ぎたい。
- ただし完全禁止にはせず、必要に応じて再反映できる仕様にする必要がある。
- DB側にも反映履歴を残して参照や監査ができるようにする必要がある。

### Description
- `README.md` の `estimate_calculations` 追加SQLに `reflected_estimate_id uuid` と `reflected_at timestamptz` を追記してカラムを用意しました。
- `estimate-calculator.js` に `getReflectionInfo(calc)` を追加して `reflected_at` / `reflected_estimate_id` を判定するロジックを導入しました。
- 見積へ反映する処理 `reflectToEstimate` で既に反映済みの場合は確認ダイアログを表示し、ユーザーの確認後に再反映を実行するようにしました。
- 見積反映成功時に元の `estimate_calculations` レコードへ `reflected_estimate_id` と `reflected_at` を保存する処理を追加し、保存済み一覧のカードヘッダーに `反映済み` バッジを表示するようにしました。

### Testing
- `node --check app.js` を実行して構文チェックを行い問題ないことを確認しました（成功）。
- `node --check estimate-calculator.js` を実行して構文チェックを行い問題ないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc07056fbc8333869d256199e4849d)