### PR TITLE
Improve CPA boki2 answer table input efficiency

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
@@ -1,3 +1,4 @@
+import type { HTMLAttributes, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { AnswerRow, AnswerState, GradeMark, TemplateDefinition } from '../types';
 import { formatAmount, isAmountColumn, isInvalidAmount, isJapaneseTextColumn, normalizeNumericInput, toHalfWidthNumber } from '../utils/numberFormat';
 import { handleTableCellKeyDown } from '../utils/tableNavigation';
@@ -29,7 +30,7 @@ function columnClass(column: string): string {
   return 'col-generic';
 }
 
-function cellInputMode(column: string): React.HTMLAttributes<HTMLInputElement>['inputMode'] {
+function cellInputMode(column: string): HTMLAttributes<HTMLInputElement>['inputMode'] {
   if (isAmountColumn(column)) return 'numeric';
   return 'text';
 }
@@ -107,7 +108,7 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
       'data-answer-cell': 'true',
       'data-row-index': rowIndex,
       'data-col-index': colIndex,
-      onKeyDown: (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex),
+      onKeyDown: (event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex),
     };
 
     if (template.optionColumns?.[column]) {

--- a/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
@@ -1,4 +1,6 @@
 import type { AnswerRow, AnswerState, GradeMark, TemplateDefinition } from '../types';
+import { formatAmount, isAmountColumn, isInvalidAmount, isJapaneseTextColumn, normalizeNumericInput, toHalfWidthNumber } from '../utils/numberFormat';
+import { handleTableCellKeyDown } from '../utils/tableNavigation';
 
 const gradeOptions: GradeMark[] = ['未採点', '○', '△', '×'];
 
@@ -18,6 +20,26 @@ export function createRows(columnCount: number, count: number): AnswerRow[] {
   return Array.from({ length: count }, (_, index) => makeRow(columnCount, index));
 }
 
+function columnClass(column: string): string {
+  if (column === '行番号') return 'col-row-number';
+  if (column.includes('設問番号')) return 'col-question-number';
+  if (isAmountColumn(column)) return 'col-amount';
+  if (column.includes('メモ')) return 'col-memo';
+  if (isJapaneseTextColumn(column)) return 'col-account';
+  return 'col-generic';
+}
+
+function cellInputMode(column: string): React.HTMLAttributes<HTMLInputElement>['inputMode'] {
+  if (isAmountColumn(column)) return 'numeric';
+  return 'text';
+}
+
+function placeholderFor(column: string): string {
+  if (isAmountColumn(column)) return '例：200,000';
+  if (isJapaneseTextColumn(column)) return column.includes('科目') ? '例：仕入' : '日本語入力';
+  return '';
+}
+
 export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Props) {
   const updateHeader = (index: number, value: string) => {
     const columns = [...answer.columns];
@@ -26,10 +48,25 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
   };
 
   const updateCell = (rowIndex: number, colIndex: number, value: string) => {
+    const column = answer.columns[colIndex] ?? '';
+    const nextValue = isAmountColumn(column) ? normalizeNumericInput(value) : value;
     const rows = answer.rows.map((row, index) => {
       if (index !== rowIndex) return row;
       const cells = [...row.cells];
-      cells[colIndex] = value;
+      cells[colIndex] = nextValue;
+      return { ...row, cells };
+    });
+    onChange({ ...answer, rows });
+  };
+
+  const updateCellOnBlur = (rowIndex: number, colIndex: number, value: string) => {
+    const column = answer.columns[colIndex] ?? '';
+    if (!isAmountColumn(column)) return;
+    const normalized = normalizeNumericInput(value);
+    const rows = answer.rows.map((row, index) => {
+      if (index !== rowIndex) return row;
+      const cells = [...row.cells];
+      cells[colIndex] = normalized;
       return { ...row, cells };
     });
     onChange({ ...answer, rows });
@@ -62,51 +99,134 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
     onChange({ ...answer, rows: rows.length ? rows : createRows(answer.columns.length, 1) });
   };
 
+  const renderCellInput = (row: AnswerRow, rowIndex: number, column: string, colIndex: number) => {
+    const value = row.cells[colIndex] ?? '';
+    const amount = isAmountColumn(column);
+    const invalidAmount = amount && isInvalidAmount(value);
+    const commonProps = {
+      'data-answer-cell': 'true',
+      'data-row-index': rowIndex,
+      'data-col-index': colIndex,
+      onKeyDown: (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex),
+    };
+
+    if (template.optionColumns?.[column]) {
+      return (
+        <select
+          {...commonProps}
+          value={value}
+          onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}
+          aria-label={`${column} ${rowIndex + 1}行目`}
+        >
+          <option value="">選択</option>
+          {template.optionColumns[column].map((option) => <option key={option} value={option}>{option}</option>)}
+        </select>
+      );
+    }
+
+    if (column.includes('メモ')) {
+      return (
+        <textarea
+          {...commonProps}
+          className="memo-cell-input"
+          value={value}
+          title={value}
+          onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}
+          lang="ja"
+          inputMode="text"
+          autoComplete="off"
+          spellCheck={false}
+          aria-label={`${column} ${rowIndex + 1}行目`}
+        />
+      );
+    }
+
+    return (
+      <input
+        {...commonProps}
+        className={invalidAmount ? 'invalid-amount' : ''}
+        type="text"
+        value={amount ? formatAmount(value) : value}
+        title={value}
+        onChange={(event) => updateCell(rowIndex, colIndex, amount ? toHalfWidthNumber(event.target.value) : event.target.value)}
+        onBlur={(event) => updateCellOnBlur(rowIndex, colIndex, event.target.value)}
+        lang={isJapaneseTextColumn(column) ? 'ja' : undefined}
+        inputMode={cellInputMode(column)}
+        pattern={amount ? '[0-9,\\-]*' : undefined}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholderFor(column)}
+        aria-label={`${column} ${rowIndex + 1}行目`}
+      />
+    );
+  };
+
   return (
     <section className="panel answer-panel">
-      <div className="section-heading">
+      <div className="section-heading answer-heading">
         <h2>答案入力テーブル</h2>
-        <div className="button-row">
+        <div className="button-row answer-actions">
           <button onClick={addRows}>10行追加</button>
           <button onClick={addColumn}>列追加</button>
           <button className="secondary" onClick={compactRows}>空行整理</button>
           <button className="accent" onClick={onApplyRowPoints}>行別得点合計を問題得点へ反映</button>
         </div>
       </div>
-      <div className="table-wrap">
-        <table className="answer-table">
+      <div className={`table-wrap answer-table-wrap ${answer.templateId === 'journal' ? 'journal-table-wrap' : ''}`}>
+        <table className={`answer-table ${answer.templateId === 'journal' ? 'journal-table' : ''}`}>
+          <colgroup>
+            {answer.columns.map((column, index) => <col key={`${column}-${index}`} className={columnClass(column)} />)}
+            <col className="col-grade" />
+            <col className="col-points" />
+          </colgroup>
           <thead>
             <tr>
               {answer.columns.map((column, index) => (
-                <th key={`${column}-${index}`}>
+                <th key={`${column}-${index}`} className={columnClass(column)}>
                   <input value={column} onChange={(event) => updateHeader(index, event.target.value)} aria-label={`列名${index + 1}`} />
                 </th>
               ))}
-              <th>採点</th>
-              <th>行別得点</th>
+              <th className="col-grade">採点</th>
+              <th className="col-points">行別得点</th>
             </tr>
           </thead>
           <tbody>
             {answer.rows.map((row, rowIndex) => (
               <tr key={row.id}>
                 {answer.columns.map((column, colIndex) => (
-                  <td key={`${row.id}-${colIndex}`}>
-                    {template.optionColumns?.[column] ? (
-                      <select value={row.cells[colIndex] ?? ''} onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}>
-                        <option value="">選択</option>
-                        {template.optionColumns[column].map((option) => <option key={option} value={option}>{option}</option>)}
-                      </select>
-                    ) : (
-                      <input value={row.cells[colIndex] ?? ''} onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)} />
-                    )}
+                  <td key={`${row.id}-${colIndex}`} className={columnClass(column)}>
+                    {renderCellInput(row, rowIndex, column, colIndex)}
                   </td>
                 ))}
-                <td>
-                  <select value={row.grade} onChange={(event) => updateGrade(rowIndex, event.target.value as GradeMark)}>
+                <td className="col-grade">
+                  <select
+                    data-answer-cell="true"
+                    data-row-index={rowIndex}
+                    data-col-index={answer.columns.length}
+                    value={row.grade}
+                    onChange={(event) => updateGrade(rowIndex, event.target.value as GradeMark)}
+                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length)}
+                    aria-label={`採点 ${rowIndex + 1}行目`}
+                  >
                     {gradeOptions.map((grade) => <option key={grade} value={grade}>{grade}</option>)}
                   </select>
                 </td>
