### PR TITLE
Publish CPA boki2 app under GitHub Pages subpath

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Prepare existing app files
+        run: |
+          rm -rf pages-dist
+          mkdir -p pages-dist
+          rsync -a ./ pages-dist/ \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='node_modules' \
+            --exclude='pages-dist' \
+            --exclude='cpa-boki2-trial-section-answer-manager'
+          touch pages-dist/.nojekyll
+
+      - name: Build CPA boki2 trial section app
+        working-directory: cpa-boki2-trial-section-answer-manager
+        run: |
+          npm install
+          npm run build
+
+      - name: Add CPA boki2 app to Pages artifact subpath
+        run: |
+          mkdir -p pages-dist/cpa-boki2-trial-section-answer-manager
+          cp -R cpa-boki2-trial-section-answer-manager/dist/. pages-dist/cpa-boki2-trial-section-answer-manager/
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages-dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 目的
既存案件管理アプリをトップURLのまま維持しつつ、PR #228 で追加した簿記アプリを GitHub Pages のサブパスで公開できるようにします。

## 期待URL
- 既存案件管理アプリ: `https://akashidaiki19910915-star.github.io/gyosei-app/`
- 簿記アプリ: `https://akashidaiki19910915-star.github.io/gyosei-app/cpa-boki2-trial-section-answer-manager/`

## 修正内容
- `.github/workflows/pages.yml` を追加
- 既存リポジトリ直下の静的ファイルを `pages-dist/` にコピー
- `cpa-boki2-trial-section-answer-manager/` で `npm install` と `npm run build` を実行
- 生成された `dist/` の中身を `pages-dist/cpa-boki2-trial-section-answer-manager/` にコピー
- `actions/upload-pages-artifact` と `actions/deploy-pages` で、既存アプリと簿記アプリを同一Pages成果物としてデプロイ

## 既存アプリへの影響
- 既存案件管理アプリの `index.html`、`app.js`、`styles.css`、`src/` は変更していません。
- トップURLを簿記アプリで置き換えていません。
- 簿記アプリ本体も再作成していません。

## 著作権対応
問題文・解答・解説・CPAロゴ・教材画像は追加していません。

## 注意
GitHub Pages の公開元が現在 branch/root の場合、このPRマージ後に Pages の Source を GitHub Actions に切り替える必要がある可能性があります。