### PR TITLE
Fix permit base field visibility for v1 scenario switches by targeting static control IDs

### DIFF
--- a/app.js
+++ b/app.js
@@ -1120,10 +1120,21 @@ function getPermitBaseFieldConfig(scenarioKey) {
 function syncPermitBaseFieldsVisibility() {
   if (!permitHearingForm || !permitScenarioSelect) return;
   const visibleFieldNames = new Set(getPermitBaseFieldConfig(String(permitScenarioSelect.value || "")));
-  const fieldNames = ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitOnlineApplication", "permitUrgency", "permitMemo"];
-  fieldNames.forEach((name) => {
-    const field = permitHearingForm.elements.namedItem(name);
-    const control = field instanceof RadioNodeList ? field[0] : field;
+  const baseFieldIdMap = {
+    permitApplicantType: "permit-applicant-type",
+    permitApplicationType: "permit-application-type",
+    permitJurisdictionPrefecture: "permit-jurisdiction-prefecture",
+    permitJurisdictionCity: "permit-jurisdiction-city",
+    permitApplicantName: "permit-applicant-name",
+    permitOfficeAddress: "permit-office-address",
+    permitOfficerCount: "permit-officer-count",
+    permitQualifiedCount: "permit-qualified-count",
+    permitOnlineApplication: "permit-online-application",
+    permitUrgency: "permit-urgency",
+    permitMemo: "permit-memo",
+  };
+  Object.entries(baseFieldIdMap).forEach(([name, id]) => {
+    const control = document.getElementById(id);
     const label = control?.closest?.("label") || control?.parentElement;
     if (label) label.hidden = !visibleFieldNames.has(name);
   });


### PR DESCRIPTION
### Motivation
- Fix a bug where construction-only base fields (e.g. 事業所所在地・役員人数・有資格者人数) remained visible after switching the v1 `permitScenario` to automobile/相続/会社設立 because dynamic fields could shadow static controls when using `form.elements.namedItem`.
- Ensure unnecessary base items are hidden immediately on scenario change, re-render and initial display without touching saved-answer or estimate logic.

### Description
- Rewrote `syncPermitBaseFieldsVisibility()` to target static base controls by their DOM `id` instead of using `form.elements.namedItem(...)`, eliminating ambiguity when dynamic work-type fields reuse names (change located in `app.js`).
- Left `getPermitBaseFieldConfig()` and `renderWorkTypeFields()` behavior intact and still used to compute which base fields should be visible for each scenario key.
- `renderWorkTypeFields()` continues to call `syncPermitBaseFieldsVisibility()` after rendering dynamic fields so base visibility updates immediately on re-render and scenario switch.

### Testing
- Ran `node --check app.js` and it completed without errors.
- Ran `node --check estimate-calculator.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc54fa53883338f70b20d09ab48f3)