### PR TITLE
日報編集中にフォームが初期化される不具合を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -2061,7 +2061,9 @@ async function applyAuthState(options = {}) {
     resetSaleForm();
     resetExpenseForm();
     resetFixedExpenseForm();
-    resetDailyReportForm();
+    if (!editState.dailyReportId) {
+      resetDailyReportForm();
+    }
     safeRender("renderAfterDataChanged", renderAfterDataChanged);
     state.isInitialDataReady = true;
     setDataMutationControlsEnabled(true);


### PR DESCRIPTION
### Motivation
- 認証再適用やデータ再読込時に編集中の「日報」フォームが無条件で初期化され、編集状態（`editState.dailyReportId`）が失われる不具合を防ぐための修正。 

### Description
- 原因は `applyAuthState()` 内で `loadAllDataSafely()` 後に無条件で `resetDailyReportForm()` が呼ばれていたことです。
- 対応として `applyAuthState()` の該当箇所で `if (!editState.dailyReportId) { resetDailyReportForm(); }` を追加し、編集中はリセットを行わないようにしました（変更箇所：`app.js` の `applyAuthState` ブロック）。
- 他の `resetDailyReportForm()` 呼び出し（登録/更新成功時の `runMutation` 経由リセット、編集中レコード削除時のリセット、全データ削除/ログアウト時のリセット）は要件通り維持していますので他画面への影響は限定的です。 
- 簡単な動作確認手順は、日報一覧で任意の日報を編集して（`editState.dailyReportId` が設定される状態）、入力を行ったまま 15 秒以上待ち、別タブに移動して戻す／スクロールする等の再描画を誘発してもボタンが `日報を更新` のままで入力が消えないことを確認することです。

### Testing
- 実施した自動確認はソース検索と差分確認で、`rg` による該当呼び出し検索と `git diff` で差分を確認し、期待通りにガード文が追加されていることを確認しました（コマンドは成功）。
- 変更は `app.js` の最小差分（条件追加 1 箇所）に限定され、自動テストスイートは無しのためユニットテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045dedf6d48333804f0814056ade0c)