### PR TITLE
日報復元時の ReferenceError (activeTab 未定義) を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -11409,8 +11409,18 @@ function saveDailyReportDraft() {
   }
 }
 
+function getActiveMainTabKey() {
+  const activeTabButton = tabs.find((btn) => btn.classList.contains("active"));
+  if (activeTabButton?.dataset?.tab) return normalizeTabKey(activeTabButton.dataset.tab);
+
+  const activePanelEntry = Object.entries(panels).find(([, panel]) => panel?.classList?.contains("active"));
+  if (activePanelEntry) return normalizeTabKey(activePanelEntry[0]);
+
+  return "cases";
+}
+
 function isDailyReportEntryActive() {
-  return normalizeTabKey(activeTab || "cases") === "daily-reports" && subtabState["daily-reports"] === "entry";
+  return getActiveMainTabKey() === "daily-reports" && subtabState["daily-reports"] === "entry";
 }
 
 function restoreDailyReportDraftOnResume() {


### PR DESCRIPTION
### Motivation
- `isDailyReportEntryActive()` が未定義の `activeTab` を参照しており、`window.focus` / `document.visibilitychange` 経由で `restoreDailyReportDraftOnResume()` が呼ばれた際に `Uncaught ReferenceError: activeTab is not defined` が発生していました。 
- このエラーを解消しつつ、PR #226 で導入されたタブ復帰時の下書き復元フローを壊さない必要がありました。 
- 既存のタブ状態管理（表示上の `.active` クラスや `panels` / `subtabState`）に合わせて判定ロジックを修正する方針としました。 

### Description
- `getActiveMainTabKey()` を追加し、まず `tabs` のうち `.active` を持つボタンの `dataset.tab` を参照し、次に `panels` 側で `.active` のパネルを探し、どちらもなければ `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c73fcf7e08333bb1a02bba11ce316)