### PR TITLE
Add CPA boki2 study queue backup dashboard and exam set mode

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -1,18 +1,24 @@
 import { useEffect, useMemo, useState } from 'react';
 import { AnswerTable, createRows } from './components/AnswerTable';
+import { BackupSafetyPanel } from './components/BackupSafetyPanel';
+import { DashboardPanel } from './components/DashboardPanel';
+import { ExamSetPanel } from './components/ExamSetPanel';
 import { ExampleGuide } from './components/ExampleGuide';
 import { HistoryPanel } from './components/HistoryPanel';
 import { ProblemSelector } from './components/ProblemSelector';
 import { ReviewPanel } from './components/ReviewPanel';
 import { ScoringPanel } from './components/ScoringPanel';
+import { StudyQueuePanel } from './components/StudyQueuePanel';
 import { Timer } from './components/Timer';
 import { getProblemById, problemCatalog } from './data/problemCatalog';
 import { getTemplateById } from './data/templateCatalog';
-import { addHistory, clearHistories, deleteHistory, exportAllData, getAllAnswers, getAnswer, getHistories, importAllData, saveAnswer } from './storage/indexedDb';
-import type { AnswerState, BackupPayload, HistoryEntry, TemplateId } from './types';
-import { currentAnswerCsvRows, downloadCsv, downloadText, historyCsvRows, missReasonCsvRows, problemStatsCsvRows, reviewTargetCsvRows } from './utils/csv';
+import { addHistory, clearHistories, deleteHistory, exportAllData, getAllAnswers, getAnswer, getBackupMetadata, getExamSets, getHistories, importAllData, recordBackupMade, saveAnswer, saveExamSet } from './storage/indexedDb';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, StorageSafetyInfo, TemplateId } from './types';
+import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, missReasonCsvRows, problemStatsCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
 import { isDueTodayOrEarlier, nowIso } from './utils/dates';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
+import { getStorageSafetyInfo } from './utils/storageSafety';
+import { buildStudyQueue } from './utils/studyQueue';
 import './styles.css';
 
 type HistoryFilter = 'all' | 'today' | 'overdue' | 'c' | 'b';
@@ -98,15 +104,38 @@ function buildHistory(answer: AnswerState): HistoryEntry {
 export default function App() {
   const [problemId, setProblemId] = useState(problemCatalog[0].id);
   const [answer, setAnswer] = useState<AnswerState>(() => createAnswer(problemCatalog[0].id, problemCatalog[0].defaultTemplateId));
+  const [answers, setAnswers] = useState<AnswerState[]>([]);
   const [histories, setHistories] = useState<HistoryEntry[]>([]);
+  const [examSets, setExamSets] = useState<ExamSetRecord[]>([]);
+  const [backupMeta, setBackupMeta] = useState<BackupMetadata | null>(null);
+  const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
   const [historyFilter, setHistoryFilter] = useState<HistoryFilter>('all');
 
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
+  const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
+
+  async function refreshAnswers() {
+    setAnswers((await getAllAnswers()).map(normalizeAnswer));
+  }
 
   async function loadHistories() {
     setHistories(await getHistories());
+  }
+
+  async function loadExamSets() {
+    setExamSets(await getExamSets());
+  }
+
+  async function refreshSafety() {
+    const [historyRows, answerRows, meta] = await Promise.all([getHistories(), getAllAnswers(), getBackupMetadata()]);
+    setBackupMeta(meta);
+    setSafetyInfo(await getStorageSafetyInfo(historyRows.length, answerRows.length, meta));
+  }
+
+  async function refreshAll() {
+    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), refreshSafety()]);
   }
 
   async function loadProblem(nextProblemId: string) {
@@ -119,13 +148,16 @@ export default function App() {
 
   useEffect(() => {
     loadProblem(problemCatalog[0].id);
-    loadHistories();
+    refreshAll();
   }, []);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
       const updated = normalizeAnswer({ ...answer, updatedAt: nowIso() });
-      saveAnswer(updated).then(() => setMessage(`自動保存済み ${new Date().toLocaleTimeString('ja-JP')}`));
+      saveAnswer(updated).then(() => {
+        setMessage(`自動保存済み ${new Date().toLocaleTimeString('ja-JP')}`);
+        refreshAnswers();
+      });
     }, 800);
     return () => window.clearTimeout(timer);
   }, [answer]);
