### PR TITLE
許認可ヒアリング：業務切替時の固定項目表示切替を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -1103,7 +1103,7 @@ function renderWorkTypeFields() {
 function getPermitBaseFieldConfig(scenarioKey) {
   const workTypeKey = SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey))?.key || "default";
   const baseByWorkType = {
-    construction: ["permitApplicantType", "permitApplicationType", "permitMemo"],
+    construction: ["permitApplicantType", "permitApplicationType", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitMemo"],
     takken: ["permitApplicantType", "permitApplicationType", "permitMemo"],
     kobutsu: ["permitApplicantType", "permitMemo"],
     company_establishment: ["permitApplicationType", "permitApplicantName", "permitOfficeAddress", "permitMemo"],
@@ -1123,7 +1123,8 @@ function syncPermitBaseFieldsVisibility() {
   const fieldNames = ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitOnlineApplication", "permitUrgency", "permitMemo"];
   fieldNames.forEach((name) => {
     const field = permitHearingForm.elements.namedItem(name);
-    const label = field?.closest?.("label");
+    const control = field instanceof RadioNodeList ? field[0] : field;
+    const label = control?.closest?.("label") || control?.parentElement;
     if (label) label.hidden = !visibleFieldNames.has(name);
   });
 }


### PR DESCRIPTION
### Motivation
- 業務を切り替えた際に建設業／会社系の固定ベース項目（事業所所在地・役員人数・有資格者人数など）が不要な業務で残ってしまう現象を防ぎ、業務選択直後に不要項目が即時非表示になるようにする。 

### Description
- `app.js` の `getPermitBaseFieldConfig()` の `construction` 設定に `permitOfficeAddress`、`permitOfficerCount`、`permitQualifiedCount` を追加して建設業向け固定項目を明示的に含めた。 
- `syncPermitBaseFieldsVisibility()` を改善して、`namedItem()` が `RadioNodeList` を返す場合は先頭コントロールを使い、`closest("label")` が取得できない場合は `parentElement` をフォールバックしてラベル／コントロールを確実に解決して `hidden` 制御するようにした。 
- `renderWorkTypeFields()` の後に `syncPermitBaseFieldsVisibility()` を呼び表示ルールを即時反映する動作は維持している。 

### Testing
- `node --check app.js` を実行して問題なし（成功）。 
- `node --check estimate-calculator.js` を実行して問題なし（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbfdf3d0483339fb152eabd6c7dbf)