### PR TITLE
売上→入金フローの整合性と重複登録防止の安定化

### DIFF
--- a/app.js
+++ b/app.js
@@ -2808,12 +2808,17 @@ async function handleSaleSubmit(event) {
     }
 
     const paymentStatus = calculatePaymentStatus(invoiceAmount, paidAmount);
+    const normalizedPaidAmount = Math.max(Number(paidAmount) || 0, 0);
+    const normalizedPaidDate = normalizedPaidAmount > 0 ? (paidDate || null) : null;
+    if (!isEdit && caseId && state.sales.some((sale) => sale.caseId === caseId)) {
+      throw new Error("この案件は既に売上登録済みです。重複登録はできません。");
+    }
     const rawPayload = {
       user_id: currentUser.id,
       case_id: caseId || null,
       invoice_amount: invoiceAmount,
-      paid_amount: paidAmount || 0,
-      paid_date: paidDate || null,
+      paid_amount: normalizedPaidAmount,
+      paid_date: normalizedPaidDate,
       due_date: dueDate || null,
       payment_status: paymentStatus,
       is_unpaid: paymentStatus !== "入金済",
@@ -3804,9 +3809,14 @@ async function deletePayment(paymentId) {
     const currentSalePaid = Number(saleRow.paid_amount || 0);
     const newPaidAmount = Math.max(0, currentSalePaid - deletedAmount);
     const paymentStatus = calculatePaymentStatus(invoiceAmount, newPaidAmount);
+    const remainingPayments = state.payments
+      .filter((entry) => entry.saleId === target.saleId && entry.id !== paymentId)
+      .slice()
+      .sort((a, b) => toSortTimestamp(b.paymentDate) - toSortTimestamp(a.paymentDate));
+    const latestPaymentDate = remainingPayments[0]?.paymentDate || null;
     const saleUpdatePayload = {
       paid_amount: newPaidAmount,
-      paid_date: newPaidAmount > 0 ? (target.paymentDate || null) : null,
+      paid_date: newPaidAmount > 0 ? latestPaymentDate : null,
       payment_status: paymentStatus,
       is_unpaid: newPaidAmount < invoiceAmount,
     };


### PR DESCRIPTION
### Motivation
- 既存の導線（案件→売上登録→入金管理→未入金/一部入金/入金済み確認）を監査し、表示や状態判定の不整合を解消して安定化するための修正です。 
- 入金ステータス判定（`paid_amount = 0`→未入金、`0 < paid_amount < invoice_amount`→一部入金、`paid_amount >= invoice_amount`→入金済み）との整合性を確実にすることを目的としています。 
- 同一案件からの誤った重複売上登録を防止して、既存の見積起点の重複防止ロジックと合わせて導線全体を安定化します.

### Description
- 売上登録時に`paid_amount`を常に非負数で正規化し、`paid_amount === 0`の場合は`paid_date`を`null`で保存するようにしました（新規登録/編集のpayload整形）。
- 手動での新規売上登録時に、同一`case_id`で既に売上が存在する場合は登録を中止して重複を防止するガードを追加しました。 
- 入金履歴削除時に売上側の`paid_amount`を再計算するとともに、残存する入金履歴から最新の`paymentDate`を算出して`sales.paid_date`に反映するよう修正し、日付不整合を防止しました。 
- DBスキーマ変更やRLS/service_roleの利用は行っておらず、保存payloadは既存の`SALES_MUTATION_COLUMNS`でフィルタして未定義カラムを送信しないようにしています。 
- 手動確認項目（導線の安定化確認用）: 案件一覧から売上登録ができること、売上一覧に反映されること、入金0円なら「未入金」、一部入金なら「一部入金」、全額入金なら「入金済み」と表示されること、売上・入金・案件側の金額表示に矛盾がないこと、重複売上登録が発生しないこと、CSV/Excel出力・取込に影響がないこと、Supabase保存時に未定義カラムを送信していないこと。 

### Testing
- `node --check app.js` を実行して構文チェックは成功しました。 
- `node --check estimate-calculator.js` を実行して構文チェックは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00953b32548333b8f50ca02760190a)