### PR TITLE
Restore and preserve daily report drafts on app/tab resume

### DIFF
--- a/app.js
+++ b/app.js
@@ -809,9 +809,11 @@ function bindEvents() {
   if (permitHearingFilterClearBtn) permitHearingFilterClearBtn.dataset.action = "clear_permit_hearing_filters";
   window.addEventListener("pageshow", forceHideLoading);
   window.addEventListener("focus", forceHideLoading);
+  window.addEventListener("focus", restoreDailyReportDraftOnResume);
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
       forceHideLoading();
+      restoreDailyReportDraftOnResume();
     }
   });
   if (loadingForceCloseBtn) loadingForceCloseBtn.dataset.action = "force_close_loading";
@@ -3079,7 +3081,13 @@ async function handleDailyReportSubmit(event) {
     }, {
       successMessage: isEdit ? "日報を更新しました。" : "日報を登録しました。",
       resetForm: resetDailyReportForm,
-      afterSuccess: () => activateSubtab("daily-reports", "list"),
+      afterSuccess: () => {
+        clearCurrentDailyReportDraft();
+        if (!isEdit) {
+          clearDailyReportDraft();
+        }
+        activateSubtab("daily-reports", "list");
+      },
     });
   } catch (error) {
     showAppMessage(`日報登録に失敗しました。${error?.message || ""} ${error?.details || ""} ${error?.hint || ""} ${error?.code || ""}`, true);
@@ -8496,7 +8504,6 @@ function resetFixedExpenseForm() {
 }
 
 function resetDailyReportForm() {
-  clearDailyReportDraft();
   resetEditMode("dailyReport");
   dailyReportForm.reset();
   dailyReportForm.elements.reportDate.value = toDateString(new Date());
@@ -11402,6 +11409,15 @@ function saveDailyReportDraft() {
   }
 }
 
+function isDailyReportEntryActive() {
+  return normalizeTabKey(activeTab || "cases") === "daily-reports" && subtabState["daily-reports"] === "entry";
+}
+
+function restoreDailyReportDraftOnResume() {
+  if (!isDailyReportEntryActive()) return;
+  restoreDailyReportDraft();
+}
+
 function restoreDailyReportDraft() {
   if (!dailyReportForm) return;
   try {
@@ -11436,3 +11452,11 @@ function clearDailyReportDraft() {
   }
 }
 
+function clearCurrentDailyReportDraft() {
+  const key = getDailyReportDraftStorageKey();
+  try {
+    sessionStorage.removeItem(key);
+  } catch (error) {
+    console.warn("日報下書き削除に失敗", error);
+  }
+}


### PR DESCRIPTION
### Motivation

- The daily-report draft persistence added earlier was ineffective because `resetDailyReportForm()` unconditionally deleted stored drafts before restoration, causing drafts to be lost during auth/state refresh and UI re-render paths. 
- Users reported that unsaved inputs disappeared when navigating away and back within the app or when switching browser tabs and returning, so draft restore must be re-triggered on resume while preserving post-save safety.

### Description

- Removed the unconditional `clearDailyReportDraft()` call from `resetDailyReportForm()` so drafts are not deleted before restore. 
- Added `isDailyReportEntryActive()` and `restoreDailyReportDraftOnResume()` and hooked `restoreDailyReportDraftOnResume()` to `window.focus` and `document.visibilitychange` (when visible) so drafts are restored when returning to the app/tab while the daily-report entry subtab is active. 
- Introduced `clearCurrentDailyReportDraft()` and call it on successful daily-report save; on new registrations also call `clearDailyReportDraft()` to avoid stale new-draft resurrection while preserving safety for edit/new separation. 
- Kept existing input hooks (`input`/`change` → `saveDailyReportDraft`) and preserved the set of saved fields (date, client, case, content, minutes, next action, next action date, memo). 

### Testing

- Ran `node --check app.js` to validate the modified file and it succeeded. 
- No automated unit tests were present for this UI flow; changes are limited to event wiring and storage handling and require the manual verification steps described in the PR checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c38c7284083339a9c6210d16cc004)