### PR TITLE
Fix CPA boki2 answer cell edit mode navigation

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { HTMLAttributes, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type { FocusEvent as ReactFocusEvent, HTMLAttributes, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { AnswerRow, AnswerState, GradeMark, TemplateDefinition } from '../types';
 import { formatAmount, isAmountColumn, isInvalidAmount, isJapaneseTextColumn, normalizeNumericInput, toHalfWidthNumber } from '../utils/numberFormat';
 import { handleTableCellKeyDown } from '../utils/tableNavigation';
@@ -54,7 +54,7 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
   const enterEditMode = (rowIndex: number, colIndex: number) => setEditingCell({ rowIndex, colIndex });
   const exitEditMode = () => setEditingCell(null);
 
-  const selectOnMoveFocus = (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>, rowIndex: number, colIndex: number) => {
+  const selectOnMoveFocus = (event: ReactFocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>, rowIndex: number, colIndex: number) => {
     if (isEditing(rowIndex, colIndex)) return;
     if (event.currentTarget instanceof HTMLInputElement) event.currentTarget.select();
   };
@@ -133,7 +133,7 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
       'data-row-index': rowIndex,
       'data-col-index': colIndex,
       'data-edit-mode': editing ? 'true' : 'false',
-      onFocus: (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => selectOnMoveFocus(event, rowIndex, colIndex),
+      onFocus: (event: ReactFocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => selectOnMoveFocus(event, rowIndex, colIndex),
       onDoubleClick: () => enterEditMode(rowIndex, colIndex),
       onKeyDown: (event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex, keyDownOptions(rowIndex, colIndex)),
     };

--- a/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx
@@ -1,9 +1,15 @@
+import { useState } from 'react';
 import type { HTMLAttributes, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { AnswerRow, AnswerState, GradeMark, TemplateDefinition } from '../types';
 import { formatAmount, isAmountColumn, isInvalidAmount, isJapaneseTextColumn, normalizeNumericInput, toHalfWidthNumber } from '../utils/numberFormat';
 import { handleTableCellKeyDown } from '../utils/tableNavigation';
 
 const gradeOptions: GradeMark[] = ['未採点', '○', '△', '×'];
+
+type EditingCell = {
+  rowIndex: number;
+  colIndex: number;
+} | null;
 
 interface Props {
   answer: AnswerState;
@@ -42,6 +48,17 @@ function placeholderFor(column: string): string {
 }
 
 export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Props) {
+  const [editingCell, setEditingCell] = useState<EditingCell>(null);
+
+  const isEditing = (rowIndex: number, colIndex: number) => editingCell?.rowIndex === rowIndex && editingCell.colIndex === colIndex;
+  const enterEditMode = (rowIndex: number, colIndex: number) => setEditingCell({ rowIndex, colIndex });
+  const exitEditMode = () => setEditingCell(null);
+
+  const selectOnMoveFocus = (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>, rowIndex: number, colIndex: number) => {
+    if (isEditing(rowIndex, colIndex)) return;
+    if (event.currentTarget instanceof HTMLInputElement) event.currentTarget.select();
+  };
+
   const updateHeader = (index: number, value: string) => {
     const columns = [...answer.columns];
     columns[index] = value;
@@ -100,21 +117,32 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
     onChange({ ...answer, rows: rows.length ? rows : createRows(answer.columns.length, 1) });
   };
 
+  const keyDownOptions = (rowIndex: number, colIndex: number) => ({
+    isEditing: isEditing(rowIndex, colIndex),
+    enterEditMode: () => enterEditMode(rowIndex, colIndex),
+    exitEditMode,
+  });
+
   const renderCellInput = (row: AnswerRow, rowIndex: number, column: string, colIndex: number) => {
     const value = row.cells[colIndex] ?? '';
     const amount = isAmountColumn(column);
     const invalidAmount = amount && isInvalidAmount(value);
+    const editing = isEditing(rowIndex, colIndex);
     const commonProps = {
       'data-answer-cell': 'true',
       'data-row-index': rowIndex,
       'data-col-index': colIndex,
-      onKeyDown: (event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex),
+      'data-edit-mode': editing ? 'true' : 'false',
+      onFocus: (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => selectOnMoveFocus(event, rowIndex, colIndex),
+      onDoubleClick: () => enterEditMode(rowIndex, colIndex),
+      onKeyDown: (event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => handleTableCellKeyDown(event, rowIndex, colIndex, keyDownOptions(rowIndex, colIndex)),
     };
 
     if (template.optionColumns?.[column]) {
       return (
         <select
           {...commonProps}
+          className={editing ? 'cell-editing' : ''}
           value={value}
           onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}
           aria-label={`${column} ${rowIndex + 1}行目`}
@@ -129,7 +157,7 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
       return (
         <textarea
           {...commonProps}
-          className="memo-cell-input"
+          className={`memo-cell-input ${editing ? 'cell-editing' : ''}`}
           value={value}
           title={value}
           onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}
@@ -145,7 +173,7 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
     return (
       <input
         {...commonProps}
-        className={invalidAmount ? 'invalid-amount' : ''}
+        className={`${invalidAmount ? 'invalid-amount' : ''} ${editing ? 'cell-editing' : ''}`.trim()}
         type="text"
         value={amount ? formatAmount(value) : value}
         title={value}
@@ -204,9 +232,13 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
                     data-answer-cell="true"
                     data-row-index={rowIndex}
                     data-col-index={answer.columns.length}
+                    data-edit-mode={isEditing(rowIndex, answer.columns.length) ? 'true' : 'false'}
+                    className={isEditing(rowIndex, answer.columns.length) ? 'cell-editing' : ''}
                     value={row.grade}
+                    onFocus={(event) => selectOnMoveFocus(event, rowIndex, answer.columns.length)}
+                    onDoubleClick={() => enterEditMode(rowIndex, answer.columns.length)}
                     onChange={(event) => updateGrade(rowIndex, event.target.value as GradeMark)}
-                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length)}
+                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length, keyDownOptions(rowIndex, answer.columns.length))}
                     aria-label={`採点 ${rowIndex + 1}行目`}
                   >
                     {gradeOptions.map((grade) => <option key={grade} value={grade}>{grade}</option>)}
@@ -217,12 +249,16 @@ export function AnswerTable({ answer, template, onChange, onApplyRowPoints }: Pr
                     data-answer-cell="true"
                     data-row-index={rowIndex}
                     data-col-index={answer.columns.length + 1}
+                    data-edit-mode={isEditing(rowIndex, answer.columns.length + 1) ? 'true' : 'false'}
+                    className={isEditing(rowIndex, answer.columns.length + 1) ? 'cell-editing' : ''}
                     type="text"
                     inputMode="numeric"
                     pattern="[0-9,\\-]*"
                     value={String(row.points)}
+                    onFocus={(event) => selectOnMoveFocus(event, rowIndex, answer.columns.length + 1)}
+                    onDoubleClick={() => enterEditMode(rowIndex, answer.columns.length + 1)}
                     onChange={(event) => updatePoints(rowIndex, Number(normalizeNumericInput(event.target.value) || 0))}
-                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length + 1)}
+                    onKeyDown={(event) => handleTableCellKeyDown(event, rowIndex, answer.columns.length + 1, keyDownOptions(rowIndex, answer.columns.length + 1))}
                     autoComplete="off"
                     spellCheck={false}
                     aria-label={`行別得点 ${rowIndex + 1}行目`}

--- a/cpa-boki2-trial-section-answer-manager/src/styles.css
+++ b/cpa-boki2-trial-section-answer-manager/src/styles.css
@@ -62,6 +62,7 @@ th { background: #e8f2ee; position: sticky; top: 0; z-index: 1; }
 .answer-table input, .answer-table select, .answer-table textarea { width: 100%; min-width: 0; box-sizing: border-box; font-size: 14px; padding: 6px 8px; }
 .answer-table th input { font-weight: 700; background: #f7fbf9; }
 .answer-table input:focus, .answer-table select:focus, .answer-table textarea:focus { outline: 2px solid #7bbda6; outline-offset: 1px; }
+.answer-table .cell-editing { outline: 2px solid #d79b22 !important; background: #fffdf2; }
 .memo-cell-input { min-height: 34px; max-height: 70px; resize: vertical; line-height: 1.35; }
 .invalid-amount { border-color: #d65844 !important; background: #fff4f1; }
 .answer-table .col-row-number, .answer-table col.col-row-number { width: 44px; }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts
@@ -2,6 +2,12 @@ import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 type NavigableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
+interface TableNavigationOptions {
+  isEditing: boolean;
+  enterEditMode: () => void;
+  exitEditMode: () => void;
+}
+
 function findCell(rowIndex: number, colIndex: number): NavigableElement | null {
   return document.querySelector<NavigableElement>(`[data-answer-cell="true"][data-row-index="${rowIndex}"][data-col-index="${colIndex}"]`);
 }
@@ -14,24 +20,55 @@ function selectContent(element: NavigableElement): void {
   if (element instanceof HTMLInputElement) element.select();
 }
 
-export function focusCell(rowIndex: number, colIndex: number): void {
+export function focusCell(rowIndex: number, colIndex: number, select = true): void {
   const element = findCell(rowIndex, colIndex);
   if (!element) return;
   element.focus();
-  selectContent(element);
+  if (select) selectContent(element);
+}
+
+function moveToCell(rowIndex: number, colIndex: number, options: TableNavigationOptions): void {
+  if (rowIndex < 0 || colIndex < 0) return;
+  const target = findCell(rowIndex, colIndex);
+  if (!target) return;
+  options.exitEditMode();
+  target.focus();
+  selectContent(target);
 }
 
 export function handleTableCellKeyDown(
   event: ReactKeyboardEvent<NavigableElement>,
   rowIndex: number,
   colIndex: number,
+  options: TableNavigationOptions,
 ): void {
   const native = event.nativeEvent as KeyboardEvent;
   if (native.isComposing) return;
 
   const key = event.key;
   const textarea = isTextArea(event.target);
-  if (textarea && (key === 'ArrowLeft' || key === 'ArrowRight' || key === 'ArrowUp' || key === 'ArrowDown' || key === 'Enter')) return;
+
+  if (key === 'F2') {
+    event.preventDefault();
+    options.enterEditMode();
+    return;
+  }
+
+  if (key === 'Escape') {
+    if (options.isEditing) event.preventDefault();
+    options.exitEditMode();
+    return;
+  }
+
+  if (options.isEditing) {
+    if (textarea && key === 'Enter' && (event.altKey || event.ctrlKey)) return;
+    if (key.startsWith('Arrow') || key === 'Home' || key === 'End') return;
+    if (key === 'Enter') {
+      event.preventDefault();
+      moveToCell(event.shiftKey ? rowIndex - 1 : rowIndex + 1, colIndex, options);
+    }
+    return;
+  }
 
   let nextRow = rowIndex;
   let nextCol = colIndex;
@@ -41,10 +78,6 @@ export function handleTableCellKeyDown(
   else if (key === 'ArrowUp' || (key === 'Enter' && event.shiftKey)) nextRow -= 1;
   else return;
 
-  if (nextRow < 0 || nextCol < 0) return;
-  const target = findCell(nextRow, nextCol);
-  if (!target) return;
   event.preventDefault();
-  target.focus();
-  selectContent(target);
+  moveToCell(nextRow, nextCol, options);
 }


### PR DESCRIPTION
## 目的
CPA日商簿記2級 試験対策編 解答・復習管理アプリの答案入力テーブルについて、Excelに近い操作感に近づけるため、セル移動モードとセル内編集モードを分離します。

対象アプリ:
- `cpa-boki2-trial-section-answer-manager/`

## 1. 問題点
- 入力欄内で `ArrowLeft` / `ArrowRight` を押しても文字カーソル移動ができず、隣のセルへ移動していました。
- メモ欄 `textarea` では、矢印キーやEnterによるセル移動が止まっていました。
- セル移動とセル内編集の切り替えがなく、Excel的な操作感になっていませんでした。

## 2. 原因
- `ArrowLeft` / `ArrowRight` / `ArrowUp` / `ArrowDown` / `Enter` を常にセル移動として処理していました。
- `textarea` では矢印キー・Enterを一律returnしていたため、通常時のセル移動も編集時の使い分けもできませんでした。

## 3. 修正内容
### セル移動モードとセル内編集モードを分離
- 通常状態はセル移動モード
- ダブルクリックまたは `F2` でセル内編集モード
- `Esc` で編集モード解除
- セル移動時はinputの内容を全選択
- 編集モード中は入力欄内のカーソル移動を優先

### セル移動モード
- `ArrowRight`: 右セルへ移動
- `ArrowLeft`: 左セルへ移動
- `ArrowDown`: 下の同じ列へ移動
- `ArrowUp`: 上の同じ列へ移動
- `Enter`: 下の同じ列へ移動
- `Shift + Enter`: 上の同じ列へ移動
- メモ欄textareaも通常時は同じセル移動を実行

### セル内編集モード
- `ArrowLeft` / `ArrowRight`: 入力欄内の文字カーソル移動
- `ArrowUp` / `ArrowDown`: 入力欄内の標準カーソル移動
- `Home` / `End`: ブラウザ標準の行頭・行末移動
- `Ctrl + ArrowLeft` / `Ctrl + ArrowRight`: ブラウザ標準の単語移動
- `Enter`: 編集確定して下の同じ列へ移動
- `Shift + Enter`: 編集確定して上の同じ列へ移動
- `textarea` の `Alt + Enter` / `Ctrl + Enter`: 改行を許可

## 4. 維持した内容
- `native.isComposing` による日本語変換中の暴発防止
- 金額欄3桁カンマ処理
- 全角数字から半角数字への正規化
- 仕訳テーブルの列幅修正
- 横スクロール削減
- 右パネルが答案欄にかぶらない状態
- 行追加
- 列追加
- 空行整理
- 行別得点合計を問題得点へ反映
- JSONバックアップ・復元
- CSV出力
- 記入例・使い方
- 今日の学習キュー
- 成績ダッシュボード
- 90分セット演習

## 5. 変更ファイル
- `cpa-boki2-trial-section-answer-manager/src/components/AnswerTable.tsx`
- `cpa-boki2-trial-section-answer-manager/src/utils/tableNavigation.ts`
- `cpa-boki2-trial-section-answer-manager/src/styles.css`

## 6. 既存案件管理アプリへの影響なし
既存案件管理アプリ本体は変更していません。

変更していないもの:
- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体の `src/`

## 7. Pages workflowへの影響なし
`.github/workflows/` 配下は変更していません。
Pages workflowは変更していません。

## 8. 著作権対応
以下は追加していません。
- CPA教材の問題文
- CPA教材の解答
- CPA教材の解説
- CPAロゴ
- 教材画像
- 日本商工会議所の問題文・サンプル問題

## 9. 動作確認結果
この環境ではローカルの `npm run build` は実行できていません。

コード上で確認した項目:
- `native.isComposing` 判定を維持
- 通常時のArrow / Enterセル移動を維持
- F2で編集モードに入る処理を追加
- ダブルクリックで編集モードに入る処理を追加
- 編集モード中のArrow / Home / Endはブラウザ標準に委ねる
- 編集モード中のEnter / Shift+Enterで上下移動
- Escで編集モード解除
- textarea通常時はセル移動、編集時は内部カーソル移動と改行を許可
- 金額欄カンマ処理は変更なし
- 仕訳テーブルの `会社名・立場` 列は復活していません

PR作成後、GitHub Actions / Pages buildおよび実画面で最終確認してください。