### PR TITLE
許認可ヒアリング：シナリオ切替時の固定項目表示を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -727,9 +727,10 @@ function bindEvents() {
   caseTaskForm?.addEventListener("submit", handleCaseTaskSubmit);
   caseDocumentForm?.addEventListener("submit", handleCaseDocumentSubmit);
   permitHearingForm?.addEventListener("submit", handlePermitHearingSubmit);
-  permitScenarioSelect?.addEventListener("change", () => {
-    renderWorkTypeFields();
-    syncPermitBaseFieldsVisibility();
+  permitScenarioSelect?.addEventListener("change", (event) => {
+    const scenarioKey = String(event?.target?.value || "");
+    renderWorkTypeFields(scenarioKey);
+    syncPermitBaseFieldsVisibility(scenarioKey);
   });
   permitHearingForm?.elements?.namedItem("permitCaseId")?.addEventListener?.("change", syncPermitBaseFieldsVisibility);
   permitDocumentsList?.addEventListener("input", syncPermitGeneratedFromInputs);
@@ -1095,7 +1096,9 @@ function buildPermitBranchingResult(baseDocs, baseTasks, conditions) {
   return { docs, tasks, addedDocs, addedTasks, estimateAdjustments };
 }
 
-function getCurrentPermitScenarioKey() {
+function getCurrentPermitScenarioKey(explicitScenarioKey = "") {
+  const direct = String(explicitScenarioKey || "").trim();
+  if (direct) return direct;
   if (!permitScenarioSelect) return "";
   const selected = String(permitScenarioSelect.value || "").trim();
   if (selected) return selected;
@@ -1111,9 +1114,9 @@ function resolveWorkTypeSchema(scenarioKey) {
   return WORK_TYPE_FIELD_SCHEMA[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_FIELD_SCHEMA.default || [];
 }
 
-function renderWorkTypeFields() {
+function renderWorkTypeFields(explicitScenarioKey = "") {
   if (!permitWorkTypeFields || !permitScenarioSelect) return;
-  const scenarioKey = getCurrentPermitScenarioKey();
+  const scenarioKey = getCurrentPermitScenarioKey(explicitScenarioKey);
   const schema = resolveWorkTypeSchema(scenarioKey);
   const previous = permitHearingForm ? Object.fromEntries(new FormData(permitHearingForm).entries()) : {};
   permitWorkTypeFields.innerHTML = schema.map((field) => {
@@ -1133,9 +1136,9 @@ function getPermitBaseFieldConfig(scenarioKey) {
   return WORK_TYPE_BASE_FIELDS[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_BASE_FIELDS.default;
 }
 
-function syncPermitBaseFieldsVisibility() {
+function syncPermitBaseFieldsVisibility(explicitScenarioKey = "") {
   if (!permitHearingForm || !permitScenarioSelect) return;
-  const scenarioKey = getCurrentPermitScenarioKey();
+  const scenarioKey = getCurrentPermitScenarioKey(explicitScenarioKey);
   const visibleFieldNames = new Set(getPermitBaseFieldConfig(scenarioKey));
   const baseFieldIdMap = {
     permitApplicantType: "permit-applicant-type",

--- a/app.js
+++ b/app.js
@@ -727,7 +727,11 @@ function bindEvents() {
   caseTaskForm?.addEventListener("submit", handleCaseTaskSubmit);
   caseDocumentForm?.addEventListener("submit", handleCaseDocumentSubmit);
   permitHearingForm?.addEventListener("submit", handlePermitHearingSubmit);
-  permitScenarioSelect?.addEventListener("change", renderWorkTypeFields);
+  permitScenarioSelect?.addEventListener("change", () => {
+    renderWorkTypeFields();
+    syncPermitBaseFieldsVisibility();
+  });
+  permitHearingForm?.elements?.namedItem("permitCaseId")?.addEventListener?.("change", syncPermitBaseFieldsVisibility);
   permitDocumentsList?.addEventListener("input", syncPermitGeneratedFromInputs);
   permitTasksList?.addEventListener("input", syncPermitGeneratedFromInputs);
   permitDocumentsList?.addEventListener("click", handlePermitGeneratedListClick);
@@ -764,6 +768,7 @@ function bindEvents() {
   caseStatusFilterSelect?.addEventListener("change", handleCaseStatusFilterChange);
   caseDeadlineFilterSelect?.addEventListener("change", handleCaseDeadlineFilterChange);
   if (caseFilterClearBtn) caseFilterClearBtn.dataset.action = "clear_case_filters";
+  syncPermitBaseFieldsVisibility();
   salesSearchInput?.addEventListener("input", handleSalesSearchInput);
   if (salesFilterClearBtn) salesFilterClearBtn.dataset.action = "clear_sales_search";
   expensesSearchInput?.addEventListener("input", handleExpensesSearchInput);
@@ -1090,6 +1095,14 @@ function buildPermitBranchingResult(baseDocs, baseTasks, conditions) {
   return { docs, tasks, addedDocs, addedTasks, estimateAdjustments };
 }
 
+function getCurrentPermitScenarioKey() {
+  if (!permitScenarioSelect) return "";
+  const selected = String(permitScenarioSelect.value || "").trim();
+  if (selected) return selected;
+  const formSelected = String(permitHearingForm?.elements?.namedItem("permitScenario")?.value || "").trim();
+  return formSelected;
+}
+
 function resolveWorkTypeCategory(scenarioKey) {
   return SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey))?.key || "default";
 }
@@ -1100,7 +1113,8 @@ function resolveWorkTypeSchema(scenarioKey) {
 
 function renderWorkTypeFields() {
   if (!permitWorkTypeFields || !permitScenarioSelect) return;
-  const schema = resolveWorkTypeSchema(String(permitScenarioSelect.value || ""));
+  const scenarioKey = getCurrentPermitScenarioKey();
+  const schema = resolveWorkTypeSchema(scenarioKey);
   const previous = permitHearingForm ? Object.fromEntries(new FormData(permitHearingForm).entries()) : {};
   permitWorkTypeFields.innerHTML = schema.map((field) => {
     const value = previous[field.name] ?? field.value ?? "";
@@ -1121,7 +1135,8 @@ function getPermitBaseFieldConfig(scenarioKey) {
 
 function syncPermitBaseFieldsVisibility() {
   if (!permitHearingForm || !permitScenarioSelect) return;
-  const visibleFieldNames = new Set(getPermitBaseFieldConfig(String(permitScenarioSelect.value || "")));
+  const scenarioKey = getCurrentPermitScenarioKey();
+  const visibleFieldNames = new Set(getPermitBaseFieldConfig(scenarioKey));
   const baseFieldIdMap = {
     permitApplicantType: "permit-applicant-type",
     permitApplicationType: "permit-application-type",
@@ -1136,9 +1151,12 @@ function syncPermitBaseFieldsVisibility() {
     permitMemo: "permit-memo",
   };
   Object.entries(baseFieldIdMap).forEach(([name, id]) => {
-    const control = document.getElementById(id);
-    const label = control?.closest?.("label") || control?.parentElement;
-    if (label) label.hidden = !visibleFieldNames.has(name);
+    const control = document.getElementById(id) || permitHearingForm.elements.namedItem(name);
+    const label = control?.closest?.("label") || permitHearingForm.querySelector(`label[for="${id}"]`) || control?.parentElement;
+    const wrapper = label?.closest?.(".form-row, .form-grid, .inline-field") || label;
+    const isVisible = visibleFieldNames.has(name);
+    if (label) label.hidden = !isVisible;
+    if (wrapper && wrapper !== label && wrapper.children.length === 1) wrapper.hidden = !isVisible;
   });
 }
 


### PR DESCRIPTION
### Motivation
- 許認可ヒアリングでシナリオを「遺産分割協議書 作成準備」などに切り替えても、建設業向け固定項目（事業所所在地・役員人数・有資格者人数）が残る不整合を解消するための修正です。 
- 原因は `permitScenarioSelect.value` のみを参照していたシナリオ取得と、DOM 要素（label/wrapper）解決の脆弱さ、及び初期表示／案件選択時の同期漏れにありました。 
- 変更は小手先ではなく、シナリオ取得経路と表示同期ルートを一元化して根本対処します。

### Description
- `getCurrentPermitScenarioKey()` を追加してシナリオキー取得を一元化し、`renderWorkTypeFields()` と `syncPermitBaseFieldsVisibility()` が同じ経路を使うようにしました（`getCurrentPermitScenarioKey` を参照）。
- `syncPermitBaseFieldsVisibility()` を強化して `id` と `name` の両方からコントロールを解決し、`label` とそのラッパー（`.form-row/.form-grid/.inline-field` 等）に対して堅牢に `hidden` を設定するようにしました。 
- イベントトリガーを追加・強化して `permitScenarioSelect` の `change` で `renderWorkTypeFields()` と `syncPermitBaseFieldsVisibility()` を即時実行し、`permitCaseId` 変更時にも同期を走らせ、`bindEvents()` 内で初期同期を実行するようにしました。 
- 実装後の固定項目表示パターン（各パターンで表示される固定項目一覧）: 相続手続/遺産分割協議書は `申請者名`、`メモ` のみ表示（事業所所在地・役員人数・有資格者人数は非表示）、車庫証明/自動車移転登録は `申請区分`、`申請者名`、`メモ` を表示（事業所所在地等は非表示）、建設業許可は `法人/個人`、`申請区分`、`事業所所在地`、`役員人数`、`有資格者人数`、`メモ` を表示、会社設立は `申請区分`、`申請者名`、`メモ` を表示（建設業向けの役員/有資格者は非表示）。

### Testing
- `node --check app.js` を実行して構文チェックは成功しました。 
- `node --check estimate-calculator.js` を実行して構文チェックは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde03688f48333a7b172f491adb990)