### PR TITLE
Fix CPA boki2 table navigation TypeScript build error

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
@@ -27,7 +27,7 @@ export function handleTableCellKeyDown(
   colIndex: number,
 ): void {
   const native = event.nativeEvent as KeyboardEvent;
-  if (event.isComposing || native.isComposing) return;
+  if (native.isComposing) return;
 
   const key = event.key;
   const textarea = isTextArea(event.target);


### PR DESCRIPTION
## 目的
PR #232 マージ後の GitHub Pages build 失敗を修正します。

対象アプリ:
- `cpa-boki2-trial-section-answer-manager/`

## 1. build失敗原因
`src/utils/tableNavigation.ts` で React の `KeyboardEvent<NavigableElement>` に対して `event.isComposing` を直接参照していたため、TypeScript build が失敗していました。

該当箇所:
```ts
const native = event.nativeEvent as KeyboardEvent;
if (event.isComposing || native.isComposing) return;
```

React のSyntheticEventではブラウザのネイティブイベントへ `nativeEvent` からアクセスでき、`isComposing` はネイティブの `KeyboardEvent` 側で扱うのが安全です。

## 2. 修正内容
`event.isComposing` の直接参照を削除し、`nativeEvent` 側のみを参照するように変更しました。

修正後:
```ts
const native = event.nativeEvent as KeyboardEvent;
if (native.isComposing) return;
```

変更ファイル:
- `cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts`

差分は1行のみです。

## 3. 日本語変換中の暴発防止
日本語変換中の矢印キー移動暴発防止は維持しています。

- `native.isComposing` が true の場合はセル移動処理を中断
- Arrow / Enter / Shift+Enter のセル移動機能は維持
- textareaメモ欄の通常入力優先も維持

## 4. 既存案件管理アプリへの影響なし
既存案件管理アプリ本体は変更していません。

変更していないもの:
- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体の `src/`

## 5. Pages workflowへの影響なし
`.github/workflows/` 配下は変更していません。
Pages workflowは変更していません。

## 6. 動作確認結果
この環境ではローカルの `npm run build` は実行できませんでした。

コード上で確認した項目:
- `event.isComposing` の直接参照を削除
- `native.isComposing` による日本語変換中判定を維持
- 矢印キー移動ロジックは変更なし
- textareaメモ欄の通常入力優先は変更なし
- 金額欄の3桁カンマ処理は変更なし
- 仕訳テーブルの列幅修正は変更なし
- 問題文・解答・解説・CPAロゴ・教材画像は追加していません

PR作成後、GitHub Actions / Pages buildで最終確認してください。