-                <td><input type="number" value={row.points} onChange={(event) => updatePoints(rowIndex, Number(event.target.value || 0))} /></td>
+                <td className="col-points">
+                  <input
+                    data-answer-cell="true"
+                    data-row-index={rowIndex}
+                    data-col-index={answer.columns.length + 1}
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9,\\-]*"
+                    value={String(row.points)}
+                    onChange={(event) => updatePoints(rowIndex, Number(normalizeNumericInput(event.target.value) || 0))}
+                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length + 1)}
+                    autoComplete="off"
+                    spellCheck={false}
+                    aria-label={`行別得点 ${rowIndex + 1}行目`}
+                  />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/cpa-boki2-trial-section-answer-manager/src/styles.css
+++ b/cpa-boki2-trial-section-answer-manager/src/styles.css
@@ -47,13 +47,34 @@ textarea { min-height: 96px; resize: vertical; }
 .button-row, .button-grid { display: flex; flex-wrap: wrap; gap: 8px; }
 .button-grid { margin-top: 12px; }
 .section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.answer-heading { align-items: flex-start; }
+.answer-actions { max-width: 100%; }
+.answer-actions button { padding: 8px 10px; }
 .table-wrap { width: 100%; max-width: 100%; overflow-x: auto; overflow-y: auto; max-height: 62vh; border: 1px solid var(--border); border-radius: 10px; }