@@ -152,6 +184,7 @@ export default function App() {
 
   const manualSave = async () => {
     await saveAnswer(normalizeAnswer({ ...answer, updatedAt: nowIso() }));
+    await refreshAll();
     setMessage('手動保存しました');
   };
 
@@ -160,20 +193,21 @@ export default function App() {
     const cleared = createAnswer(problemId, answer.templateId);
     await saveAnswer(cleared);
     setAnswer(cleared);
+    await refreshAll();
     setMessage('現在問題IDの答案を全消去しました');
   };
 
   const bulkAddAllAnswers = async () => {
-    const answers = (await getAllAnswers()).map(normalizeAnswer).filter(hasMeaningfulAnswer);
-    if (answers.length === 0) {
+    const rows = (await getAllAnswers()).map(normalizeAnswer).filter(hasMeaningfulAnswer);
+    if (rows.length === 0) {
       setMessage('履歴追加できる保存済み答案がありません');
       return;
     }
-    for (const item of answers) {
+    for (const item of rows) {
       await addHistory(buildHistory(item));
     }
-    await loadHistories();
-    setMessage(`保存済み答案 ${answers.length}件を一括で履歴追加しました`);
+    await refreshAll();
+    setMessage(`保存済み答案 ${rows.length}件を一括で履歴追加しました`);
   };
 
   const confirmScoring = async () => {
@@ -186,7 +220,7 @@ export default function App() {
     await saveAnswer(scored);
     await addHistory(buildHistory(scored));
     setAnswer(scored);
-    await loadHistories();
+    await refreshAll();
     setMessage('採点確定して履歴に追加しました');
   };
 
@@ -196,20 +230,21 @@ export default function App() {
     await saveAnswer(restored);
     setProblemId(entry.problemId);
     setAnswer(restored);
+    await refreshAll();
     setMessage('履歴を復元しました');
   };
 
   const deleteHistoryEntry = async (id: string) => {
     if (!window.confirm('この履歴を削除しますか？')) return;
     await deleteHistory(id);
-    await loadHistories();
+    await refreshAll();
     setMessage('履歴を削除しました');
   };
 
   const clearAllHistories = async () => {
     if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return;
     await clearHistories();
-    await loadHistories();
+    await refreshAll();
     setMessage('履歴を全削除しました');
   };
 
@@ -218,10 +253,17 @@ export default function App() {
   const exportReviewCsv = () => downloadCsv('review-targets.csv', reviewTargetCsvRows(histories.filter((history) => isDueTodayOrEarlier(history.nextReviewDate))));
   const exportProblemStatsCsv = () => downloadCsv('problem-stats.csv', problemStatsCsvRows(histories));
   const exportMissReasonCsv = () => downloadCsv('miss-reasons.csv', missReasonCsvRows(histories));
+  const exportStudyQueueCsv = () => downloadCsv('study-queue.csv', studyQueueCsvRows(studyQueue));
+  const exportDashboardCsv = () => downloadCsv('dashboard.csv', dashboardCsvRows(histories));
+  const exportExamSetCsv = () => downloadCsv('exam-sets.csv', examSetCsvRows(examSets));
 
   const exportJson = async () => {
     const payload = await exportAllData();
     downloadText('cpa-boki2-backup.json', JSON.stringify(payload, null, 2), 'application/json;charset=utf-8');
+    const meta = await recordBackupMade(payload.histories.length, payload.answers.length);
+    setBackupMeta(meta);
+    await refreshSafety();
+    setMessage('JSONバックアップを出力しました');
   };
 
   const importJson = async (file: File | undefined) => {
@@ -230,11 +272,17 @@ export default function App() {
       const payload = JSON.parse(await file.text()) as BackupPayload;
       await importAllData(payload);
       await loadProblem(problemId);
-      await loadHistories();
+      await refreshAll();
       setMessage('JSONバックアップを復元しました');
     } catch {
       setMessage('JSONの形式が不正です');
     }
+  };
+
+  const saveExamSetRecord = async (record: ExamSetRecord) => {
+    await saveExamSet(record);
+    await loadExamSets();
+    setMessage('90分セット演習履歴を保存しました');
   };
 
   return (
@@ -261,6 +309,13 @@ export default function App() {
         <label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label>
         <button onClick={() => window.print()}>印刷</button>
       </div>
+
+      <section className="management-stack">
+        <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
+        <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
+        <DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} />
+        <ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} />
+      </section>
 
       <div className="main-grid">
         <ProblemSelector selectedProblem={problem} selectedTemplateId={answer.templateId} onSelectProblem={loadProblem} onSelectTemplate={selectTemplate} />

--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -15,7 +15,7 @@ import { getTemplateById } from './data/templateCatalog';
 import { addHistory, clearHistories, deleteHistory, exportAllData, getAllAnswers, getAnswer, getBackupMetadata, getExamSets, getHistories, importAllData, recordBackupMade, saveAnswer, saveExamSet } from './storage/indexedDb';
 import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, StorageSafetyInfo, TemplateId } from './types';
 import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, missReasonCsvRows, problemStatsCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
-import { isDueTodayOrEarlier, nowIso } from './utils/dates';
+import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
 import { getStorageSafetyInfo } from './utils/storageSafety';
 import { buildStudyQueue } from './utils/studyQueue';
@@ -107,7 +107,7 @@ export default function App() {
   const [answers, setAnswers] = useState<AnswerState[]>([]);
   const [histories, setHistories] = useState<HistoryEntry[]>([]);
   const [examSets, setExamSets] = useState<ExamSetRecord[]>([]);
-  const [backupMeta, setBackupMeta] = useState<BackupMetadata | null>(null);
+  const [, setBackupMeta] = useState<BackupMetadata | null>(null);
   const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
   const [historyFilter, setHistoryFilter] = useState<HistoryFilter>('all');
@@ -258,9 +258,10 @@ export default function App() {
   const exportExamSetCsv = () => downloadCsv('exam-sets.csv', examSetCsvRows(examSets));
 
   const exportJson = async () => {
+    const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]);
+    const meta = await recordBackupMade(historyRows.length, answerRows.length);
     const payload = await exportAllData();
-    downloadText('cpa-boki2-backup.json', JSON.stringify(payload, null, 2), 'application/json;charset=utf-8');
-    const meta = await recordBackupMade(payload.histories.length, payload.answers.length);
+    downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8');
     setBackupMeta(meta);
     await refreshSafety();
     setMessage('JSONバックアップを出力しました');
@@ -280,9 +281,30 @@ export default function App() {
   };
 
   const saveExamSetRecord = async (record: ExamSetRecord) => {
-    await saveExamSet(record);
-    await loadExamSets();
-    setMessage('90分セット演習履歴を保存しました');
+    const relatedHistoryIds: string[] = [];
+    for (const problemState of record.problemStates) {
+      if (problemState.rank !== 'B' && problemState.rank !== 'C') continue;
+      const problemDefinition = getProblemById(problemState.problemId);
+      const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId);
+      const scored = normalizeAnswer({
+        ...base,
+        score: Number(problemState.score) || 0,
+        rowPointsTotal: Number(problemState.score) || 0,
+        rank: problemState.rank,
+        nextReviewDate: reviewDateForRank(problemState.rank),
+        reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`,
+        scored: true,
+        scoredAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+      const history = buildHistory(scored);
+      relatedHistoryIds.push(history.id);
+      await addHistory(history);
+    }
+
+    await saveExamSet({ ...record, relatedHistoryIds });
+    await refreshAll();
+    setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。');
   };
 
   return (

--- a/cpa-boki2-trial-section-answer-manager/src/components/BackupSafetyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/BackupSafetyPanel.tsx
@@ -1,0 +1,51 @@
+import type { StorageSafetyInfo } from '../types';
+import { formatBytes, requestPersistentStorage } from '../utils/storageSafety';
+
+interface Props {
+  info: StorageSafetyInfo | null;
+  onBackup: () => void;
+  onRestoreFile: (file: File | undefined) => void;
+  onRefresh: () => void;
+  onMessage: (message: string) => void;
+}
+
+export function BackupSafetyPanel({ info, onBackup, onRestoreFile, onRefresh, onMessage }: Props) {
+  const enablePersistent = async () => {
+    const result = await requestPersistentStorage();
+    onMessage(`永続ストレージ要求結果：${result}`);
+    onRefresh();
+  };
+
+  return (
+    <details className="panel management-panel" open>
+      <summary>保存安全性チェック</summary>
+      <div className="panel-body">
+        <p className="warning-text">このアプリの学習履歴はブラウザ内に保存されています。ブラウザデータ削除・端末変更・シークレットモード利用により消える可能性があります。定期的にJSONバックアップを取得してください。</p>
+        {info ? (
+          <>
+            <div className="metric-grid">
+              <div><span>保存方式</span><strong>{info.saveMethod}</strong></div>
+              <div><span>履歴件数</span><strong>{info.historyCount}</strong></div>
+              <div><span>保存済み答案</span><strong>{info.answerCount}</strong></div>
+              <div><span>最終バックアップ</span><strong>{info.lastBackupAt || '未取得'}</strong></div>
+              <div><span>最終復元</span><strong>{info.lastRestoreAt || '-'}</strong></div>
+              <div><span>バックアップ回数</span><strong>{info.backupCount}</strong></div>
+              <div><span>推定使用量</span><strong>{formatBytes(info.estimatedUsage)}</strong></div>
+              <div><span>推定上限</span><strong>{formatBytes(info.estimatedQuota)}</strong></div>
+              <div><span>永続ストレージ</span><strong>{info.persistentStatus}</strong></div>
+            </div>
+            {info.warnings.length ? (
+              <ul className="warning-list">{info.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul>
+            ) : <p className="ok-text">現時点で重大なバックアップ警告はありません。</p>}
+          </>
+        ) : <p>保存状態を確認中です。</p>}
+        <div className="button-row">
+          <button onClick={onBackup}>JSONバックアップ</button>
+          <label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => onRestoreFile(event.target.files?.[0])} /></label>
+          <button className="secondary" onClick={enablePersistent}>永続ストレージを有効化</button>
+          <button className="secondary" onClick={onRefresh}>保存状態を再確認</button>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/DashboardPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/DashboardPanel.tsx
@@ -1,0 +1,74 @@
+import type { HistoryEntry } from '../types';
+import { buildDashboard } from '../utils/dashboard';
+
+interface Props {
+  histories: HistoryEntry[];
+  answerCount: number;
+  onExportCsv: () => void;
+}
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export function DashboardPanel({ histories, answerCount, onExportCsv }: Props) {
+  const dashboard = buildDashboard(histories, answerCount);
+  const { summary } = dashboard;
+
+  return (
+    <details className="panel management-panel">
+      <summary>成績ダッシュボード</summary>
+      <div className="panel-body">
+        <div className="button-row"><button onClick={onExportCsv}>成績ダッシュボードCSV</button></div>
+        <div className="metric-grid">
+          <div><span>総演習回数</span><strong>{summary.totalAttempts}</strong></div>
+          <div><span>履歴件数</span><strong>{summary.historyCount}</strong></div>
+          <div><span>保存済み答案</span><strong>{summary.answerCount}</strong></div>
+          <div><span>平均点</span><strong>{summary.averageScore.toFixed(1)}</strong></div>
+          <div><span>平均得点率</span><strong>{pct(summary.averageRate)}</strong></div>
+          <div><span>70%以上相当</span><strong>{summary.passLikeCount}</strong></div>
+          <div><span>A判定</span><strong>{summary.aCount}</strong></div>
+          <div><span>B判定</span><strong>{summary.bCount}</strong></div>
+          <div><span>C判定</span><strong>{summary.cCount}</strong></div>
+          <div><span>未着手</span><strong>{summary.untouchedCount}</strong></div>
+          <div><span>期限超過</span><strong>{summary.overdueCount}</strong></div>
+          <div><span>今日復習</span><strong>{summary.todayCount}</strong></div>
+          <div><span>直近7日演習</span><strong>{summary.sevenDayAttempts}</strong></div>
+          <div><span>直近30日演習</span><strong>{summary.thirtyDayAttempts}</strong></div>
+          <div><span>直近7日C</span><strong>{summary.sevenDayC}</strong></div>
+          <div><span>直近30日C</span><strong>{summary.thirtyDayC}</strong></div>
+        </div>
+
+        <h3>問題ID別成績</h3>
+        <div className="table-wrap compact-wrap">
+          <table className="compact-table">
+            <thead><tr><th>問題ID</th><th>論点</th><th>回数</th><th>最新</th><th>最高</th><th>最低</th><th>判定</th><th>ミス原因</th><th>復習日</th><th>改善</th></tr></thead>
+            <tbody>
+              {dashboard.problemStats.map((row) => (
+                <tr key={row.problem.id}>
+                  <td>{row.problem.displayId}</td><td>{row.problem.topic}</td><td>{row.attempts}</td><td>{row.latestScore ?? '-'}</td><td>{row.highestScore ?? '-'}</td><td>{row.lowestScore ?? '-'}</td><td>{row.latestRank || '-'}</td><td>{row.latestMissReasons.join(' / ') || '-'}</td><td>{row.latestReviewDate || '-'}</td><td>{row.trend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <h3>大問別成績</h3>
+        <div className="table-wrap compact-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>大問</th><th>演習回数</th><th>平均点</th><th>C判定</th><th>よくあるミス原因</th></tr></thead>
+            <tbody>{dashboard.sectionStats.map((row) => <tr key={row.sectionId}><td>{row.sectionLabel}</td><td>{row.attempts}</td><td>{row.averageScore.toFixed(1)}</td><td>{row.cCount}</td><td>{row.commonReason}</td></tr>)}</tbody>
+          </table>
+        </div>
+
+        <h3>ミス原因ランキング</h3>
+        <div className="table-wrap compact-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>ミス原因</th><th>件数</th><th>該当問題ID</th><th>最新発生日</th></tr></thead>
+            <tbody>{dashboard.missReasonRanking.map((row) => <tr key={row.reason}><td>{row.reason}</td><td>{row.count}</td><td>{row.problemIds.join(' / ')}</td><td>{row.latestAt}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/ExamSetPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/ExamSetPanel.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { problemCatalog } from '../data/problemCatalog';
+import type { ExamSetProblemState, ExamSetRecord, HistoryEntry, ProblemDefinition, ReviewRank, SectionId } from '../types';
+import { nowIso } from '../utils/dates';
+
+const sectionOrder: SectionId[] = ['q1', 'q2', 'q3', 'q4', 'q5'];
+const EXAM_SECONDS = 90 * 60;
+
+interface Props {
+  histories: HistoryEntry[];
+  examSets: ExamSetRecord[];
+  onSave: (record: ExamSetRecord) => void;
+  onOpenProblem: (problemId: string) => void;
+  onExportCsv: () => void;
+}
+
+function firstBySection(sectionId: SectionId): ProblemDefinition {
+  return problemCatalog.find((problem) => problem.sectionId === sectionId)!;
+}
+
+function defaultSelected(): string[] {
+  return sectionOrder.map((sectionId) => firstBySection(sectionId).id);
+}
+
+function latestHistories(histories: HistoryEntry[]) {
+  const map = new Map<string, HistoryEntry>();
+  histories.forEach((history) => {
+    const current = map.get(history.problemId);
+    if (!current || history.savedAt > current.savedAt) map.set(history.problemId, history);
+  });
+  return map;
+}
+
+export function ExamSetPanel({ histories, examSets, onSave, onOpenProblem, onExportCsv }: Props) {
+  const [name, setName] = useState('90分セット演習');
+  const [selectedIds, setSelectedIds] = useState<string[]>(defaultSelected);
+  const [problemStates, setProblemStates] = useState<ExamSetProblemState[]>(() => defaultSelected().map((problemId) => ({ problemId, status: '未開始', score: 0, rank: '' })));
+  const [memo, setMemo] = useState('');
+  const [startedAt, setStartedAt] = useState('');
+  const [finishedAt, setFinishedAt] = useState('');
+  const [seconds, setSeconds] = useState(EXAM_SECONDS);
+  const [running, setRunning] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const latest = useMemo(() => latestHistories(histories), [histories]);
+
+  useEffect(() => {
+    if (!running) return;
+    timerRef.current = window.setInterval(() => setSeconds((value) => Math.max(value - 1, 0)), 1000);
+    return () => {
+      if (timerRef.current !== null) window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    };
+  }, [running]);
+
+  useEffect(() => {
+    if (seconds === 0 && running) setRunning(false);
+  }, [seconds, running]);
+
+  const totalScore = problemStates.reduce((sum, state) => sum + (Number(state.score) || 0), 0);
+  const minutes = Math.floor(seconds / 60).toString().padStart(2, '0');
+  const rest = (seconds % 60).toString().padStart(2, '0');
+
+  const updateProblem = (sectionIndex: number, problemId: string) => {
+    const nextIds = [...selectedIds];
+    nextIds[sectionIndex] = problemId;
+    setSelectedIds(nextIds);
+    setProblemStates(nextIds.map((id) => problemStates.find((state) => state.problemId === id) ?? { problemId: id, status: '未開始', score: 0, rank: '' }));
+  };
+
+  const updateState = (problemId: string, patch: Partial<ExamSetProblemState>) => {
+    setProblemStates((rows) => rows.map((row) => row.problemId === problemId ? { ...row, ...patch } : row));
+  };
+
+  const autoUntouched = () => {
+    const selected = sectionOrder.map((sectionId) => problemCatalog.find((problem) => problem.sectionId === sectionId && !latest.has(problem.id)) ?? firstBySection(sectionId));
+    setSelectedIds(selected.map((problem) => problem.id));
+    setProblemStates(selected.map((problem) => ({ problemId: problem.id, status: '未開始', score: 0, rank: '' })));
+  };
+
+  const autoC = () => {
+    const selected = sectionOrder.map((sectionId) => problemCatalog.find((problem) => latest.get(problem.id)?.rank === 'C' && problem.sectionId === sectionId) ?? firstBySection(sectionId));
+    setSelectedIds(selected.map((problem) => problem.id));
+    setProblemStates(selected.map((problem) => ({ problemId: problem.id, status: '未開始', score: 0, rank: '' })));
+  };
+
+  const autoRandom = () => {
+    const selected = sectionOrder.map((sectionId) => {
+      const rows = problemCatalog.filter((problem) => problem.sectionId === sectionId);
+      return rows[Math.floor(Math.random() * rows.length)] ?? firstBySection(sectionId);
+    });
+    setSelectedIds(selected.map((problem) => problem.id));
+    setProblemStates(selected.map((problem) => ({ problemId: problem.id, status: '未開始', score: 0, rank: '' })));
+  };
+
+  const start = () => {
+    if (!startedAt) setStartedAt(nowIso());
+    setRunning(true);
+  };
+
+  const finishAndSave = () => {
+    const end = nowIso();
+    setFinishedAt(end);
+    setRunning(false);
+    const record: ExamSetRecord = {
+      id: crypto.randomUUID(),
+      name,
+      createdAt: nowIso(),
+      startedAt: startedAt || nowIso(),
+      finishedAt: end,
+      durationSeconds: EXAM_SECONDS - seconds,
+      selectedProblemIds: selectedIds,
+      problemStates,
+      problemScores: Object.fromEntries(problemStates.map((state) => [state.problemId, Number(state.score) || 0])),
+      totalScore,
+      passLineReached: totalScore >= 70,
+      memo,
+      relatedHistoryIds: [],
+    };
+    onSave(record);
+  };
+
+  return (
+    <details className="panel management-panel">
+      <summary>90分セット演習モード</summary>
+      <div className="panel-body">
+        <div className="exam-timer"><strong>{minutes}:{rest}</strong><span>{running ? '演習中' : seconds === 0 ? '終了' : '待機中'}</span></div>
+        <div className="button-row"><button onClick={start}>90分タイマー開始</button><button className="secondary" onClick={() => setRunning(false)}>一時停止</button><button className="secondary" onClick={() => { setRunning(false); setSeconds(EXAM_SECONDS); setStartedAt(''); setFinishedAt(''); }}>リセット</button><button onClick={autoUntouched}>未着手優先で自動作成</button><button onClick={autoC}>C判定優先で自動作成</button><button onClick={autoRandom}>ランダムセット作成</button><button onClick={onExportCsv}>セット履歴CSV</button></div>
+        <label>セット名<input value={name} onChange={(event) => setName(event.target.value)} /></label>
+        <div className="table-wrap compact-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>大問</th><th>問題ID</th><th>状態</th><th>得点</th><th>判定</th><th>操作</th></tr></thead>
+            <tbody>
+              {sectionOrder.map((sectionId, index) => {
+                const problems = problemCatalog.filter((problem) => problem.sectionId === sectionId);
+                const selected = selectedIds[index];
+                const state = problemStates.find((row) => row.problemId === selected) ?? { problemId: selected, status: '未開始', score: 0, rank: '' as ReviewRank };
+                return (
+                  <tr key={sectionId}>
+                    <td>{firstBySection(sectionId).sectionLabel}</td>
+                    <td><select value={selected} onChange={(event) => updateProblem(index, event.target.value)}>{problems.map((problem) => <option key={problem.id} value={problem.id}>{problem.displayId} {problem.topic}</option>)}</select></td>
+                    <td><select value={state.status} onChange={(event) => updateState(selected, { status: event.target.value as ExamSetProblemState['status'] })}><option>未開始</option><option>開始</option><option>完了</option></select></td>
+                    <td><input type="number" value={state.score} onChange={(event) => updateState(selected, { score: Number(event.target.value || 0) })} /></td>
+                    <td><select value={state.rank} onChange={(event) => updateState(selected, { rank: event.target.value as ReviewRank })}><option value="">未選択</option><option value="A">A</option><option value="B">B</option><option value="C">C</option></select></td>
+                    <td><button onClick={() => onOpenProblem(selected)}>問題へ移動</button></td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div className="result-card"><strong>合計点：{totalScore}点</strong><span>{totalScore >= 70 ? '合格ライン到達' : '復習優先'}</span></div>
+        <label>セットメモ<textarea value={memo} onChange={(event) => setMemo(event.target.value)} /></label>
+        <button className="accent" onClick={finishAndSave}>セット演習を保存</button>
+
+        <h3>セット履歴</h3>
+        <div className="table-wrap compact-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>作成日時</th><th>セット名</th><th>合計点</th><th>判定</th><th>問題ID</th></tr></thead>
+            <tbody>{examSets.slice(0, 10).map((set) => <tr key={set.id}><td>{set.createdAt}</td><td>{set.name}</td><td>{set.totalScore}</td><td>{set.passLineReached ? '合格ライン到達' : '復習優先'}</td><td>{set.selectedProblemIds.map((id) => problemCatalog.find((problem) => problem.id === id)?.displayId ?? id).join(' / ')}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/StudyQueuePanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/StudyQueuePanel.tsx
@@ -1,0 +1,57 @@
+import type { StudyQueueItem } from '../types';
+import { queueCounts } from '../utils/studyQueue';
+
+interface Props {
+  items: StudyQueueItem[];
+  onStart: (problemId: string) => void;
+  onRestoreLatest?: (item: StudyQueueItem) => void;
+  onExportCsv: () => void;
+}
+
+export function StudyQueuePanel({ items, onStart, onRestoreLatest, onExportCsv }: Props) {
+  const counts = queueCounts(items);
+  const top = items[0];
+
+  return (
+    <details className="panel management-panel" open>
+      <summary>今日の学習キュー：{counts.total}件 / 期限超過 {counts.overdue}件 / C判定 {counts.c}件 / 未着手 {counts.untouched}件</summary>
+      <div className="panel-body">
+        {top ? (
+          <div className="priority-card">
+            <div className="badge-row">{top.statusLabels.map((label) => <span key={label} className="status-badge">{label}</span>)}</div>
+            <h3>今日の最優先：{top.problem.displayId} {top.problem.topic}</h3>
+            <p>{top.reason}</p>
+            <button onClick={() => onStart(top.problem.id)}>この問題を開始</button>
+          </div>
+        ) : <p className="empty">今日の学習キューはありません。</p>}
+
+        <div className="button-row"><button onClick={onExportCsv}>今日の学習キューCSV</button></div>
+        <div className="table-wrap compact-wrap">
+          <table className="compact-table">
+            <thead>
+              <tr><th>優先</th><th>状態</th><th>問題ID</th><th>科目</th><th>大問</th><th>論点</th><th>前回得点</th><th>判定</th><th>復習日</th><th>ミス原因</th><th>メモ</th><th>操作</th></tr>
+            </thead>
+            <tbody>
+              {items.slice(0, 30).map((item) => (
+                <tr key={item.problem.id}>
+                  <td>{item.priority}</td>
+                  <td>{item.statusLabels.join(' / ')}</td>
+                  <td>{item.problem.displayId}</td>
+                  <td>{item.problem.subject === 'commercial' ? '商業簿記' : '工業簿記'}</td>
+                  <td>{item.problem.sectionLabel}</td>
+                  <td>{item.problem.topic}</td>
+                  <td>{item.previousScore ?? '-'}/{item.maxScore ?? '-'}</td>
+                  <td>{item.rank || '-'}</td>
+                  <td>{item.nextReviewDate || '-'}</td>
+                  <td>{item.missReasons.join(' / ') || '-'}</td>
+                  <td>{item.memoSummary || '-'}</td>
+                  <td className="button-cell"><button onClick={() => onStart(item.problem.id)}>開始</button>{item.latestHistory && onRestoreLatest ? <button className="secondary" onClick={() => onRestoreLatest(item)}>最新履歴</button> : null}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
@@ -1,8 +1,8 @@
-import type { AnswerState, BackupPayload, HistoryEntry } from '../types';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry } from '../types';
 
 const DB_NAME = 'cpa-boki2-trial-section-answer-manager';
-const DB_VERSION = 1;
-const STORES = ['answers', 'histories', 'settings', 'templates', 'backups'] as const;
+const DB_VERSION = 2;
+const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets'] as const;
 
 type StoreName = (typeof STORES)[number];
 
@@ -65,15 +65,68 @@ export async function clearHistories(): Promise<void> {
   await tx('histories', 'readwrite', (store) => store.clear());
 }
 
+export async function saveExamSet(record: ExamSetRecord): Promise<void> {
+  await tx('examSets', 'readwrite', (store) => store.put(record));
+}
+
+export async function getExamSets(): Promise<ExamSetRecord[]> {
+  const rows = await tx<ExamSetRecord[]>('examSets', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export async function deleteExamSet(id: string): Promise<void> {
+  await tx('examSets', 'readwrite', (store) => store.delete(id));
+}
+
+export async function getBackupMetadata(): Promise<BackupMetadata | null> {
+  const row = await tx<BackupMetadata | undefined>('backups', 'readonly', (store) => store.get('backupMeta'));
+  return row ?? null;
+}
+
+export async function saveBackupMetadata(meta: BackupMetadata): Promise<void> {
+  await tx('backups', 'readwrite', (store) => store.put(meta));
+}
+
+export async function recordBackupMade(historyCount: number, answerCount: number): Promise<BackupMetadata> {
+  const current = await getBackupMetadata();
+  const next: BackupMetadata = {
+    id: 'backupMeta',
+    lastBackupAt: new Date().toISOString(),
+    lastRestoreAt: current?.lastRestoreAt ?? '',
+    backupCount: (current?.backupCount ?? 0) + 1,
+    lastBackupHistoryCount: historyCount,
+    lastBackupAnswerCount: answerCount,
+  };
+  await saveBackupMetadata(next);
+  return next;
+}
+
+export async function recordRestoreMade(): Promise<BackupMetadata> {
+  const current = await getBackupMetadata();
+  const next: BackupMetadata = {
+    id: 'backupMeta',
+    lastBackupAt: current?.lastBackupAt ?? '',
+    lastRestoreAt: new Date().toISOString(),
+    backupCount: current?.backupCount ?? 0,
+    lastBackupHistoryCount: current?.lastBackupHistoryCount ?? 0,
+    lastBackupAnswerCount: current?.lastBackupAnswerCount ?? 0,
+  };
+  await saveBackupMetadata(next);
+  return next;
+}
+
 export async function exportAllData(): Promise<BackupPayload> {
   return {
     exportedAt: new Date().toISOString(),
     appName: 'CPA日商簿記2級 試験対策編 解答・復習管理アプリ',
-    version: '1.0.0',
+    version: '1.1.0',
     answers: await getAllAnswers(),
     histories: await getHistories(),
     settings: await tx<Record<string, unknown>[]>('settings', 'readonly', (store) => store.getAll()),
     templates: await tx<Record<string, unknown>[]>('templates', 'readonly', (store) => store.getAll()),
+    backups: await tx<Record<string, unknown>[]>('backups', 'readonly', (store) => store.getAll()),
+    examSets: await getExamSets(),
+    backupMetadata: await getBackupMetadata(),
   };
 }
 
@@ -86,6 +139,9 @@ export async function importAllData(payload: BackupPayload): Promise<void> {
     payload.histories?.forEach((item) => transaction.objectStore('histories').put(item));
     payload.settings?.forEach((item) => transaction.objectStore('settings').put(item));
     payload.templates?.forEach((item) => transaction.objectStore('templates').put(item));
+    payload.backups?.forEach((item) => transaction.objectStore('backups').put(item));
+    payload.examSets?.forEach((item) => transaction.objectStore('examSets').put(item));
+    if (payload.backupMetadata) transaction.objectStore('backups').put(payload.backupMetadata);
     transaction.oncomplete = () => {
       db.close();
       resolve();
@@ -95,4 +151,5 @@ export async function importAllData(payload: BackupPayload): Promise<void> {
       reject(transaction.error);
     };
   });
+  await recordRestoreMade();
 }

--- a/cpa-boki2-trial-section-answer-manager/src/styles.css
+++ b/cpa-boki2-trial-section-answer-manager/src/styles.css
@@ -38,7 +38,7 @@ textarea { min-height: 96px; resize: vertical; }
 .panel h2 { margin: 0 0 12px; color: var(--main-dark); font-size: 20px; }
 .panel h3 { margin: 14px 0 8px; color: var(--main-dark); font-size: 15px; }
 .sidebar { position: sticky; top: 12px; }
-.sidebar label, .scoring-panel label { display: block; margin-top: 12px; font-weight: 700; font-size: 13px; }
+.sidebar label, .scoring-panel label, .management-panel label { display: block; margin-top: 12px; font-weight: 700; font-size: 13px; }
 .notice-small { margin-top: 14px; padding: 10px; background: #f7fbf9; border-left: 4px solid var(--main); font-size: 12px; line-height: 1.6; }
 .timer-card { background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.34); border-radius: 14px; padding: 12px; }
 .timer-display { font-weight: 800; font-size: 38px; letter-spacing: .03em; }
@@ -64,6 +64,35 @@ th { background: #e8f2ee; position: sticky; top: 0; z-index: 1; }
 .empty { color: #667; font-size: 13px; }
 .history-wrap { max-height: 360px; }
 .button-cell { min-width: 120px; }
+
+.management-stack { display: grid; gap: 12px; margin-bottom: 16px; }
+.management-panel { padding: 0; overflow: hidden; }
+.management-panel > summary { cursor: pointer; padding: 14px 16px; font-weight: 800; color: var(--main-dark); background: #f8fcfa; border-bottom: 1px solid var(--border); list-style-position: inside; }
+.management-panel[open] > summary { background: #edf7f2; }
+.panel-body { display: grid; gap: 14px; padding: 16px; }
+.priority-card { border: 2px solid #e0b84d; background: #fff9e8; border-radius: 12px; padding: 14px; }
+.priority-card h3 { margin: 8px 0; font-size: 18px; }
+.badge-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.status-badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 8px; background: #e2f0ea; color: #185341; font-size: 12px; font-weight: 700; }
+.metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+.metric-grid > div { background: #f7fbf9; border: 1px solid #d9e9e3; border-radius: 10px; padding: 10px; display: grid; gap: 4px; }
+.metric-grid span { color: #5d6e68; font-size: 12px; }
+.metric-grid strong { font-size: 18px; color: var(--main-dark); word-break: break-word; }
+.warning-text { margin: 0; padding: 12px; border-left: 4px solid var(--warning); border-radius: 10px; background: #fff7e6; line-height: 1.7; font-weight: 700; }
+.warning-list { margin: 0; padding: 12px 12px 12px 28px; border: 1px solid #f1c7a1; background: #fff3eb; border-radius: 10px; color: #7a351b; line-height: 1.7; }
+.ok-text { margin: 0; padding: 10px; background: #ebf8ef; border: 1px solid #b8dfc2; border-radius: 10px; color: #17633b; }
+.compact-wrap { max-height: 360px; }
+.short-wrap { max-height: 260px; }
+.compact-table { border-collapse: collapse; width: max-content; min-width: 100%; background: #fff; }
+.compact-table th { background: #e8f2ee; }
+.compact-table td, .compact-table th { white-space: nowrap; }
+.compact-table input, .compact-table select { min-width: 120px; }
+.exam-timer { display: inline-flex; align-items: baseline; gap: 12px; background: #173f35; color: #fff; border-radius: 12px; padding: 12px 16px; width: fit-content; }
+.exam-timer strong { font-size: 28px; letter-spacing: .04em; }
+.exam-timer span { color: #d7f1e8; font-weight: 700; }
+.result-card { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; border-radius: 12px; padding: 12px; background: #edf7f2; border: 1px solid #cde5db; }
+.result-card strong { color: var(--main-dark); font-size: 20px; }
+.result-card span { font-weight: 700; }
 
 .example-guide { background: #fffdf4; border: 1px solid #eadca5; border-radius: 14px; padding: 0; box-shadow: 0 4px 14px rgba(92, 72, 18, .08); }
 .example-guide summary { cursor: pointer; padding: 14px 16px; font-weight: 800; color: #574410; list-style-position: inside; }

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -85,6 +85,82 @@ export interface HistoryEntry {
   snapshot: AnswerState;
 }
 
+export type QueueStatusLabel = '期限超過' | '今日復習' | 'C判定' | 'B判定' | 'A判定' | '未着手' | '低得点' | 'ミス多い' | '日付未設定C';
+
+export interface StudyQueueItem {
+  priority: number;
+  statusLabels: QueueStatusLabel[];
+  problem: ProblemDefinition;
+  latestHistory?: HistoryEntry;
+  previousScore?: number;
+  maxScore?: number;
+  rank: ReviewRank;
+  nextReviewDate: string;
+  missReasons: MissReason[];
+  memoSummary: string;
+  reason: string;
+}
+
+export interface DashboardProblemStats {
+  problem: ProblemDefinition;
+  attempts: number;
+  latestScore: number | null;
+  highestScore: number | null;
+  lowestScore: number | null;
+  latestRank: ReviewRank;
+  latestMissReasons: MissReason[];
+  latestReviewDate: string;
+  trend: '改善' | '横ばい' | '悪化' | 'データ不足';
+}
+
+export interface BackupMetadata {
+  id: 'backupMeta';
+  lastBackupAt: string;
+  lastRestoreAt: string;
+  backupCount: number;
+  lastBackupHistoryCount: number;
+  lastBackupAnswerCount: number;
+}
+
+export interface StorageSafetyInfo {
+  saveMethod: 'IndexedDB';
+  historyCount: number;
+  answerCount: number;
+  lastBackupAt: string;
+  lastRestoreAt: string;
+  backupCount: number;
+  lastBackupHistoryCount: number;
+  lastBackupAnswerCount: number;
+  estimatedUsage: number | null;
+  estimatedQuota: number | null;
+  persistentStatus: '許可済み' | '未許可' | '非対応' | '確認不可';
+  storageManagerSupported: boolean;
+  warnings: string[];
+}
+
+export interface ExamSetProblemState {
+  problemId: string;
+  status: '未開始' | '開始' | '完了';
+  score: number;
+  rank: ReviewRank;
+}
+
+export interface ExamSetRecord {
+  id: string;
+  name: string;
+  createdAt: string;
+  startedAt: string;
+  finishedAt: string;
+  durationSeconds: number;
+  selectedProblemIds: string[];
+  problemStates: ExamSetProblemState[];
+  problemScores: Record<string, number>;
+  totalScore: number;
+  passLineReached: boolean;
+  memo: string;
+  relatedHistoryIds: string[];
+}
+
 export interface BackupPayload {
   exportedAt: string;
   appName: string;
@@ -93,4 +169,7 @@ export interface BackupPayload {
   histories: HistoryEntry[];
   settings: Record<string, unknown>[];
   templates: Record<string, unknown>[];
+  backups?: Record<string, unknown>[];
+  examSets?: ExamSetRecord[];
+  backupMetadata?: BackupMetadata | null;
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
@@ -1,4 +1,4 @@
-import type { AnswerState, HistoryEntry, ProblemDefinition } from '../types';
+import type { AnswerState, ExamSetRecord, HistoryEntry, ProblemDefinition, StudyQueueItem } from '../types';
 import { draftSummary } from './scoring';
 
 function escapeCsv(value: unknown): string {
@@ -54,7 +54,40 @@ export function problemStatsCsvRows(histories: HistoryEntry[]): unknown[][] {
 }
 
 export function missReasonCsvRows(histories: HistoryEntry[]): unknown[][] {
-  const counts = new Map<string, number>();
-  histories.forEach((history) => history.missReasons.forEach((reason) => counts.set(reason, (counts.get(reason) || 0) + 1)));
-  return [['ミス原因', '件数'], ...Array.from(counts.entries())];
+  const counts = new Map<string, { count: number; problemIds: Set<string>; latestAt: string }>();
+  histories.forEach((history) => history.missReasons.forEach((reason) => {
+    const current = counts.get(reason) ?? { count: 0, problemIds: new Set<string>(), latestAt: '' };
+    current.count += 1;
+    current.problemIds.add(history.displayId);
+    if (history.savedAt > current.latestAt) current.latestAt = history.savedAt;
+    counts.set(reason, current);
+  }));
+  return [['ミス原因', '件数', '該当問題ID', '最新発生日'], ...Array.from(counts.entries()).map(([reason, info]) => [reason, info.count, Array.from(info.problemIds).join('/'), info.latestAt])];
+}
+
+export function studyQueueCsvRows(items: StudyQueueItem[]): unknown[][] {
+  return [
+    ['優先順位', '状態ラベル', '科目', '大問対策', '問題ID', '論点名', '前回得点', '満点', '前回判定', '次回復習日', 'ミス原因', '前回メモ要約', '理由'],
+    ...items.map((item) => [item.priority, item.statusLabels.join('/'), item.problem.subject, item.problem.sectionLabel, item.problem.displayId, item.problem.topic, item.previousScore ?? '', item.maxScore ?? '', item.rank, item.nextReviewDate, item.missReasons.join('/'), item.memoSummary, item.reason]),
+  ];
+}
+
+export function dashboardCsvRows(histories: HistoryEntry[]): unknown[][] {
+  const byProblem = new Map<string, HistoryEntry[]>();
+  histories.forEach((history) => byProblem.set(history.displayId, [...(byProblem.get(history.displayId) ?? []), history]));
+  return [
+    ['問題ID', '演習回数', '最新得点', '最高得点', '最低得点', '最新判定', '最新復習日', '最新ミス原因'],
+    ...Array.from(byProblem.entries()).map(([displayId, rows]) => {
+      const sorted = rows.sort((a, b) => a.savedAt.localeCompare(b.savedAt));
+      const latest = sorted.at(-1)!;
+      return [displayId, rows.length, latest.score, Math.max(...rows.map((row) => row.score)), Math.min(...rows.map((row) => row.score)), latest.rank, latest.nextReviewDate, latest.missReasons.join('/')];
+    }),
+  ];
+}
+
+export function examSetCsvRows(examSets: ExamSetRecord[]): unknown[][] {
+  return [
+    ['作成日時', 'セット名', '開始日時', '終了日時', '所要秒数', '選択問題ID', '合計点', '70点判定', 'メモ'],
+    ...examSets.map((set) => [set.createdAt, set.name, set.startedAt, set.finishedAt, set.durationSeconds, set.selectedProblemIds.join('/'), set.totalScore, set.passLineReached ? '合格ライン到達' : '復習優先', set.memo]),
+  ];
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/dashboard.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/dashboard.ts
@@ -1,0 +1,101 @@
+import { problemCatalog } from '../data/problemCatalog';
+import type { DashboardProblemStats, HistoryEntry, MissReason, SectionId } from '../types';
+import { isDueTodayOrEarlier, isOverdue } from './dates';
+
+function scoreRate(history: HistoryEntry): number {
+  return history.maxScore ? history.score / history.maxScore : 0;
+}
+
+export function buildProblemStats(histories: HistoryEntry[]): DashboardProblemStats[] {
+  return problemCatalog.map((problem) => {
+    const rows = histories.filter((history) => history.problemId === problem.id).sort((a, b) => a.savedAt.localeCompare(b.savedAt));
+    const latest = rows.at(-1);
+    const previous = rows.at(-2);
+    let trend: DashboardProblemStats['trend'] = 'データ不足';
+    if (latest && previous) {
+      if (latest.score > previous.score) trend = '改善';
+      else if (latest.score < previous.score) trend = '悪化';
+      else trend = '横ばい';
+    }
+    return {
+      problem,
+      attempts: rows.length,
+      latestScore: latest?.score ?? null,
+      highestScore: rows.length ? Math.max(...rows.map((row) => row.score)) : null,
+      lowestScore: rows.length ? Math.min(...rows.map((row) => row.score)) : null,
+      latestRank: latest?.rank ?? '',
+      latestMissReasons: latest?.missReasons ?? [],
+      latestReviewDate: latest?.nextReviewDate ?? '',
+      trend,
+    };
+  });
+}
+
+export function buildDashboard(histories: HistoryEntry[], answerCount: number) {
+  const rates = histories.map(scoreRate).filter((rate) => Number.isFinite(rate));
+  const averageRate = rates.length ? rates.reduce((sum, value) => sum + value, 0) / rates.length : 0;
+  const averageScore = histories.length ? histories.reduce((sum, history) => sum + history.score, 0) / histories.length : 0;
+  const problemStats = buildProblemStats(histories);
+  const untouchedCount = problemStats.filter((row) => row.attempts === 0).length;
+  const overdueCount = histories.filter((history) => isOverdue(history.nextReviewDate)).length;
+  const todayCount = histories.filter((history) => isDueTodayOrEarlier(history.nextReviewDate)).length;
+  const missCounts = new Map<MissReason, { count: number; problemIds: Set<string>; latestAt: string }>();
+
+  histories.forEach((history) => {
+    history.missReasons.forEach((reason) => {
+      const current = missCounts.get(reason) ?? { count: 0, problemIds: new Set<string>(), latestAt: '' };
+      current.count += 1;
+      current.problemIds.add(history.displayId);
+      if (history.savedAt > current.latestAt) current.latestAt = history.savedAt;
+      missCounts.set(reason, current);
+    });
+  });
+
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const inRange = (history: HistoryEntry, date: Date) => new Date(history.savedAt) >= date;
+
+  const sectionStats = (['q1', 'q2', 'q3', 'q4', 'q5'] as SectionId[]).map((sectionId) => {
+    const sectionRows = histories.filter((history) => history.sectionId === sectionId);
+    const count = sectionRows.length;
+    const cCount = sectionRows.filter((history) => history.rank === 'C').length;
+    const reasons = new Map<string, number>();
+    sectionRows.forEach((history) => history.missReasons.forEach((reason) => reasons.set(reason, (reasons.get(reason) || 0) + 1)));
+    const commonReason = Array.from(reasons.entries()).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '-';
+    return {
+      sectionId,
+      sectionLabel: problemCatalog.find((problem) => problem.sectionId === sectionId)?.sectionLabel ?? sectionId,
+      attempts: count,
+      averageScore: count ? sectionRows.reduce((sum, history) => sum + history.score, 0) / count : 0,
+      cCount,
+      commonReason,
+    };
+  });
+
+  return {
+    summary: {
+      totalAttempts: histories.length,
+      historyCount: histories.length,
+      answerCount,
+      averageScore,
+      averageRate,
+      passLikeCount: histories.filter((history) => history.maxScore && history.score / history.maxScore >= 0.7).length,
+      aCount: histories.filter((history) => history.rank === 'A').length,
+      bCount: histories.filter((history) => history.rank === 'B').length,
+      cCount: histories.filter((history) => history.rank === 'C').length,
+      untouchedCount,
+      overdueCount,
+      todayCount,
+      sevenDayAttempts: histories.filter((history) => inRange(history, sevenDaysAgo)).length,
+      thirtyDayAttempts: histories.filter((history) => inRange(history, thirtyDaysAgo)).length,
+      sevenDayC: histories.filter((history) => history.rank === 'C' && inRange(history, sevenDaysAgo)).length,
+      thirtyDayC: histories.filter((history) => history.rank === 'C' && inRange(history, thirtyDaysAgo)).length,
+    },
+    problemStats,
+    sectionStats,
+    missReasonRanking: Array.from(missCounts.entries()).map(([reason, info]) => ({ reason, count: info.count, problemIds: Array.from(info.problemIds), latestAt: info.latestAt })).sort((a, b) => b.count - a.count),
+  };
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/storageSafety.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/storageSafety.ts
@@ -1,0 +1,70 @@
+import type { BackupMetadata, StorageSafetyInfo } from '../types';
+
+function daysSince(value: string): number | null {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  if (Number.isNaN(time)) return null;
+  return Math.floor((Date.now() - time) / 86400000);
+}
+
+export async function getStorageSafetyInfo(historyCount: number, answerCount: number, metadata: BackupMetadata | null): Promise<StorageSafetyInfo> {
+  const storageSupported = typeof navigator !== 'undefined' && 'storage' in navigator;
+  let estimatedUsage: number | null = null;
+  let estimatedQuota: number | null = null;
+  let persistentStatus: StorageSafetyInfo['persistentStatus'] = storageSupported ? '確認不可' : '非対応';
+
+  try {
+    if (storageSupported && navigator.storage.estimate) {
+      const estimate = await navigator.storage.estimate();
+      estimatedUsage = estimate.usage ?? null;
+      estimatedQuota = estimate.quota ?? null;
+    }
+    if (storageSupported && navigator.storage.persisted) {
+      persistentStatus = (await navigator.storage.persisted()) ? '許可済み' : '未許可';
+    }
+  } catch {
+    persistentStatus = '確認不可';
+  }
+
+  const lastBackupAt = metadata?.lastBackupAt ?? '';
+  const backupAge = daysSince(lastBackupAt);
+  const warnings: string[] = [];
+  if (!lastBackupAt) warnings.push('JSONバックアップ未取得です。ブラウザデータ削除・端末変更に備えてバックアップしてください。');
+  if (backupAge !== null && backupAge >= 7) warnings.push('最終JSONバックアップから7日以上経過しています。');
+  if (historyCount >= 50 && !lastBackupAt) warnings.push('履歴件数が50件以上ありますが、JSONバックアップが未取得です。');
+  if (!storageSupported) warnings.push('このブラウザはStorageManager APIに非対応です。保存状態の詳細確認ができません。');
+  if (persistentStatus === '未許可') warnings.push('永続ストレージが許可されていません。ブラウザ判断で保存データが削除される可能性があります。');
+
+  return {
+    saveMethod: 'IndexedDB',
+    historyCount,
+    answerCount,
+    lastBackupAt,
+    lastRestoreAt: metadata?.lastRestoreAt ?? '',
+    backupCount: metadata?.backupCount ?? 0,
+    lastBackupHistoryCount: metadata?.lastBackupHistoryCount ?? 0,
+    lastBackupAnswerCount: metadata?.lastBackupAnswerCount ?? 0,
+    estimatedUsage,
+    estimatedQuota,
+    persistentStatus,
+    storageManagerSupported: storageSupported,
+    warnings,
+  };
+}
+
+export async function requestPersistentStorage(): Promise<'許可済み' | '未許可' | '非対応'> {
+  if (typeof navigator === 'undefined' || !('storage' in navigator) || !navigator.storage.persist) return '非対応';
+  try {
+    return (await navigator.storage.persist()) ? '許可済み' : '未許可';
+  } catch {
+    return '未許可';
+  }
+}
+
+export function formatBytes(value: number | null): string {
+  if (value === null) return '-';
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  if (value < 1024 * 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MB`;
+  return `${(value / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/studyQueue.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/studyQueue.ts
@@ -1,0 +1,83 @@
+import { problemCatalog } from '../data/problemCatalog';
+import type { HistoryEntry, ProblemDefinition, StudyQueueItem } from '../types';
+import { isDueTodayOrEarlier, isOverdue } from './dates';
+
+function latestByProblem(histories: HistoryEntry[]): Map<string, HistoryEntry> {
+  const map = new Map<string, HistoryEntry>();
+  histories.forEach((history) => {
+    const current = map.get(history.problemId);
+    if (!current || history.savedAt > current.savedAt) map.set(history.problemId, history);
+  });
+  return map;
+}
+
+function buildItem(problem: ProblemDefinition, history: HistoryEntry | undefined, priority: number, reason: string, statusLabels: StudyQueueItem['statusLabels']): StudyQueueItem {
+  return {
+    priority,
+    statusLabels,
+    problem,
+    latestHistory: history,
+    previousScore: history?.score,
+    maxScore: history?.maxScore,
+    rank: history?.rank ?? '',
+    nextReviewDate: history?.nextReviewDate ?? '',
+    missReasons: history?.missReasons ?? [],
+    memoSummary: history?.draftMemoSummary || history?.reviewMemo?.slice(0, 80) || '',
+    reason,
+  };
+}
+
+export function buildStudyQueue(histories: HistoryEntry[]): StudyQueueItem[] {
+  const latest = latestByProblem(histories);
+  const items: StudyQueueItem[] = [];
+  const pushed = new Set<string>();
+
+  function add(problem: ProblemDefinition, history: HistoryEntry | undefined, priority: number, reason: string, labels: StudyQueueItem['statusLabels']) {
+    if (pushed.has(problem.id)) return;
+    pushed.add(problem.id);
+    items.push(buildItem(problem, history, priority, reason, labels));
+  }
+
+  problemCatalog.forEach((problem) => {
+    const history = latest.get(problem.id);
+    if (!history) return;
+    const overdue = isOverdue(history.nextReviewDate);
+    const due = isDueTodayOrEarlier(history.nextReviewDate);
+    const noDateC = history.rank === 'C' && !history.nextReviewDate;
+    if (history.rank === 'C' && overdue) add(problem, history, 1, '期限超過のC判定', ['期限超過', 'C判定']);
+    else if (history.rank === 'C' && due) add(problem, history, 2, '今日が復習日のC判定', ['今日復習', 'C判定']);
+    else if (history.rank === 'B' && overdue) add(problem, history, 3, '期限超過のB判定', ['期限超過', 'B判定']);
+    else if (history.rank === 'B' && due) add(problem, history, 4, '今日が復習日のB判定', ['今日復習', 'B判定']);
+    else if (history.rank === 'A' && overdue) add(problem, history, 5, '期限超過のA判定', ['期限超過', 'A判定']);
+    else if (history.rank === 'A' && due) add(problem, history, 6, '今日が復習日のA判定', ['今日復習', 'A判定']);
+    else if (noDateC) add(problem, history, 6.5, 'C判定だが次回復習日が未設定', ['日付未設定C', 'C判定']);
+  });
+
+  problemCatalog.forEach((problem) => {
+    if (!latest.has(problem.id)) add(problem, undefined, 7, '未着手問題', ['未着手']);
+  });
+
+  problemCatalog.forEach((problem) => {
+    const history = latest.get(problem.id);
+    if (!history || pushed.has(problem.id)) return;
+    const rate = history.maxScore ? history.score / history.maxScore : 1;
+    if (rate < 0.6) add(problem, history, 8, '直近の得点率が低い問題', ['低得点']);
+  });
+
+  problemCatalog.forEach((problem) => {
+    const history = latest.get(problem.id);
+    if (!history || pushed.has(problem.id)) return;
+    if ((history.missReasons?.length ?? 0) >= 2) add(problem, history, 9, 'ミス原因が多い問題', ['ミス多い']);
+  });
+
+  return items.sort((a, b) => a.priority - b.priority || a.problem.displayId.localeCompare(b.problem.displayId));
+}
+
+export function queueCounts(items: StudyQueueItem[]) {
+  return {
+    total: items.length,
+    overdue: items.filter((item) => item.statusLabels.includes('期限超過')).length,
+    c: items.filter((item) => item.statusLabels.includes('C判定')).length,
+    untouched: items.filter((item) => item.statusLabels.includes('未着手')).length,
+  };
+}


### PR DESCRIPTION
## 目的
CPA日商簿記2級 試験対策編 解答・復習管理アプリについて、毎日の学習判断を自動化し、保存データ消失リスクを下げ、90分の本番形式に近いセット演習まで管理できる状態にします。

対象アプリ:
- `cpa-boki2-trial-section-answer-manager/`

公開予定URL:
- `https://akashidaiki19910915-star.github.io/gyosei-app/cpa-boki2-trial-section-answer-manager/`

## 実装した機能一覧
### 1. 今日やる問題リスト／復習キュー強化
- `StudyQueuePanel.tsx` を追加
- 優先順位付きの今日の学習キューを表示
- 期限超過C、今日復習C、期限超過B、今日復習B、期限超過A、今日復習A、未着手、低得点、ミス多い問題の順で表示
- 今日やる件数、期限超過件数、C判定件数、未着手件数を表示
- 今日の最優先1件を強調表示
- 開始ボタンで該当問題IDへ移動
- 最新履歴がある場合は最新履歴復元ボタンも表示
- 今日の学習キューCSVを追加

### 2. バックアップ警告・保存安全性チェック
- `BackupSafetyPanel.tsx` と `storageSafety.ts` を追加
- IndexedDB保存方式、履歴件数、保存済み答案件数、最終JSONバックアップ日時、最終JSON復元日時、推定ストレージ使用量、推定上限、永続ストレージ許可状態を表示
- JSONバックアップ未取得、7日以上未取得、履歴50件以上かつ未取得、永続ストレージ未許可、StorageManager API非対応時に警告
- `navigator.storage.estimate()`、`navigator.storage.persisted()`、`navigator.storage.persist()` に対応
- 保存安全性パネル内にJSONバックアップ、JSON復元、永続ストレージ有効化、保存状態再確認ボタンを配置

### 3. 成績ダッシュボード
- `DashboardPanel.tsx` と `dashboard.ts` を追加
- 全体サマリー、問題ID別成績、大問別成績、ミス原因ランキング、直近7日間・30日間の演習回数とC判定数を表示
- 成績ダッシュボードCSVを追加
- 外部チャートライブラリは追加していません

### 4. 90分セット演習モード
- `ExamSetPanel.tsx` を追加
- 第1問対策〜第5問対策から各1問を選択可能
- セット名、90分タイマー、各問題IDの開始/完了状態、得点、A/B/C判定、合計点、70点判定、メモを管理
- セット演習履歴をIndexedDBへ保存
- 未着手優先、C判定優先、ランダムセット作成ボタンを追加
- セット履歴CSVを追加

## 変更ファイル一覧
- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/BackupSafetyPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/DashboardPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/ExamSetPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/StudyQueuePanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts`
- `cpa-boki2-trial-section-answer-manager/src/styles.css`
- `cpa-boki2-trial-section-answer-manager/src/types/index.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/csv.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/dashboard.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/storageSafety.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/studyQueue.ts`

## 既存案件管理アプリへの影響有無
- 既存案件管理アプリ本体は変更していません。
- 既存トップURL用のファイルは変更していません。
- Pages workflowは変更していません。

## 既存簿記アプリ機能への影響有無
- 既存の答案入力、自己採点、履歴保存、履歴復元、CSV、JSONバックアップ、記入例表示は維持しています。
- PR #230 の仕訳テーブル修正、記入例追加、右パネルかぶり防止を巻き戻していません。
- `会社名・立場` 列は復活させていません。

## IndexedDBの変更点
- DB_VERSIONを `1` から `2` に更新
- 既存ストアは削除せず維持
  - `answers`
  - `histories`
  - `settings`
  - `templates`
  - `backups`
- 新規ストアを追加
  - `examSets`
- `backups` ストアにバックアップメタ情報 `backupMeta` を保存

## JSONバックアップ互換性
- 既存の `answers`、`histories`、`settings`、`templates` を維持
- 新たに `examSets`、`backups`、`backupMetadata` を含めるよう拡張
- 旧JSONで不足する `examSets` や `backups` は空扱いで読み込めるようにしています

## 動作確認結果
この環境ではローカルの `npm install` / `npm run build` は実行できません。PR作成後、GitHub Actions / Pages buildで確認してください。

コード上で確認した項目:
- 今日の学習キュー表示を実装
- 未着手問題表示を実装
- C判定・期限超過の優先表示ロジックを実装
- キュー開始ボタンによる問題ID移動を実装
- 保存安全性チェック表示を実装
- JSONバックアップ未取得警告を実装
- JSONバックアップ実行時の最終バックアップ日時更新を実装
- StorageManager APIによる永続ストレージ確認・要求を実装
- 成績ダッシュボード表示を実装
- 問題ID別成績表示を実装
- ミス原因ランキング表示を実装
- 90分セット演習モードを実装
- 第1問〜第5問の問題ID選択を実装
- セット演習の得点・合計点・70点判定を実装
- セット演習履歴保存を実装

## 未確認事項
- GitHub Pages Actions成功可否
- 公開URLでの実機表示確認
- 長期履歴蓄積時の表示速度
- ブラウザごとの永続ストレージ許可挙動

## 著作権対応
以下は追加していません。
- CPA教材の問題文
- CPA教材の解答
- CPA教材の解説
- CPAロゴ
- 教材画像
- 日本商工会議所の問題文・サンプル問題

## 次回以降に回した機能
- 建設業経理士2級モード
- 弁理士モード
- Supabase同期
- ログイン機能
- 自動採点
- AI解説
- 教材PDF取込
- 問題文保存
- グラフライブラリ導入
- PWA化