### PR TITLE
許認可ヒアリングの固定項目表示を業務カテゴリ単位で統一

### DIFF
--- a/app.js
+++ b/app.js
@@ -997,6 +997,20 @@ const SCENARIO_WORK_TYPE_CONFIG = [
   { key: "zairyu", scenarios: ["zairyu_nintei", "zairyu_henko", "zairyu_koshin"] },
   { key: "inheritance", scenarios: ["sozoku_initial", "isan_bunkatsu_prep", "kousei_yuigon_prep"] },
 ];
+const PERMIT_BASE_FIELD_ID_MAP = {
+  permitApplicantType: "permit-applicant-type",
+  permitApplicationType: "permit-application-type",
+  permitJurisdictionPrefecture: "permit-jurisdiction-prefecture",
+  permitJurisdictionCity: "permit-jurisdiction-city",
+  permitApplicantName: "permit-applicant-name",
+  permitOfficeAddress: "permit-office-address",
+  permitOfficerCount: "permit-officer-count",
+  permitQualifiedCount: "permit-qualified-count",
+  permitOnlineApplication: "permit-online-application",
+  permitUrgency: "permit-urgency",
+  permitMemo: "permit-memo",
+};
+
 const WORK_TYPE_BASE_FIELDS = {
   default: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitMemo"],
   construction: ["permitApplicantType", "permitApplicationType", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitMemo"],
@@ -1009,6 +1023,16 @@ const WORK_TYPE_BASE_FIELDS = {
   inheritance: ["permitApplicantName", "permitMemo"],
   automobile: ["permitApplicationType", "permitApplicantName", "permitMemo"],
 };
+
+const PERMIT_CATEGORY_CONFIG = Object.freeze(
+  Object.fromEntries(Object.keys(WORK_TYPE_BASE_FIELDS).map((categoryKey) => [
+    categoryKey,
+    {
+      baseFields: WORK_TYPE_BASE_FIELDS[categoryKey],
+      dynamicSchema: WORK_TYPE_FIELD_SCHEMA[categoryKey] || WORK_TYPE_FIELD_SCHEMA.default || [],
+    },
+  ])),
+);
 const PERMIT_TASK_RULES = [
   { matcher: (key) => ["zairyu_nintei", "zairyu_henko", "zairyu_koshin"].includes(key), tasks: ["在留資格別必要書類確認", "申請取次資格確認", "本人・所属機関・代理人の提出可否確認"] },
   { matcher: (key) => ["sozoku_initial", "isan_bunkatsu_prep", "kousei_yuigon_prep"].includes(key), tasks: ["紛争性の有無確認", "相続登記の司法書士連携要否確認", "相続税申告の税理士連携要否確認"] },
@@ -1083,21 +1107,32 @@ function buildPermitBranchingResult(baseDocs, baseTasks, conditions) {
 }
 
 function getCurrentPermitScenarioKey(explicitScenarioKey = "") {
-  const direct = String(explicitScenarioKey || "").trim();
+  const direct = normalizePermitScenarioKey(explicitScenarioKey);
   if (direct) return direct;
   if (!permitScenarioSelect) return "";
-  const selected = String(permitScenarioSelect.value || "").trim();
+  const selected = normalizePermitScenarioKey(permitScenarioSelect.value);
   if (selected) return selected;
-  const formSelected = String(permitHearingForm?.elements?.namedItem("permitScenario")?.value || "").trim();
-  return formSelected;
+  return normalizePermitScenarioKey(permitHearingForm?.elements?.namedItem("permitScenario")?.value || "");
+}
+
+function normalizePermitScenarioKey(rawScenarioKey = "") {
+  const candidate = String(rawScenarioKey || "").trim();
+  if (!candidate) return "";
+  if (PERMIT_SCENARIO_MASTER[candidate]) return candidate;
+  return Object.entries(PERMIT_SCENARIO_MASTER).find(([, scenario]) => String(scenario?.label || "").trim() === candidate)?.[0] || "";
 }
 
 function resolveWorkTypeCategory(scenarioKey) {
-  return SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(scenarioKey))?.key || "default";
+  const normalizedScenarioKey = normalizePermitScenarioKey(scenarioKey);
+  return SCENARIO_WORK_TYPE_CONFIG.find((entry) => entry.scenarios.includes(normalizedScenarioKey))?.key || "default";
+}
+
+function resolvePermitCategoryConfig(scenarioKey) {
+  return PERMIT_CATEGORY_CONFIG[resolveWorkTypeCategory(scenarioKey)] || PERMIT_CATEGORY_CONFIG.default;
 }
 
 function resolveWorkTypeSchema(scenarioKey) {
-  return WORK_TYPE_FIELD_SCHEMA[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_FIELD_SCHEMA.default || [];
+  return resolvePermitCategoryConfig(scenarioKey).dynamicSchema;
 }
 
 function renderWorkTypeFields(explicitScenarioKey = "") {
@@ -1119,27 +1154,14 @@ function renderWorkTypeFields(explicitScenarioKey = "") {
 }
 
 function getPermitBaseFieldConfig(scenarioKey) {
-  return WORK_TYPE_BASE_FIELDS[resolveWorkTypeCategory(scenarioKey)] || WORK_TYPE_BASE_FIELDS.default;
+  return resolvePermitCategoryConfig(scenarioKey).baseFields;
 }
 
 function syncPermitBaseFieldsVisibility(explicitScenarioKey = "") {
   if (!permitHearingForm || !permitScenarioSelect) return;
   const scenarioKey = getCurrentPermitScenarioKey(explicitScenarioKey);
   const visibleFieldNames = new Set(getPermitBaseFieldConfig(scenarioKey));
-  const baseFieldIdMap = {
-    permitApplicantType: "permit-applicant-type",
-    permitApplicationType: "permit-application-type",
-    permitJurisdictionPrefecture: "permit-jurisdiction-prefecture",
-    permitJurisdictionCity: "permit-jurisdiction-city",
-    permitApplicantName: "permit-applicant-name",
-    permitOfficeAddress: "permit-office-address",
-    permitOfficerCount: "permit-officer-count",
-    permitQualifiedCount: "permit-qualified-count",
-    permitOnlineApplication: "permit-online-application",
-    permitUrgency: "permit-urgency",
-    permitMemo: "permit-memo",
-  };
-  Object.entries(baseFieldIdMap).forEach(([name, id]) => {
+  Object.entries(PERMIT_BASE_FIELD_ID_MAP).forEach(([name, id]) => {
     const control = document.getElementById(id) || permitHearingForm.elements.namedItem(name);
     const label = control?.closest?.("label") || permitHearingForm.querySelector(`label[for="${id}"]`) || control?.parentElement;
     const wrapper = label?.closest?.(".form-row, .form-grid, .inline-field") || label;


### PR DESCRIPTION
### Motivation
- 特定の v1 対象業務を選択した際に建設業向けの固定項目（事業所所在地・役員人数・有資格者人数）が残ってしまう問題を根本から修正するため、表示制御を定義駆動で一元化しました。 
- `renderWorkTypeFields`/`getPermitBaseFieldConfig`/`syncPermitBaseFieldsVisibility` と初期表示・選択変更の解決経路を統一して表示ロジックの不整合を無くします。

### Description
- 画面制御を一元化するために `PERMIT_BASE_FIELD_ID_MAP`（name↔id マップ）と `PERMIT_CATEGORY_CONFIG`（カテゴリごとの `baseFields` と `dynamicSchema` を集約）を追加し、固定項目定義を1か所にまとめました。 
- シナリオキー/ラベル揺れを吸収する `normalizePermitScenarioKey` を追加し、`getCurrentPermitScenarioKey`→`resolveWorkTypeCategory`→`resolvePermitCategoryConfig` の同一経路で `renderWorkTypeFields`/`getPermitBaseFieldConfig`/`syncPermitBaseFieldsVisibility` を参照するように統一しました。 
- カテゴリ別の固定項目表示設計は次のとおりです（今回の実装で表示される固定項目名は `WORK_TYPE_BASE_FIELDS` を基準に設定しています）： `construction` は `permitApplicantType`, `permitApplicationType`, `permitOfficeAddress`, `permitOfficerCount`, `permitQualifiedCount`, `permitMemo` を表示し、`automobile` は `permitApplicationType`, `permitApplicantName`, `permitMemo` のみを表示し（そのため車庫証明 普通車 / 自動車 移転登録 では `permitOfficeAddress` / `permitOfficerCount` / `permitQualifiedCount` は非表示になります）、`inheritance` は `permitApplicantName`, `permitMemo`、`company_establishment` は `permitApplicationType`, `permitApplicantName`, `permitMemo` を表示します。 
- 変更は `app.js` のみで、表示制御ロジックの統一に集中しています（動的フィールドスキーマは既存の `WORK_TYPE_FIELD_SCHEMA` を利用）。

### Testing
- 自動構文チェックとして `node --check app.js` を実行し成功しました。 
- 依存ファイルの静的チェックとして `node --check estimate-calculator.js` を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf1bcab0c833391ebae56cc121a5e)