+.answer-table-wrap { max-height: 64vh; }
+.journal-table-wrap { overflow-x: hidden; }
 .answer-table { border-collapse: collapse; width: max-content; min-width: 100%; max-width: none; background: #fff; }
+.journal-table { width: 100%; min-width: 0; max-width: 100%; table-layout: fixed; }
 .history-panel table { border-collapse: collapse; width: max-content; min-width: 100%; background: #fff; }
 th, td { border: 1px solid #d9e5e1; padding: 6px; vertical-align: top; }
 th { background: #e8f2ee; position: sticky; top: 0; z-index: 1; }
-.answer-table input, .answer-table select { min-width: 118px; }
-.answer-table th input { min-width: 130px; font-weight: 700; background: #f7fbf9; }
+.answer-table th, .answer-table td { padding: 4px; }
+.answer-table input, .answer-table select, .answer-table textarea { width: 100%; min-width: 0; box-sizing: border-box; font-size: 14px; padding: 6px 8px; }
+.answer-table th input { font-weight: 700; background: #f7fbf9; }
+.answer-table input:focus, .answer-table select:focus, .answer-table textarea:focus { outline: 2px solid #7bbda6; outline-offset: 1px; }
+.memo-cell-input { min-height: 34px; max-height: 70px; resize: vertical; line-height: 1.35; }
+.invalid-amount { border-color: #d65844 !important; background: #fff4f1; }
+.answer-table .col-row-number, .answer-table col.col-row-number { width: 44px; }
+.answer-table .col-question-number, .answer-table col.col-question-number { width: 64px; }
+.answer-table .col-account, .answer-table col.col-account { width: 140px; }
+.answer-table .col-amount, .answer-table col.col-amount { width: 120px; }
+.answer-table .col-memo, .answer-table col.col-memo { width: 160px; }
+.answer-table .col-grade, .answer-table col.col-grade { width: 64px; }
+.answer-table .col-points, .answer-table col.col-points { width: 70px; }
+.answer-table .col-generic, .answer-table col.col-generic { width: 120px; }
+.journal-table .col-row-number input { text-align: center; }
+.journal-table .col-question-number input { text-align: center; }
+.journal-table .col-amount input, .journal-table .col-points input { text-align: right; font-variant-numeric: tabular-nums; }
 .score-grid { display: grid; gap: 10px; }
 .check-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
 .check-list label { margin: 0; font-weight: 500; display: flex; gap: 5px; align-items: center; }
@@ -116,6 +137,11 @@ th { background: #e8f2ee; position: sticky; top: 0; z-index: 1; }
   .main-grid { grid-template-columns: 1fr; }
   .sidebar { position: static; }
   .app-header { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 980px) {
+  .journal-table-wrap { overflow-x: auto; }
+  .journal-table { min-width: 922px; }
 }
 
 @media print {

--- a/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
@@ -1,10 +1,15 @@
 import type { AnswerState, ExamSetRecord, HistoryEntry, ProblemDefinition, StudyQueueItem } from '../types';
+import { formatAmount, isAmountColumn } from './numberFormat';
 import { draftSummary } from './scoring';
 
 function escapeCsv(value: unknown): string {
   const raw = value === null || value === undefined ? '' : value;
   const text = String(raw).replace(/"/g, '""');
   return `"${text}"`;
+}
+
+function formatAnswerCell(columnName: string, value: string): string {
+  return isAmountColumn(columnName) ? formatAmount(value) : value;
 }
 
 export function downloadText(filename: string, text: string, type = 'text/plain;charset=utf-8'): void {
@@ -29,7 +34,7 @@ export function currentAnswerCsvRows(answer: AnswerState, problem: ProblemDefini
     [],
     ['行番号', ...answer.columns, '採点', '行別得点'],
   ];
-  answer.rows.forEach((row, index) => rows.push([index + 1, ...row.cells, row.grade, row.points]));
+  answer.rows.forEach((row, index) => rows.push([index + 1, ...answer.columns.map((column, colIndex) => formatAnswerCell(column, row.cells[colIndex] ?? '')), row.grade, row.points]));
   return rows;
 }
 

--- a/cpa-boki2-trial-section-answer-manager/src/utils/numberFormat.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/numberFormat.ts
@@ -1,0 +1,49 @@
+const amountKeywords = ['金額', '残高', '売上高', '営業利益', '固定費', '変動費', '単価', '差異額', '小計', '合計', '入力値'];
+const scoreKeywords = ['行別得点', '問題得点', '得点', '満点'];
+const japaneseTextKeywords = ['借方科目', '貸方科目', '勘定科目', '項目名', '摘要', '処理区分', '部門名', '工程', '表区分', '差異区分'];
+
+export function toHalfWidthNumber(value: string): string {
+  return value
+    .replace(/[０-９]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+    .replace(/[，、]/g, ',')
+    .replace(/[－ー―]/g, '-')
+    .replace(/[￥円]/g, '');
+}
+
+export function normalizeNumericInput(value: string): string {
+  const half = toHalfWidthNumber(value);
+  const cleaned = half.replace(/[,$\s]/g, '');
+  if (cleaned === '' || /^-?\d*$/.test(cleaned)) return cleaned;
+  return half;
+}
+
+function addCommas(integerText: string): string {
+  const negative = integerText.startsWith('-');
+  const body = negative ? integerText.slice(1) : integerText;
+  if (!body) return integerText;
+  return `${negative ? '-' : ''}${body.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+}
+
+export function formatAmount(value: string): string {
+  const normalized = normalizeNumericInput(value);
+  if (normalized === '' || normalized === '-') return normalized;
+  if (/^-?\d+$/.test(normalized)) return addCommas(normalized);
+  return toHalfWidthNumber(value);
+}
+
+export function isAmountColumn(columnName: string): boolean {
+  const normalized = columnName.trim();
+  if (scoreKeywords.some((keyword) => normalized.includes(keyword))) return false;
+  return amountKeywords.some((keyword) => normalized.includes(keyword));
+}
+
+export function isJapaneseTextColumn(columnName: string): boolean {
+  const normalized = columnName.trim();
+  return japaneseTextKeywords.some((keyword) => normalized.includes(keyword));
+}
+
+export function isInvalidAmount(value: string): boolean {
+  if (!value) return false;
+  const normalized = normalizeNumericInput(value);
+  return normalized !== '' && !/^-?\d*$/.test(normalized);
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
@@ -1,3 +1,5 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
 type NavigableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
 function findCell(rowIndex: number, colIndex: number): NavigableElement | null {
@@ -20,7 +22,7 @@ export function focusCell(rowIndex: number, colIndex: number): void {
 }
 
 export function handleTableCellKeyDown(
-  event: React.KeyboardEvent<NavigableElement>,
+  event: ReactKeyboardEvent<NavigableElement>,
   rowIndex: number,
   colIndex: number,
 ): void {

--- a/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
@@ -1,0 +1,48 @@
+type NavigableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+
+function findCell(rowIndex: number, colIndex: number): NavigableElement | null {
+  return document.querySelector<NavigableElement>(`[data-answer-cell="true"][data-row-index="${rowIndex}"][data-col-index="${colIndex}"]`);
+}
+
+function isTextArea(target: EventTarget | null): target is HTMLTextAreaElement {
+  return target instanceof HTMLTextAreaElement;
+}
+
+function selectContent(element: NavigableElement): void {
+  if (element instanceof HTMLInputElement) element.select();
+}
+
+export function focusCell(rowIndex: number, colIndex: number): void {
+  const element = findCell(rowIndex, colIndex);
+  if (!element) return;
+  element.focus();
+  selectContent(element);
+}
+
+export function handleTableCellKeyDown(
+  event: React.KeyboardEvent<NavigableElement>,
+  rowIndex: number,
+  colIndex: number,
+): void {
+  const native = event.nativeEvent as KeyboardEvent;
+  if (event.isComposing || native.isComposing) return;
+
+  const key = event.key;
+  const textarea = isTextArea(event.target);
+  if (textarea && (key === 'ArrowLeft' || key === 'ArrowRight' || key === 'ArrowUp' || key === 'ArrowDown' || key === 'Enter')) return;
+
+  let nextRow = rowIndex;
+  let nextCol = colIndex;
+  if (key === 'ArrowRight') nextCol += 1;
+  else if (key === 'ArrowLeft') nextCol -= 1;
+  else if (key === 'ArrowDown' || (key === 'Enter' && !event.shiftKey)) nextRow += 1;
+  else if (key === 'ArrowUp' || (key === 'Enter' && event.shiftKey)) nextRow -= 1;
+  else return;
+
+  if (nextRow < 0 || nextCol < 0) return;
+  const target = findCell(nextRow, nextCol);
+  if (!target) return;
+  event.preventDefault();
+  target.focus();
+  selectContent(target);
+}


### PR DESCRIPTION
## 目的
公開済みのCPA日商簿記2級 試験対策編 解答・復習管理アプリについて、答案入力をExcelに近い速度で行えるよう、答案入力テーブルのUIだけを改善します。

対象アプリ:
- `cpa-boki2-trial-section-answer-manager/`

対象URL:
- `https://akashidaiki19910915-star.github.io/gyosei-app/cpa-boki2-trial-section-answer-manager/`

## 修正した内容
### 1. 仕訳テーブルの横スクロール削減
- 仕訳テーブルでは `table-layout: fixed` を使い、横スクロールなしで全体表示しやすい列幅に調整
- 以下の列幅を固定・圧縮
  - 行番号: 44px
  - 設問番号: 64px
  - 借方科目: 140px
  - 借方金額: 120px
  - 貸方科目: 140px
  - 貸方金額: 120px
  - メモ: 160px
  - 採点: 64px
  - 行別得点: 70px
- 通常幅では仕訳テーブルの横スクロールを抑制
- 狭い画面では中央テーブル内だけ横スクロールに戻す安全策を追加
- 右パネルが答案欄にかぶらない既存構成は維持

### 2. 金額欄の3桁カンマ表示
- `src/utils/numberFormat.ts` を追加
- 金額系列を判定し、入力・表示時に3桁カンマ表示
- `200000` → `200,000`
- `１００００００` → `1,000,000`
- `200,000` と入力しても内部では `200000` に正規化
- 円記号、スペース、カンマは正規化対象
- マイナス値に対応
- 数値以外の文字は壊さず残し、警告スタイルを付与
- `行別得点`、`問題得点`、`得点`、`満点` はカンマ処理対象外
- `type="number"` は使わず、`type="text"` を維持

### 3. キーボード移動対応
- `src/utils/tableNavigation.ts` を追加
- 各入力欄に `data-row-index` / `data-col-index` を付与
- 以下のキー移動を実装
  - ArrowRight: 右セルへ移動
  - ArrowLeft: 左セルへ移動
  - ArrowDown: 下の同じ列へ移動
  - ArrowUp: 上の同じ列へ移動
  - Enter: 下の同じ列へ移動
  - Shift + Enter: 上の同じ列へ移動
- `event.isComposing` / `nativeEvent.isComposing` を確認し、日本語変換中の暴発を防止
- メモ欄textareaでは矢印キー・Enterは通常入力を優先

### 4. 日本語入力・半角数字入力しやすい属性付与
- 勘定科目・項目名・摘要・処理区分などの文字列欄には以下を付与
  - `lang="ja"`
  - `inputMode="text"`
  - `autoComplete="off"`
  - `spellCheck={false}`
  - 日本語向けplaceholder
- 金額欄には以下を付与
  - `type="text"`
  - `inputMode="numeric"`
  - `pattern="[0-9,\\-]*"`
  - `autoComplete="off"`
  - `spellCheck={false}`
  - 金額向けplaceholder

## 変更ファイル一覧
- `cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx`
- `cpa-boki2-trial-section-answer-manager/src/styles.css`
- `cpa-boki2-trial-section-answer-manager/src/utils/csv.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/numberFormat.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts`

## 既存案件管理アプリへの影響有無
- 既存案件管理アプリ本体は変更していません。
- ルート `index.html`、`app.js`、`styles.css` は変更していません。
- 既存案件管理アプリURLは維持する前提です。

## Pages workflowへの影響有無
- `.github/workflows/` 配下は変更していません。
- Pages workflowは変更していません。

## 金額欄の3桁カンマ仕様
- 表示時は3桁カンマ付き
- 保存値はカンマ除去後の数値文字列を基本とする
- 既存保存データが `200000` の場合も表示時は `200,000`
- 全角数字は半角数字へ正規化
- `type="number"` は未使用
- 数値以外は壊さず残し、入力欄に警告スタイルを付与
- CSV出力でも答案テーブル内の金額列はカンマ整形して出力

## 矢印キー移動仕様
- input / select は矢印キーとEnterでセル移動
- textareaのメモ欄は通常のカーソル移動・改行を優先
- 日本語変換中は `isComposing` を見て移動しない
- 範囲外の移動は何もしない
- フォーカス時はinputのみ全選択

## 日本語入力・半角数字入力についての技術的制約
ブラウザからPCのIMEを完全に日本語ON／英数ONへ強制切替する実装はしていません。標準的に確実なのは、`inputMode` などの入力ヒントと、入力後の正規化です。そのため本PRでは、勘定科目欄は日本語入力しやすく、金額欄は半角数字入力しやすくし、入力値を正規化する方針にしています。

## 動作確認結果
この環境ではローカルの `npm install` / `npm run build` は実行できません。PR作成後、GitHub Actions / Pages buildで確認してください。

コード上で確認した項目:
- 仕訳テーブルの列幅固定
- 金額欄の3桁カンマ表示
- 全角数字から半角数字への正規化
- カンマ付き金額の正規化
- `type="number"` 未使用
- `inputMode="numeric"` 付与
- `lang="ja"` / `inputMode="text"` 付与
- Arrow / Enter / Shift+Enter のセル移動実装
- 日本語変換中の暴発防止
- メモ欄textareaの通常入力優先
- CSV出力時の金額列カンマ整形

## 未確認事項
- GitHub Pages公開後の実画面確認
- 実ブラウザでのIME変換中挙動
- 画面幅ごとの仕訳テーブル横スクロール有無
- スマホ・タブレットでの入力キーボード挙動

## 著作権対応
以下は追加していません。
- CPA教材の問題文
- CPA教材の解答
- CPA教材の解説
- CPAロゴ
- 教材画像
- 日本商工会議所の問題文・サンプル問題

## 禁止事項への対応
- 既存案件管理アプリは変更していません
- Pages workflowは変更していません
- 自動採点は追加していません
- AI解説は追加していません
- Supabase同期・ログイン機能は追加していません
- 弁理士モード・建設業経理士2級モードは追加していません
- `会社名・立場` 列は復活させていません