### PR TITLE
既存導線の安定化: 見積→案件化/請求作成の重複防止と金額整合表示の強化

### DIFF
--- a/app.js
+++ b/app.js
@@ -7636,7 +7636,6 @@ async function handleCreateInvoiceFromEstimate(estimateId) {
     return;
   }
   const existingSale = state.sales.find((sale) => sale.estimateId === estimateId);
-  if (existingSale && !window.confirm("この見積はすでに請求作成済みです。請求を追加作成しますか？")) return null;
   if (existingSale) {
     showAppMessage("この見積は請求作成済みです。重複登録を防ぐため追加作成は行いません。");
     return existingSale;

--- a/app.js
+++ b/app.js
@@ -7352,11 +7352,17 @@ function renderEstimates() {
   filtered.forEach((entry) => {
     const isCaseCreated = state.cases.some((c) => c.estimateId === entry.id) || Boolean(entry.caseId);
     const hasCreatedInvoice = state.sales.some((sale) => sale.estimateId === entry.id);
+    const linkedSale = state.sales.find((sale) => sale.estimateId === entry.id);
+    const invoiceAmount = Number(linkedSale?.invoiceAmount ?? 0);
+    const estimateAmount = Number(entry.totalAmount ?? entry.total ?? 0);
+    const hasAmountMismatch = !!linkedSale && invoiceAmount !== estimateAmount;
     const li = document.createElement("li");
     li.className = "item estimate-card";
     li.dataset.id = entry.id;
     const itemCount = state.estimateItems.filter((row) => row.estimateId === entry.id).length;
     const casedLabel = isCaseCreated ? "案件化済み" : "未案件化";
+    const invoiceLabel = hasCreatedInvoice ? "請求書作成済み" : "請求書未作成";
+    const saleLabel = hasCreatedInvoice ? "売上登録済み" : "売上未登録";
     const sourceLabel = entry.estimateSourceLabel || getEstimateSourceLabel(entry.estimateSource);
     li.innerHTML = `
       <div class="estimate-card-body">
@@ -7371,12 +7377,15 @@ function renderEstimates() {
           <p class="meta"><span>合計金額:</span> ${formatCurrency(entry.totalAmount ?? entry.total ?? 0)}</p>
           <p class="meta"><span>明細件数:</span> ${itemCount}件</p>
           <p class="meta"><span>案件化:</span> ${casedLabel}</p>
+          <p class="meta"><span>請求:</span> ${invoiceLabel}</p>
+          <p class="meta"><span>売上:</span> ${saleLabel}</p>
+          <p class="meta"><span>金額整合:</span> ${hasAmountMismatch ? "⚠ 不一致（見積と請求）" : "一致"}</p>
         </div>
       </div>
       <div class="row-actions estimate-card-actions">
         <button type="button" class="secondary-btn estimate-edit-btn" data-action="edit_estimate" data-list-action="edit_estimate">編集</button>
         <button type="button" class="secondary-btn card-select-btn" data-action="select_estimate" data-estimate-id="${entry.id}">${new Set(getSelectedIdsByKey('selectedEstimateIds')).has(String(entry.id))?"☑":"☐"}</button><button type="button" class="danger-btn estimate-delete-btn" data-action="delete_estimate" data-list-action="delete_estimate">削除</button>
-        <button type="button" class="secondary-btn create-case-btn" data-action="create_case_from_estimate" data-list-action="create_case_from_estimate" ${isCaseCreated ? "disabled" : ""}>${isCaseCreated ? "案件化済み" : "案件化"}</button>
+        <button type="button" class="secondary-btn create-case-btn" data-action="create_case_from_estimate" data-list-action="create_case_from_estimate">案件化</button>
         <button type="button" class="secondary-btn estimate-estimate-print-btn" data-action="print_estimate" data-list-action="print_estimate">見積書出力</button>
         <button type="button" class="secondary-btn estimate-print-btn" data-action="print_invoice_from_estimate" data-list-action="print_invoice_from_estimate">請求書出力</button>
         <button type="button" class="secondary-btn estimate-delivery-note-btn" data-action="print_delivery_note" data-list-action="print_delivery_note">納品書</button>
@@ -7385,7 +7394,7 @@ function renderEstimates() {
         <button type="button" class="secondary-btn estimate-inspection-report-btn" data-action="print_acceptance_certificate" data-list-action="print_acceptance_certificate">検収書</button>
         <button type="button" class="secondary-btn estimate-estimate-xlsx-btn" data-action="export_estimate_excel" data-list-action="export_estimate_excel">見積Excel</button>
         <button type="button" class="secondary-btn estimate-xlsx-btn" data-action="export_invoice_excel_from_estimate" data-list-action="export_invoice_excel_from_estimate">請求Excel</button>
-        <button type="button" class="secondary-btn create-invoice-btn" data-action="create_invoice_from_estimate" data-list-action="create_invoice_from_estimate" ${hasCreatedInvoice ? "disabled" : ""}>${hasCreatedInvoice ? "請求済み" : "請求作成"}</button>
+        <button type="button" class="secondary-btn create-invoice-btn" data-action="create_invoice_from_estimate" data-list-action="create_invoice_from_estimate">請求作成</button>
       </div>
     `;
     estimateList.appendChild(li);
@@ -7521,13 +7530,10 @@ async function createCaseFromEstimate(estimateId) {
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
   if (!estimate) throw new Error("対象見積が見つかりません。");
   const existingCase = state.cases.find((c) => c.estimateId === estimateId || c.id === estimate.caseId);
-  if (existingCase) {
-    const duplicatedError = new Error("この見積はすでに案件化済みです。");
-    duplicatedError.code = "DUPLICATE_ESTIMATE_CASE";
-    throw duplicatedError;
-  }
+  if (existingCase) return existingCase;
   const customerName = estimate.customerName || estimate.customer_name || "顧客不明";
-  const caseName = estimate.subject || estimate.caseName || estimate.title || estimate.estimateTitle || "見積から作成した案件";
+  const estimateTitle = estimate.subject || estimate.caseName || estimate.title || estimate.estimateTitle || "";
+  const caseName = `${estimateTitle || "見積"} / ${customerName}`.replace(/\s+/g, " ").trim();
   const estimateAmount = Number(estimate.totalAmount || estimate.total || estimate.amount || estimate.estimateAmount || 0);
   const rawPayload = {
     user_id: currentUser.id,
@@ -7561,6 +7567,18 @@ async function createCaseFromEstimate(estimateId) {
 
 async function handleCreateCaseFromEstimate(estimateId) {
   console.log("CREATE CASE START", estimateId);
+  const estimate = state.estimates.find((entry) => entry.id === estimateId);
+  if (!estimate) {
+    showAppMessage("対象見積が見つかりません。", true);
+    return null;
+  }
+  const existingCase = state.cases.find((c) => c.estimateId === estimateId || c.id === estimate.caseId);
+  const confirmMessage = getCaseCreationConfirmationMessage(estimate, existingCase);
+  if (confirmMessage && !window.confirm(confirmMessage)) return null;
+  if (existingCase) {
+    showAppMessage("この見積はすでに案件化済みです。重複作成は行いません。");
+    return existingCase;
+  }
   return handleEstimateConversionAction({
     estimateId,
     loadingLabel: "案件化",
@@ -7580,11 +7598,7 @@ async function createInvoiceFromEstimate(estimateId) {
   const estimate = state.estimates.find((entry) => entry.id === estimateId);
   if (!estimate) throw new Error("対象見積が見つかりません。");
   const existingSale = state.sales.find((sale) => sale.estimateId === estimateId);
-  if (existingSale) {
-    const duplicatedError = new Error("この見積はすでに請求作成済みです。");
-    duplicatedError.code = "DUPLICATE_ESTIMATE_INVOICE";
-    throw duplicatedError;
-  }
+  if (existingSale) return existingSale;
   const invoiceAmount = Number(estimate.totalAmount || estimate.total || estimate.amount || estimate.estimateAmount || 0);
   if (!invoiceAmount || invoiceAmount <= 0) throw new Error("見積金額が0円のため請求を作成できません。");
   const rawPayload = {
@@ -7615,6 +7629,17 @@ async function handleCreateInvoiceFromEstimate(estimateId) {
   if (!estimateId) {
     showAppMessage("対象見積IDを取得できませんでした。", true);
     return;
+  }
+  const estimate = state.estimates.find((entry) => entry.id === estimateId);
+  if (!estimate) {
+    showAppMessage("対象見積が見つかりません。", true);
+    return;
+  }
+  const existingSale = state.sales.find((sale) => sale.estimateId === estimateId);
+  if (existingSale && !window.confirm("この見積はすでに請求作成済みです。請求を追加作成しますか？")) return null;
+  if (existingSale) {
+    showAppMessage("この見積は請求作成済みです。重複登録を防ぐため追加作成は行いません。");
+    return existingSale;
   }
   console.log("CREATE INVOICE START", estimateId);
   return handleEstimateConversionAction({
@@ -8194,6 +8219,15 @@ function resetEditMode(target) {
 
 function normalizeEstimateStatus(status) {
   return ESTIMATE_STATUS_ORDER.includes(status) ? status : "作成中";
+}
+
+function getCaseCreationConfirmationMessage(estimate, existingCase) {
+  if (existingCase || estimate?.caseId) {
+    return "この見積はすでに案件化済みです。再案件化は重複登録の原因になります。続行しますか？";
+  }
+  if (estimate?.status === "受注") return "";
+  if (estimate?.status === "失注") return "この見積は「失注」です。案件化は通常行いません。本当に続行しますか？";
+  return `この見積ステータスは「${estimate?.status || "未設定"}」です。受注前の案件化になります。続行しますか？`;
 }
 
 async function ensureCaseFromEstimate(estimateId, force = false) {


### PR DESCRIPTION
### Motivation
- 既存の実務導線（正式見積 → 受注 → 案件化 → 請求書作成 → 売上管理）を壊さずに安全性と重複防止を強化するための修正です。 
- 同一見積からの重複案件・重複請求作成の防止と、見積⇄請求の金額整合が分かる表示を最低限追加して運用上のミスを減らすことが目的です。

### Description
- `createCaseFromEstimate` を既存案件検出時は新規作成せず既存案件を返すよう変更し、再案件化時はステータスに応じた確認ダイアログを表示する補助関数 `getCaseCreationConfirmationMessage` を追加しました。 
- 案件名の自動生成を「見積件名 / 顧客名」の自然な形式に変更し、案件登録時は既存の `CASE_MUTATION_COLUMNS` を使って既存カラムのみを送信する挙動を維持しています。 
- `createInvoiceFromEstimate` とそのハンドラでも既存請求を検出したら重複作成を行わず既存請求を返す／確認を出すようにし、送信payloadは `SALES_MUTATION_COLUMNS` に限定しています。 
- 見積一覧表示を最小限拡張し、見積カードに「請求作成済み/未作成」「売上登録済み/未登録」ラベルと、見積合計と請求金額が不一致の際に分かるようなアラート表示を追加しました（大きなUI変更は行っていません）。 
- DBスキーマの変更や RLS / `service_role` の利用は行っておらず、未定義カラムをpayloadに含めない方針を維持しています。

### Testing
- 自動チェックとして `node --check app.js` が成功しました。 
- 自動チェックとして `node --check estimate-calculator.js` が成功しました。 
- 手動確認項目として以下を想定しています: 正式見積から案件化できること、同一見積から案件が重複作成されないこと、失注見積から案件化しようとした場合に強めの確認が出ること、受注以外（作成中/提出済/未回答）で案件化する際に確認が出ること、値引きあり見積から案件化しても金額が一致すること、見積書・請求書に内部加算明細/addon_breakdown/内部メモが出ないこと、請求書に値引き行が出ること、同じ見積から請求書を複数作成する場合に確認が出ること、売上登録済み/未登録の表示や既存アラート導線が壊れていないこと、およびCSV/Excel出力が壊れていないこと。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff009f6df0833390066f843473dbbd)