### PR TITLE
構造統一監査: 見積系バックアップ/復元の保存payload不整合を是正

### DIFF
--- a/app.js
+++ b/app.js
@@ -628,9 +628,9 @@ let eventsBound = false;
 let loadingCount = 0;
 let loadingTimer = null;
 let isApplyingAuthState = false;
-const BACKUP_TABLE_KEYS = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_INSERT_ORDER = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "sales", "expenses", "fixed_expenses", "daily_reports", "permit_hearings", "case_documents", "case_tasks", "estimates", "cases", "work_templates", "clients", "app_settings"];
+const BACKUP_TABLE_KEYS = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_INSERT_ORDER = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "estimate_calculations", "sales", "expenses", "fixed_expenses", "daily_reports", "permit_hearings", "case_documents", "case_tasks", "estimates", "cases", "work_templates", "clients", "app_settings"];
 const CASE_MUTATION_COLUMNS = [
   "user_id",
   "client_id",
@@ -682,8 +682,9 @@ const RESTORE_MUTATION_COLUMNS = {
   client_interactions: CLIENT_INTERACTION_MUTATION_COLUMNS,
   work_templates: ["user_id", "name", "items", "memo"],
   permit_hearings: ["id", "user_id", "case_id", "scenario_key", "scenario_label", "industry_primary", "industry_secondary", "industry_notes", "preparation_status", "application_route", "corporation_plan", "applicant_name", "applicant_kana", "contact_name", "contact_tel", "contact_email", "office_name", "office_address", "office_postal_code", "business_type", "capital", "employees_count", "officers_count", "years_in_business", "fiscal_month", "insurance_joined", "construction_career_system", "social_insurance_notes", "requested_permissions", "existing_permits", "past_admin_dispositions", "documents", "tasks", "hearing_notes", "next_actions", "status", "updated_at"],
-  estimates: ["user_id", "client_id", "title", "status", "issue_date", "expiry_date", "tax_rate", "subtotal", "tax", "total", "memo", "case_id"],
-  estimate_items: ["user_id", "estimate_id", "name", "quantity", "unit_price", "amount", "memo", "sort_order"],
+  estimates: ["user_id", "client_id", "customer_name", "estimate_title", "estimate_date", "valid_until", "status", "memo", "subtotal", "tax", "total", "estimate_source", "estimate_number", "case_id"],
+  estimate_items: ["user_id", "estimate_id", "item_name", "quantity", "unit_price", "amount", "memo", "sort_order"],
+  estimate_calculations: ["user_id", "client_id", "project_name", "work_type", "application_type", "corporate_type", "governor_type", "general_specific", "industry_count", "officer_count", "office_count", "document_level", "urgent", "expense_amount", "discount_amount", "memo", "base_fee", "addon_fee", "taxable_subtotal", "tax", "total", "addon_breakdown", "reflected_estimate_id", "reflected_at"],
   daily_reports: ["user_id", "client_id", "case_id", "report_date", "interaction_type", "work_content", "work_minutes", "next_action", "next_action_date", "memo"],
   app_settings: ["user_id", "office_name", "postal_code", "address", "tel", "email", "invoice_registration_number", "bank_info", "default_invoice_due_days", "tax_rate", "estimate_note", "invoice_note"],
 };
@@ -4974,6 +4975,7 @@ function buildBackupJson() {
       cases: Array.isArray(state.cases) ? state.cases : [],
       estimates: Array.isArray(state.estimates) ? state.estimates : [],
       estimate_items: Array.isArray(state.estimateItems) ? state.estimateItems : [],
+      estimate_calculations: Array.isArray(state.estimateCalculations) ? state.estimateCalculations : [],
       sales: Array.isArray(state.sales) ? state.sales : [],
       payments: Array.isArray(state.payments) ? state.payments : [],
       expenses: Array.isArray(state.expenses) ? state.expenses : [],


### PR DESCRIPTION
### Motivation
- 本PRは新機能追加ではなく、`app.js`/`estimate-calculator.js` 周辺の保存payload・取込/復元の構造不整合を最小限で是正するための監査修正です。
- 目的はバックアップ/復元やCSV/Excel取込で未定義カラムを送信するリスクを除去し、概算見積（estimate_calculations）データのバックアップ漏れを防ぐことです。

### Description
- `estimate_calculations` をバックアップ対象に追加し、`BACKUP_TABLE_KEYS` とエクスポートJSONの `data` に `estimate_calculations` を追加してバックアップ/復元の対象を揃えました（`app.js`）。
- 復元シーケンスに `estimate_calculations` を追加して `RESTORE_INSERT_ORDER` / `RESTORE_DELETE_ORDER` を整合させ、依存順序での復元/削除を正しく行えるようにしました（`app.js`）。
- 復元用 whitelist (`RESTORE_MUTATION_COLUMNS`) を実運用のカラム名に合わせて修正し、`estimates` / `estimate_items` の列名を実際の保存カラム（`customer_name`, `estimate_title`, `estimate_date`, `valid_until`, `estimate_number`, `item_name` 等）へ揃え、さらに `estimate_calculations` 用の whitelist を追加して `pickObjectKeys` による未定義カラム除外を保証しました（`app.js`）。
- 既存の `pickObjectKeys` と `buildSaveErrorMessage` の仕組みを維持し、最小変更で未定義カラム送信リスクを低減しています（構造統一のみ、機能変更なし）。

### Testing
- 自動チェックを実行し、構文エラーは発生しませんでした: `node --check app.js` ✅、`node --check estimate-calculator.js` ✅。
- 変更は主にバックアップ/復元 whitelist とエクスポートデータに限定しており、DBスキーマ変更・`service_role` 使用・RLS変更は行っていません。
- 手動確認を行う際の想定シナリオ（`docs/manual-test-scenarios.md` / `docs/test-data/` を参照）: 値引きあり見積、内部加算明細非表示、CSV に余計列あり取込、バックアップ復元、売上取込、金額一致表示。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00804f20f4833399c820968995d388)