### PR TITLE
許認可ヒアリング固定項目をカテゴリ別DOM生成へ刷新

### DIFF
--- a/app.js
+++ b/app.js
@@ -997,31 +997,31 @@ const SCENARIO_WORK_TYPE_CONFIG = [
   { key: "zairyu", scenarios: ["zairyu_nintei", "zairyu_henko", "zairyu_koshin"] },
   { key: "inheritance", scenarios: ["sozoku_initial", "isan_bunkatsu_prep", "kousei_yuigon_prep"] },
 ];
-const PERMIT_BASE_FIELD_ID_MAP = {
-  permitApplicantType: "permit-applicant-type",
-  permitApplicationType: "permit-application-type",
-  permitJurisdictionPrefecture: "permit-jurisdiction-prefecture",
-  permitJurisdictionCity: "permit-jurisdiction-city",
-  permitApplicantName: "permit-applicant-name",
-  permitOfficeAddress: "permit-office-address",
-  permitOfficerCount: "permit-officer-count",
-  permitQualifiedCount: "permit-qualified-count",
-  permitOnlineApplication: "permit-online-application",
-  permitUrgency: "permit-urgency",
-  permitMemo: "permit-memo",
+const PERMIT_BASE_FIELD_SCHEMA = {
+  permitApplicantType: { label: "法人/個人", type: "select", options: [{ value: "法人", label: "法人" }, { value: "個人", label: "個人" }] },
+  permitApplicationType: { label: "申請区分", type: "text", maxlength: 120, placeholder: "例: 新規" },
+  permitJurisdictionPrefecture: { label: "管轄都道府県", type: "text", maxlength: 40, placeholder: "例: 大阪府" },
+  permitJurisdictionCity: { label: "管轄市区町村", type: "text", maxlength: 80, placeholder: "例: 大阪市北区" },
+  permitApplicantName: { label: "申請者名", type: "text", maxlength: 120 },
+  permitOfficeAddress: { label: "事業所所在地", type: "text", maxlength: 200 },
+  permitOfficerCount: { label: "役員人数", type: "number", min: 0, value: 0 },
+  permitQualifiedCount: { label: "有資格者人数", type: "number", min: 0, value: 0 },
+  permitOnlineApplication: { label: "電子申請希望", type: "select", options: [{ value: "false", label: "希望しない" }, { value: "true", label: "希望する" }] },
+  permitUrgency: { label: "急ぎ度", type: "select", options: [{ value: "通常", label: "通常" }, { value: "急ぎ", label: "急ぎ" }] },
+  permitMemo: { label: "メモ", type: "textarea", rows: 3, maxlength: 2000 },
 };
 
 const WORK_TYPE_BASE_FIELDS = {
   default: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitMemo"],
-  construction: ["permitApplicantType", "permitApplicationType", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitMemo"],
-  takken: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-  kobutsu: ["permitApplicantType", "permitMemo"],
-  company_establishment: ["permitApplicationType", "permitApplicantName", "permitMemo"],
-  startup_finance: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-  sangyo_unpan: ["permitApplicantType", "permitApplicationType", "permitMemo"],
-  zairyu: ["permitApplicationType", "permitApplicantName", "permitMemo"],
-  inheritance: ["permitApplicantName", "permitMemo"],
-  automobile: ["permitApplicationType", "permitApplicantName", "permitMemo"],
+  construction: ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOfficeAddress", "permitOfficerCount", "permitQualifiedCount", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  takken: ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  kobutsu: ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  company_establishment: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  startup_finance: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  sangyo_unpan: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  zairyu: ["permitApplicantType", "permitApplicationType", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  inheritance: ["permitApplicantType", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
+  automobile: ["permitApplicantType", "permitApplicationType", "permitJurisdictionPrefecture", "permitJurisdictionCity", "permitApplicantName", "permitOnlineApplication", "permitUrgency", "permitMemo"],
 };
 
 const PERMIT_CATEGORY_CONFIG = Object.freeze(
@@ -1135,12 +1135,36 @@ function resolveWorkTypeSchema(scenarioKey) {
   return resolvePermitCategoryConfig(scenarioKey).dynamicSchema;
 }
 
+function renderPermitBaseFields(baseFieldNames, previousValues) {
+  const baseFieldsContainer = document.getElementById("permit-base-fields");
+  if (!baseFieldsContainer) return;
+  baseFieldsContainer.innerHTML = baseFieldNames.map((name) => {
+    const field = PERMIT_BASE_FIELD_SCHEMA[name];
+    if (!field) return "";
+    const value = previousValues[name] ?? field.value ?? "";
+    if (field.type === "select") {
+      const options = (field.options || []).map((option) => `<option value="${escapeHtml(String(option.value))}"${String(value) === String(option.value) ? " selected" : ""}>${escapeHtml(String(option.label))}</option>`).join("");
+      return `<label>${escapeHtml(field.label)}<select name="${escapeHtml(name)}">${options}</select></label>`;
+    }
+    if (field.type === "textarea") {
+      const rows = Number.isFinite(Number(field.rows)) ? ` rows="${Number(field.rows)}"` : "";
+      const maxlength = Number.isFinite(Number(field.maxlength)) ? ` maxlength="${Number(field.maxlength)}"` : "";
+      return `<label>${escapeHtml(field.label)}<textarea name="${escapeHtml(name)}"${rows}${maxlength}>${escapeHtml(String(value))}</textarea></label>`;
+    }
+    const min = Number.isFinite(Number(field.min)) ? ` min="${Number(field.min)}"` : "";
+    const maxlength = Number.isFinite(Number(field.maxlength)) ? ` maxlength="${Number(field.maxlength)}"` : "";
+    const placeholder = field.placeholder ? ` placeholder="${escapeHtml(field.placeholder)}"` : "";
+    return `<label>${escapeHtml(field.label)}<input name="${escapeHtml(name)}" type="${escapeHtml(field.type || "text")}"${min}${maxlength} value="${escapeHtml(String(value))}"${placeholder} /></label>`;
+  }).join("");
+}
+
 function renderWorkTypeFields(explicitScenarioKey = "") {
   if (!permitWorkTypeFields || !permitScenarioSelect) return;
   const scenarioKey = getCurrentPermitScenarioKey(explicitScenarioKey);
-  const schema = resolveWorkTypeSchema(scenarioKey);
+  const { baseFields, dynamicSchema } = resolvePermitCategoryConfig(scenarioKey);
   const previous = permitHearingForm ? Object.fromEntries(new FormData(permitHearingForm).entries()) : {};
-  permitWorkTypeFields.innerHTML = schema.map((field) => {
+  renderPermitBaseFields(baseFields, previous);
+  permitWorkTypeFields.innerHTML = dynamicSchema.map((field) => {
     const value = previous[field.name] ?? field.value ?? "";
     const min = Number.isFinite(Number(field.min)) ? ` min="${Number(field.min)}"` : "";
     const placeholder = field.placeholder ? ` placeholder="${escapeHtml(field.placeholder)}"` : "";
@@ -1150,7 +1174,6 @@ function renderWorkTypeFields(explicitScenarioKey = "") {
     }
     return `<label class="${field.fullWidth ? "full-width" : ""}">${escapeHtml(field.label)}<input name="${escapeHtml(field.name)}" type="${escapeHtml(field.type || "text")}"${min} value="${escapeHtml(String(value))}"${placeholder} /></label>`;
   }).join("");
-  syncPermitBaseFieldsVisibility();
 }
 
 function getPermitBaseFieldConfig(scenarioKey) {
@@ -1158,17 +1181,7 @@ function getPermitBaseFieldConfig(scenarioKey) {
 }
 
 function syncPermitBaseFieldsVisibility(explicitScenarioKey = "") {
-  if (!permitHearingForm || !permitScenarioSelect) return;
-  const scenarioKey = getCurrentPermitScenarioKey(explicitScenarioKey);
-  const visibleFieldNames = new Set(getPermitBaseFieldConfig(scenarioKey));
-  Object.entries(PERMIT_BASE_FIELD_ID_MAP).forEach(([name, id]) => {
-    const control = document.getElementById(id) || permitHearingForm.elements.namedItem(name);
-    const label = control?.closest?.("label") || permitHearingForm.querySelector(`label[for="${id}"]`) || control?.parentElement;
-    const wrapper = label?.closest?.(".form-row, .form-grid, .inline-field") || label;
-    const isVisible = visibleFieldNames.has(name);
-    if (label) label.hidden = !isVisible;
-    if (wrapper && wrapper !== label && wrapper.children.length === 1) wrapper.hidden = !isVisible;
-  });
+  renderWorkTypeFields(explicitScenarioKey);
 }
 
 if (window.location.protocol === "file:") {

--- a/index.html
+++ b/index.html
@@ -850,33 +850,8 @@
                   v1対象業務
                   <select id="permit-scenario" name="permitScenario" required></select>
                 </label>
-                <label>法人/個人
-                  <select id="permit-applicant-type" name="permitApplicantType">
-                    <option value="法人">法人</option>
-                    <option value="個人">個人</option>
-                  </select>
-                </label>
-                <label>申請区分<input id="permit-application-type" name="permitApplicationType" type="text" maxlength="120" placeholder="例: 新規" /></label>
-                <label>管轄都道府県<input id="permit-jurisdiction-prefecture" name="permitJurisdictionPrefecture" type="text" maxlength="40" placeholder="例: 大阪府" /></label>
-                <label>管轄市区町村<input id="permit-jurisdiction-city" name="permitJurisdictionCity" type="text" maxlength="80" placeholder="例: 大阪市北区" /></label>
-                <label>申請者名<input id="permit-applicant-name" name="permitApplicantName" type="text" maxlength="120" /></label>
-                <label>事業所所在地<input id="permit-office-address" name="permitOfficeAddress" type="text" maxlength="200" /></label>
-                <label>役員人数<input id="permit-officer-count" name="permitOfficerCount" type="number" min="0" value="0" /></label>
-                <label>有資格者人数<input id="permit-qualified-count" name="permitQualifiedCount" type="number" min="0" value="0" /></label>
+                <div id="permit-base-fields"></div>
                 <div id="permit-worktype-fields" class="permit-worktype-fields"></div>
-                <label>電子申請希望
-                  <select id="permit-online-application" name="permitOnlineApplication">
-                    <option value="false">希望しない</option>
-                    <option value="true">希望する</option>
-                  </select>
-                </label>
-                <label>急ぎ度
-                  <select id="permit-urgency" name="permitUrgency">
-                    <option value="通常">通常</option>
-                    <option value="急ぎ">急ぎ</option>
-                  </select>
-                </label>
-                <label>メモ<textarea id="permit-memo" name="permitMemo" rows="3" maxlength="2000"></textarea></label>
                 <button id="permit-generate-btn" type="submit">必要書類・タスクを生成</button>
               </form>
               <div id="permit-hearing-result" class="permit-result" hidden>


### PR DESCRIPTION
### Motivation
- 固定項目を後から`hidden`で切替える実装だと不要な項目がDOM上に残ってしまうため、選択中のv1対象業務カテゴリに応じて固定項目そのものを生成する方式に切り替えるための改修です。
- 特に建設業以外で「事業所所在地」「役員人数」「有資格者人数」がDOM/画面に残らないようにしたい要求に応えます。

### Description
- `PERMIT_BASE_FIELD_SCHEMA` を新設して許認可の固定項目定義を一元化し、`WORK_TYPE_BASE_FIELDS` をカテゴリごとの期待表示に合わせて更新しました（`app.js`）。
- `renderPermitBaseFields` を追加し、`renderWorkTypeFields` で固定項目（baseFields）と動的項目（dynamicSchema）を連続的に再生成するルートに一本化しました（`app.js`）。
- 既存の静的な固定項目ラベル/入力群を `index.html` から削除して `#permit-base-fields` のプレースホルダに置換し、カテゴリ切替でDOMを再構築するようにしました（`index.html`）。
- 互換関数 `syncPermitBaseFieldsVisibility` は残しつつ内部を再描画呼び出しに切り替え、hiddenベースの表示制御依存を廃止しました（`app.js`）。

### Testing
- `node --check app.js` — pass.
- `node --check estimate-calculator.js` — pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf77f6a288333b8d3d1c6e3016d33)