### PR TITLE
許認可ヒアリングの固定項目表示を業務カテゴリ(schema)で一元化

### DIFF
--- a/app.js
+++ b/app.js
@@ -994,6 +994,18 @@ const WORK_TYPE_FIELD_SCHEMA = {
     { name: "permitDeceasedName", label: "被相続人氏名", type: "text" },{ name: "permitHeirCount", label: "相続人人数", type: "number", min: 1, value: 1 },{ name: "permitKosekiCollectionStatus", label: "戸籍収集状況", type: "text" },{ name: "permitHasInheritanceAgreement", label: "遺産分割協議書の有無", type: "select", options: [{ value: "あり", label: "あり" }, { value: "なし", label: "なし" }] },{ name: "permitAssetList", label: "財産一覧", type: "text" },{ name: "permitNeedFamilyChart", label: "相続人関係図", type: "select", options: [{ value: "要", label: "要" }, { value: "不要", label: "不要" }] }
   ],
 };
+const WORK_TYPE_BASE_FIELDS = {
+  default: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitMemo"],
+  construction: ["permitApplicantType", "permitApplicationType", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitMemo"],
+  takken: ["permitApplicantType", "permitApplicationType", "permitMemo"],
+  kobutsu: ["permitApplicantType", "permitMemo"],
+  company_establishment: ["permitApplicationType", "permitApplicantName", "permitMemo"],
+  startup_finance: ["permitApplicantType", "permitApplicationType", "permitMemo"],
+  sangyo_unpan: ["permitApplicantType", "permitApplicationType", "permitMemo"],
+  zairyu: ["permitApplicationType", "permitApplicantName", "permitMemo"],
+  inheritance: ["permitApplicantName", "permitMemo"],
+  automobile: ["permitApplicationType", "permitApplicantName", "permitMemo"],
+};
 const SCENARIO_WORK_TYPE_CONFIG = [
   { key: "automobile", scenarios: ["shakoshomei_standard", "kei_hokan_todokede", "jidousha_transfer", "jidousha_change"] },
   { key: "construction", scenarios: ["construction_corp", "construction_solo", "keiei_shinsa_bidding"] },
@@ -1078,9 +1090,12 @@ function buildPermitBranchingResult(baseDocs, baseTasks, conditions) {
   return { docs, tasks, addedDocs, addedTasks, estimateAdjustments };
 }
 
+function resolveWorkTypeCategory(scenarioKey) {
+  return SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey))?.key || "default";
+}
+
 function resolveWorkTypeSchema(scenarioKey) {
-  const config = SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey));
-  return WORK_TYPE_FIELD_SCHEMA[config?.key || "default"] || [];
+  return WORK_TYPE_FIELD_SCHEMA[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_FIELD_SCHEMA.default || [];
 }
 
 function renderWorkTypeFields() {
@@ -1101,20 +1116,7 @@ function renderWorkTypeFields() {
 }
 
 function getPermitBaseFieldConfig(scenarioKey) {
-  const workTypeKey = SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey))?.key || "default";
-  const baseByWorkType = {
-    construction: ["permitApplicantType", "permitApplicationType", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitMemo"],
-    takken: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-    kobutsu: ["permitApplicantType", "permitMemo"],
-    company_establishment: ["permitApplicationType", "permitApplicantName", "permitOfficeAddress", "permitMemo"],
-    startup_finance: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-    sangyo_unpan: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-    zairyu: ["permitApplicationType", "permitApplicantName", "permitMemo"],
-    inheritance: ["permitApplicantName", "permitMemo"],
-    automobile: ["permitApplicationType", "permitMemo"],
-    default: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitMemo"],
-  };
-  return baseByWorkType[workTypeKey] || baseByWorkType.default;
+  return WORK_TYPE_BASE_FIELDS[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_BASE_FIELDS.default;
 }
 
 function syncPermitBaseFieldsVisibility() {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="styles.css" />
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-    <script src="app.js?v=20260426-payment-control-upgrade" defer></script>
+    <script src="app.js?v=20260508-worktype-schema-switch-fix" defer></script>
     <script src="estimate-calculator.js?v=20260507-saved-calculations-load-fix" defer></script>
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- 現行では動的項目(schema)と固定項目(base fields)の判定が分散しており、業務切替時に建設業向け固定項目（事業所所在地/役員人数/有資格者人数）が不要な業務に残る不整合が発生していました。 
- また `index.html` の `app.js` 読込クエリが古いと修正済みスクリプトが配信されないリスクがありました。

### Description
- `WORK_TYPE_BASE_FIELDS` を追加し、業務カテゴリごとの固定表示項目を明示的に定義しました（建設業系・車両系・相続系・会社設立系・創業融資系・在留資格系 等）。
- カテゴリ解決を一本化するために `resolveWorkTypeCategory` を導入し、`resolveWorkTypeSchema` / `renderWorkTypeFields` / `getPermitBaseFieldConfig` が同一のカテゴリ判定を参照するようにしました。 
- `getPermitBaseFieldConfig` を `WORK_TYPE_BASE_FIELDS` 参照へ差し替え、`renderWorkTypeFields` → `syncPermitBaseFieldsVisibility` の流れで表示制御が一貫するようにしました。 
- キャッシュ対策として `index.html` の `app.js` 読込クエリを更新しました（`app.js?v=20260508-worktype-schema-switch-fix`）。

### Testing
- `node --check app.js` を実行し、構文チェックは成功しました。 
- ワンショットの Node スクリプトで `WORK_TYPE_BASE_FIELDS` のマッピングを検証し、5パターンで期待どおりの基底表示項目の有無を確認しました。 
- 確認結果（自動検証スクリプト出力）: 建設業許可は `permitOfficeAddress` / `permitOfficerCount` / `permitQualifiedCount` を表示し、車庫証明／自動車移転登録／相続手続初回ヒアリング／株式会社設立 の各パターンでは上記建設業固定項目は表示対象外であることを確認しました。 
- 実行したコマンド: `node --check app.js` とワンショット `node - <<'NODE' ... NODE`（`WORK_TYPE_BASE_FIELDS` の5パターン検証）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdccdbb02883339eaa7b7fdee08d2b)