### PR TITLE
Add CPA boki2 mastery map and mistake recovery flow

### DIFF
--- a/.github/workflows/cpa-boki2-check.yml
+++ b/.github/workflows/cpa-boki2-check.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: cpa-boki2-trial-section-answer-manager/package-lock.json
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/cpa-boki2-check.yml
+++ b/.github/workflows/cpa-boki2-check.yml
@@ -1,0 +1,34 @@
+name: CPA Boki2 App Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'cpa-boki2-trial-section-answer-manager/**'
+      - '.github/workflows/cpa-boki2-check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'cpa-boki2-trial-section-answer-manager/**'
+      - '.github/workflows/cpa-boki2-check.yml'
+  workflow_dispatch:
+
+jobs:
+  build-cpa-boki2:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cpa-boki2-trial-section-answer-manager
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cpa-boki2-trial-section-answer-manager/package-lock.json
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build

--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -5,17 +5,22 @@ import { DashboardPanel } from './components/DashboardPanel';
 import { ExamSetPanel } from './components/ExamSetPanel';
 import { ExampleGuide } from './components/ExampleGuide';
 import { HistoryPanel } from './components/HistoryPanel';
+import { MasteryMapPanel } from './components/MasteryMapPanel';
+import { MistakeCardPanel } from './components/MistakeCardPanel';
 import { ProblemSelector } from './components/ProblemSelector';
+import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
 import { ScoringPanel } from './components/ScoringPanel';
 import { StudyQueuePanel } from './components/StudyQueuePanel';
 import { Timer } from './components/Timer';
 import { getProblemById, problemCatalog } from './data/problemCatalog';
 import { getTemplateById } from './data/templateCatalog';
-import { addHistory, clearHistories, deleteHistory, exportAllData, getAllAnswers, getAnswer, getBackupMetadata, getExamSets, getHistories, importAllData, recordBackupMade, saveAnswer, saveExamSet } from './storage/indexedDb';
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, StorageSafetyInfo, TemplateId } from './types';
-import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, missReasonCsvRows, problemStatsCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
+import { addHistory, clearHistories, deleteHistory, deleteMistakeCard, exportAllData, getAllAnswers, getAnswer, getBackupMetadata, getExamSets, getHistories, getMistakeCards, importAllData, recordBackupMade, saveAnswer, saveExamSet, saveMistakeCard } from './storage/indexedDb';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MistakeCard, StorageSafetyInfo, TemplateId } from './types';
+import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, masteryMapCsvRows, missReasonCsvRows, mistakeCardCsvRows, problemStatsCsvRows, recoveryPlanCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
 import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
+import { buildMasteryMap } from './utils/mastery';
+import { buildRecoveryPlan } from './utils/recovery';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
 import { getStorageSafetyInfo } from './utils/storageSafety';
 import { buildStudyQueue } from './utils/studyQueue';
@@ -107,6 +112,7 @@ export default function App() {
   const [answers, setAnswers] = useState<AnswerState[]>([]);
   const [histories, setHistories] = useState<HistoryEntry[]>([]);
   const [examSets, setExamSets] = useState<ExamSetRecord[]>([]);
+  const [mistakeCards, setMistakeCards] = useState<MistakeCard[]>([]);
   const [, setBackupMeta] = useState<BackupMetadata | null>(null);
   const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
@@ -115,6 +121,8 @@ export default function App() {
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
+  const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
+  const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
 
   async function refreshAnswers() {
     setAnswers((await getAllAnswers()).map(normalizeAnswer));
@@ -128,6 +136,10 @@ export default function App() {
     setExamSets(await getExamSets());
   }
 
+  async function loadMistakeCards() {
+    setMistakeCards(await getMistakeCards());
+  }
+
   async function refreshSafety() {
     const [historyRows, answerRows, meta] = await Promise.all([getHistories(), getAllAnswers(), getBackupMetadata()]);
     setBackupMeta(meta);
@@ -135,7 +147,7 @@ export default function App() {
   }
 
   async function refreshAll() {
-    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), refreshSafety()]);
+    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), loadMistakeCards(), refreshSafety()]);
   }
 
   async function loadProblem(nextProblemId: string) {
@@ -248,6 +260,19 @@ export default function App() {
     setMessage('履歴を全削除しました');
   };
 
+  const saveCard = async (card: MistakeCard) => {
+    await saveMistakeCard(card);
+    await loadMistakeCards();
+    setMessage('白紙再現・解き直しカードを保存しました');
+  };
+
+  const removeCard = async (id: string) => {
+    if (!window.confirm('この解き直しカードを削除しますか？')) return;
+    await deleteMistakeCard(id);
+    await loadMistakeCards();
+    setMessage('白紙再現・解き直しカードを削除しました');
+  };
+
   const exportCurrentCsv = () => downloadCsv('current-answer.csv', currentAnswerCsvRows(answer, problem));
   const exportHistoryCsv = () => downloadCsv('history.csv', historyCsvRows(histories));
   const exportReviewCsv = () => downloadCsv('review-targets.csv', reviewTargetCsvRows(histories.filter((history) => isDueTodayOrEarlier(history.nextReviewDate))));
@@ -256,6 +281,9 @@ export default function App() {
   const exportStudyQueueCsv = () => downloadCsv('study-queue.csv', studyQueueCsvRows(studyQueue));
   const exportDashboardCsv = () => downloadCsv('dashboard.csv', dashboardCsvRows(histories));
   const exportExamSetCsv = () => downloadCsv('exam-sets.csv', examSetCsvRows(examSets));
+  const exportMasteryCsv = () => downloadCsv('mastery-map.csv', masteryMapCsvRows(masteryMap));
+  const exportMistakeCardsCsv = () => downloadCsv('mistake-cards.csv', mistakeCardCsvRows(mistakeCards, getProblemById));
+  const exportRecoveryCsv = () => downloadCsv('recovery-plan.csv', recoveryPlanCsvRows(recoveryPlan));
 
   const exportJson = async () => {
     const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]);
@@ -334,6 +362,8 @@ export default function App() {
 
       <section className="management-stack">
         <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
+        <MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} />
+        <RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} />
         <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
         <DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} />
         <ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} />
@@ -348,6 +378,7 @@ export default function App() {
             <p><strong>{problem.topic}</strong></p>
             <p>使用テンプレート：{answer.templateName}</p>
           </section>
+          <MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} />
           <ExampleGuide template={template} />
           <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
           <HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} />

--- a/cpa-boki2-trial-section-answer-manager/src/components/MasteryMapPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MasteryMapPanel.tsx
@@ -1,0 +1,77 @@
+import { useMemo, useState } from 'react';
+import type { HistoryEntry, MasteryFilter } from '../types';
+import { formatDateTime } from '../utils/dates';
+import { buildMasteryMap, filterMasteryMap } from '../utils/mastery';
+
+interface Props {
+  histories: HistoryEntry[];
+  onOpenProblem: (problemId: string) => void;
+  onExportCsv: () => void;
+}
+
+const filters: MasteryFilter[] = ['全体', '未着手', '危険問題', '期限超過', 'C判定', 'B判定', '合格水準', '商業簿記', '工業簿記', '第1問対策', '第2問対策', '第3問対策', '第4問対策', '第5問対策'];
+
+function subjectLabel(value: string): string {
+  return value === 'commercial' ? '商業簿記' : '工業簿記';
+}
+
+export function MasteryMapPanel({ histories, onOpenProblem, onExportCsv }: Props) {
+  const [filter, setFilter] = useState<MasteryFilter>('危険問題');
+  const items = useMemo(() => buildMasteryMap(histories), [histories]);
+  const visible = useMemo(() => filterMasteryMap(items, filter), [filter, items]);
+  const counts = {
+    total: items.length,
+    untouched: items.filter((item) => item.status === '未着手').length,
+    dangerous: items.filter((item) => item.status === '危険問題' || item.status === '再復習対象' || item.status === '期限超過' || item.attempts === 0).length,
+    mastered: items.filter((item) => item.status === '合格水準').length,
+    overdue: items.filter((item) => item.status === '期限超過').length,
+  };
+
+  return (
+    <details className="management-panel" open>
+      <summary>合格到達マップ</summary>
+      <div className="panel-body">
+        <div className="metric-grid">
+          <div><span>全問題ID</span><strong>{counts.total}</strong></div>
+          <div><span>未着手</span><strong>{counts.untouched}</strong></div>
+          <div><span>危険・再復習</span><strong>{counts.dangerous}</strong></div>
+          <div><span>期限超過</span><strong>{counts.overdue}</strong></div>
+          <div><span>合格水準</span><strong>{counts.mastered}</strong></div>
+        </div>
+        <div className="button-row">
+          {filters.map((item) => <button key={item} className={filter === item ? 'accent' : 'secondary'} onClick={() => setFilter(item)}>{item}</button>)}
+          <button onClick={onExportCsv}>合格到達マップCSV</button>
+        </div>
+        <div className="table-wrap compact-wrap">
+          <table className="compact-table">
+            <thead>
+              <tr>
+                <th>状態</th><th>問題ID</th><th>科目</th><th>大問</th><th>論点</th><th>最新得点</th><th>得点率</th><th>判定</th><th>回数</th><th>A/B/C</th><th>最終演習</th><th>次回復習</th><th>推奨アクション</th><th>開始</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((item) => (
+                <tr key={item.problem.id}>
+                  <td><span className={`status-badge status-${item.status}`}>{item.status}</span></td>
+                  <td>{item.problem.displayId}</td>
+                  <td>{subjectLabel(item.problem.subject)}</td>
+                  <td>{item.problem.sectionLabel}</td>
+                  <td>{item.problem.topic}</td>
+                  <td>{item.latestScore ?? '未'}/{item.maxScore ?? '-'}</td>
+                  <td>{item.scoreRate === null ? '-' : `${item.scoreRate}%`}</td>
+                  <td>{item.latestRank || '-'}</td>
+                  <td>{item.attempts}</td>
+                  <td>{item.aCount}/{item.bCount}/{item.cCount}</td>
+                  <td>{formatDateTime(item.lastPracticedAt) || '-'}</td>
+                  <td>{item.nextReviewDate || '-'}</td>
+                  <td>{item.action}</td>
+                  <td><button onClick={() => onOpenProblem(item.problem.id)}>開く</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/MistakeCardPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MistakeCardPanel.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { AnswerState, MissReason, MistakeCard, ProblemDefinition } from '../types';
+import { formatDateTime, nowIso } from '../utils/dates';
+
+interface Props {
+  problem: ProblemDefinition;
+  answer: AnswerState;
+  cards: MistakeCard[];
+  onSave: (card: MistakeCard) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  onExportCsv: () => void;
+}
+
+const missReasonOptions: MissReason[] = ['論点理解不足', '仕訳ミス', '借方貸方逆', '金額ミス', '集計ミス', '転記ミス', '表の入力位置ミス', '下書き不足', '時間不足', '解答欄形式の誤認', '問題文読み落とし', 'その他'];
+
+function emptyCard(problemId: string): MistakeCard {
+  const now = nowIso();
+  return {
+    id: crypto.randomUUID(),
+    problemId,
+    correctFlow: '',
+    mistakeReason: '',
+    firstReviewPoint: '',
+    preSolveChecklist: '',
+    preventionPhrase: '',
+    missReasons: [],
+    importance: '中',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function MistakeCardPanel({ problem, answer, cards, onSave, onDelete, onExportCsv }: Props) {
+  const problemCards = useMemo(() => cards.filter((card) => card.problemId === problem.id).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)), [cards, problem.id]);
+  const latest = problemCards[0];
+  const needsCard = answer.rank === 'C' || (answer.maxScore > 0 && answer.score / answer.maxScore < 0.7);
+  const [draft, setDraft] = useState<MistakeCard>(() => latest ?? emptyCard(problem.id));
+
+  useEffect(() => {
+    setDraft(latest ?? emptyCard(problem.id));
+  }, [latest, problem.id]);
+
+  const update = (patch: Partial<MistakeCard>) => setDraft((current) => ({ ...current, ...patch, updatedAt: nowIso() }));
+  const toggleReason = (reason: MissReason) => {
+    const exists = draft.missReasons.includes(reason);
+    update({ missReasons: exists ? draft.missReasons.filter((item) => item !== reason) : [...draft.missReasons, reason] });
+  };
+
+  const save = async () => {
+    await onSave({ ...draft, problemId: problem.id, updatedAt: nowIso() });
+  };
+
+  const startNew = () => setDraft(emptyCard(problem.id));
+  const editCard = (card: MistakeCard) => setDraft(card);
+
+  return (
+    <details className="management-panel recovery-card-panel" open>
+      <summary>白紙再現・解き直しカード</summary>
+      <div className="panel-body">
+        <p className="notice-small">問題文・解答・解説をそのまま保存しないでください。ここには、自分の言葉で「処理手順」「ミス原因」「次回の注意点」だけを書いてください。</p>
+        {needsCard && problemCards.length === 0 && <p className="warning-text">C判定または70%未満です。次回同じミスを防ぐため、白紙再現・解き直しカードを作成してください。</p>}
+        {latest && (
+          <div className="priority-card">
+            <span className="status-badge">最新カード</span>
+            <h3>{latest.preventionPhrase || '同じミスを防ぐ一言は未入力'}</h3>
+            <p><strong>次回最初に見る注意点：</strong>{latest.firstReviewPoint || '未入力'}</p>
+            <p><strong>更新：</strong>{formatDateTime(latest.updatedAt)}</p>
+          </div>
+        )}
+        <div className="form-grid two-columns">
+          <label>重要度
+            <select value={draft.importance} onChange={(event) => update({ importance: event.target.value as MistakeCard['importance'] })}>
+              <option value="高">高</option><option value="中">中</option><option value="低">低</option>
+            </select>
+          </label>
+          <label>同じミスを防ぐ一言
+            <input value={draft.preventionPhrase} onChange={(event) => update({ preventionPhrase: event.target.value })} placeholder="例：金額を入れる前に、処理時点を確認する。" />
+          </label>
+        </div>
+        <label>正しい処理の流れ
+          <textarea value={draft.correctFlow} onChange={(event) => update({ correctFlow: event.target.value })} placeholder="例：売上原価を計算してから、期末商品の処理、貸倒引当金、減価償却の順に確認する。" />
+        </label>
+        <label>なぜ間違えたか
+          <textarea value={draft.mistakeReason} onChange={(event) => update({ mistakeReason: event.target.value })} placeholder="例：問題文の「期末に一括処理」という条件を読み落とした。" />
+        </label>
+        <label>次回最初に見る注意点
+          <textarea value={draft.firstReviewPoint} onChange={(event) => update({ firstReviewPoint: event.target.value })} placeholder="例：処理条件、日付、期末整理か期中処理かを先に見る。" />
+        </label>
+        <label>次回は何を確認してから解くか
+          <textarea value={draft.preSolveChecklist} onChange={(event) => update({ preSolveChecklist: event.target.value })} placeholder="例：設問の時点、処理対象、資料の使い分けを最初に確認する。" />
+        </label>
+        <div>
+          <strong>関連するミス原因</strong>
+          <div className="check-list wide">
+            {missReasonOptions.map((reason) => <label key={reason}><input type="checkbox" checked={draft.missReasons.includes(reason)} onChange={() => toggleReason(reason)} />{reason}</label>)}
+          </div>
+        </div>
+        <div className="button-row">
+          <button className="accent" onClick={save}>カード保存</button>
+          <button className="secondary" onClick={startNew}>新規カード</button>
+          <button onClick={onExportCsv}>解き直しカードCSV</button>
+        </div>
+        <div className="table-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>重要度</th><th>更新日</th><th>一言</th><th>注意点</th><th>操作</th></tr></thead>
+            <tbody>
+              {problemCards.map((card) => (
+                <tr key={card.id}>
+                  <td>{card.importance}</td><td>{formatDateTime(card.updatedAt)}</td><td>{card.preventionPhrase}</td><td>{card.firstReviewPoint}</td>
+                  <td><button onClick={() => editCard(card)}>編集</button> <button className="danger" onClick={() => onDelete(card.id)}>削除</button></td>
+                </tr>
+              ))}
+              {problemCards.length === 0 && <tr><td colSpan={5}>この問題IDの解き直しカードは未作成です。</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/RecoveryPlanPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/RecoveryPlanPanel.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import type { ExamSetRecord, HistoryEntry } from '../types';
+import { buildRecoveryPlan } from '../utils/recovery';
+
+interface Props {
+  histories: HistoryEntry[];
+  examSets: ExamSetRecord[];
+  onExportCsv: () => void;
+}
+
+export function RecoveryPlanPanel({ histories, examSets, onExportCsv }: Props) {
+  const plan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
+  return (
+    <details className="management-panel" open>
+      <summary>70点突破リカバリー表</summary>
+      <div className="panel-body">
+        <div className="result-card">
+          <strong>{plan.totalScore}/{plan.maxScore}点</strong>
+          <span>判定元：{plan.source}</span>
+          <span>70点まであと {plan.shortage70}点</span>
+          <span>72点まであと {plan.shortage72}点</span>
+          <span>80点まであと {plan.shortage80}点</span>
+        </div>
+        <div className="metric-grid">
+          <div><span>最も失点が大きい大問</span><strong>{plan.biggestLossSection}</strong></div>
+          <div><span>最も多いミス原因</span><strong>{plan.mostFrequentMissReason}</strong></div>
+          <div><span>次回の重点対策</span><strong>{plan.nextFocus}</strong></div>
+          <div><span>取り戻し候補</span><strong>{plan.recoveryCandidates.join(' / ') || 'データ不足'}</strong></div>
+        </div>
+        <div className="button-row"><button onClick={onExportCsv}>70点突破リカバリーCSV</button></div>
+        <div className="table-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>大問</th><th>得点</th><th>満点</th><th>失点</th><th>対策優先度</th></tr></thead>
+            <tbody>
+              {plan.sectionRows.map((row) => (
+                <tr key={row.sectionId}>
+                  <td>{row.sectionLabel}</td><td>{row.score}</td><td>{row.maxScore}</td><td>{row.lostPoints}</td><td>{row.lostPoints >= 8 ? '最優先' : row.lostPoints >= 4 ? '優先' : '維持'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
@@ -1,8 +1,8 @@
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry } from '../types';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MistakeCard } from '../types';
 
 const DB_NAME = 'cpa-boki2-trial-section-answer-manager';
-const DB_VERSION = 2;
-const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets'] as const;
+const DB_VERSION = 3;
+const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets', 'mistakeCards'] as const;
 
 type StoreName = (typeof STORES)[number];
 
@@ -78,6 +78,19 @@ export async function deleteExamSet(id: string): Promise<void> {
   await tx('examSets', 'readwrite', (store) => store.delete(id));
 }
 
+export async function saveMistakeCard(card: MistakeCard): Promise<void> {
+  await tx('mistakeCards', 'readwrite', (store) => store.put(card));
+}
+
+export async function getMistakeCards(): Promise<MistakeCard[]> {
+  const rows = await tx<MistakeCard[]>('mistakeCards', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function deleteMistakeCard(id: string): Promise<void> {
+  await tx('mistakeCards', 'readwrite', (store) => store.delete(id));
+}
+
 export async function getBackupMetadata(): Promise<BackupMetadata | null> {
   const row = await tx<BackupMetadata | undefined>('backups', 'readonly', (store) => store.get('backupMeta'));
   return row ?? null;
@@ -119,13 +132,14 @@ export async function exportAllData(): Promise<BackupPayload> {
   return {
     exportedAt: new Date().toISOString(),
     appName: 'CPA日商簿記2級 試験対策編 解答・復習管理アプリ',
-    version: '1.1.0',
+    version: '1.2.0',
     answers: await getAllAnswers(),
     histories: await getHistories(),
     settings: await tx<Record<string, unknown>[]>('settings', 'readonly', (store) => store.getAll()),
     templates: await tx<Record<string, unknown>[]>('templates', 'readonly', (store) => store.getAll()),
     backups: await tx<Record<string, unknown>[]>('backups', 'readonly', (store) => store.getAll()),
     examSets: await getExamSets(),
+    mistakeCards: await getMistakeCards(),
     backupMetadata: await getBackupMetadata(),
   };
 }
@@ -141,6 +155,7 @@ export async function importAllData(payload: BackupPayload): Promise<void> {
     payload.templates?.forEach((item) => transaction.objectStore('templates').put(item));
     payload.backups?.forEach((item) => transaction.objectStore('backups').put(item));
     payload.examSets?.forEach((item) => transaction.objectStore('examSets').put(item));
+    payload.mistakeCards?.forEach((item) => transaction.objectStore('mistakeCards').put(item));
     if (payload.backupMetadata) transaction.objectStore('backups').put(payload.backupMetadata);
     transaction.oncomplete = () => {
       db.close();

--- a/cpa-boki2-trial-section-answer-manager/src/styles.css
+++ b/cpa-boki2-trial-section-answer-manager/src/styles.css
@@ -78,8 +78,11 @@ th { background: #e8f2ee; position: sticky; top: 0; z-index: 1; }
 .journal-table .col-amount input, .journal-table .col-points input { text-align: right; font-variant-numeric: tabular-nums; }
 .score-grid { display: grid; gap: 10px; }
 .check-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+.check-list.wide { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin-top: 8px; }
 .check-list label { margin: 0; font-weight: 500; display: flex; gap: 5px; align-items: center; }
 .check-list input { width: auto; }
+.form-grid { display: grid; gap: 12px; }
+.form-grid.two-columns { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
 .review-box { border: 1px solid #dbe8e4; border-radius: 10px; padding: 10px; margin-bottom: 10px; background: #f7fbf9; }
 .review-row { padding: 8px 0; border-bottom: 1px dashed #cdded8; }
 .review-row:last-child { border-bottom: none; }

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -161,6 +161,63 @@ export interface ExamSetRecord {
   relatedHistoryIds: string[];
 }
 
+export type MasteryStatus = '未着手' | '1回演習済み' | '2回演習済み' | '3回以上演習済み' | '合格水準' | '再復習対象' | '危険問題' | '期限超過';
+export type MasteryFilter = '全体' | '未着手' | '危険問題' | '期限超過' | 'C判定' | 'B判定' | '合格水準' | '商業簿記' | '工業簿記' | '第1問対策' | '第2問対策' | '第3問対策' | '第4問対策' | '第5問対策';
+
+export interface MasteryMapItem {
+  problem: ProblemDefinition;
+  latestScore: number | null;
+  maxScore: number | null;
+  scoreRate: number | null;
+  latestRank: ReviewRank;
+  attempts: number;
+  aCount: number;
+  bCount: number;
+  cCount: number;
+  lastPracticedAt: string;
+  nextReviewDate: string;
+  status: MasteryStatus;
+  action: string;
+  sortPriority: number;
+}
+
+export interface MistakeCard {
+  id: string;
+  problemId: string;
+  correctFlow: string;
+  mistakeReason: string;
+  firstReviewPoint: string;
+  preSolveChecklist: string;
+  preventionPhrase: string;
+  missReasons: MissReason[];
+  importance: '高' | '中' | '低';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RecoveryPlanRow {
+  sectionId: SectionId;
+  sectionLabel: string;
+  score: number;
+  maxScore: number;
+  lostPoints: number;
+}
+
+export interface RecoveryPlan {
+  source: '直近90分セット' | '問題別履歴';
+  totalScore: number;
+  maxScore: number;
+  shortage70: number;
+  shortage72: number;
+  shortage80: number;
+  sectionRows: RecoveryPlanRow[];
+  biggestLossSection: string;
+  mostFrequentMissReason: string;
+  nextFocus: string;
+  recoveryCandidates: string[];
+  latestExamSet?: ExamSetRecord;
+}
+
 export interface BackupPayload {
   exportedAt: string;
   appName: string;
@@ -171,5 +228,6 @@ export interface BackupPayload {
   templates: Record<string, unknown>[];
   backups?: Record<string, unknown>[];
   examSets?: ExamSetRecord[];
+  mistakeCards?: MistakeCard[];
   backupMetadata?: BackupMetadata | null;
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/csv.ts
@@ -1,4 +1,4 @@
-import type { AnswerState, ExamSetRecord, HistoryEntry, ProblemDefinition, StudyQueueItem } from '../types';
+import type { AnswerState, ExamSetRecord, HistoryEntry, MasteryMapItem, MistakeCard, ProblemDefinition, RecoveryPlan, StudyQueueItem } from '../types';
 import { formatAmount, isAmountColumn } from './numberFormat';
 import { draftSummary } from './scoring';
 
@@ -94,5 +94,32 @@ export function examSetCsvRows(examSets: ExamSetRecord[]): unknown[][] {
   return [
     ['作成日時', 'セット名', '開始日時', '終了日時', '所要秒数', '選択問題ID', '合計点', '70点判定', 'メモ'],
     ...examSets.map((set) => [set.createdAt, set.name, set.startedAt, set.finishedAt, set.durationSeconds, set.selectedProblemIds.join('/'), set.totalScore, set.passLineReached ? '合格ライン到達' : '復習優先', set.memo]),
+  ];
+}
+
+export function masteryMapCsvRows(items: MasteryMapItem[]): unknown[][] {
+  return [
+    ['問題ID', '科目', '大問対策', '論点名', '最新得点', '満点', '得点率', '最新判定', '演習回数', 'A回数', 'B回数', 'C回数', '最終演習日', '次回復習日', '到達状態', '次の推奨アクション'],
+    ...items.map((item) => [item.problem.displayId, item.problem.subject, item.problem.sectionLabel, item.problem.topic, item.latestScore ?? '', item.maxScore ?? '', item.scoreRate ?? '', item.latestRank, item.attempts, item.aCount, item.bCount, item.cCount, item.lastPracticedAt, item.nextReviewDate, item.status, item.action]),
+  ];
+}
+
+export function mistakeCardCsvRows(cards: MistakeCard[], problemResolver: (problemId: string) => ProblemDefinition): unknown[][] {
+  return [
+    ['作成日', '更新日', '問題ID', '論点名', '重要度', '正しい処理の流れ', 'なぜ間違えたか', '次回最初に見る注意点', '次回確認事項', '同じミスを防ぐ一言', '関連ミス原因'],
+    ...cards.map((card) => {
+      const problem = problemResolver(card.problemId);
+      return [card.createdAt, card.updatedAt, problem.displayId, problem.topic, card.importance, card.correctFlow, card.mistakeReason, card.firstReviewPoint, card.preSolveChecklist, card.preventionPhrase, card.missReasons.join('/')];
+    }),
+  ];
+}
+
+export function recoveryPlanCsvRows(plan: RecoveryPlan): unknown[][] {
+  return [
+    ['判定元', '合計点', '満点', '70点まで', '72点まで', '80点まで', '最大失点大問', '最多ミス原因', '次回重点対策', '取り戻し候補'],
+    [plan.source, plan.totalScore, plan.maxScore, plan.shortage70, plan.shortage72, plan.shortage80, plan.biggestLossSection, plan.mostFrequentMissReason, plan.nextFocus, plan.recoveryCandidates.join('/')],
+    [],
+    ['大問', '得点', '満点', '失点'],
+    ...plan.sectionRows.map((row) => [row.sectionLabel, row.score, row.maxScore, row.lostPoints]),
   ];
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/mastery.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/mastery.ts
@@ -1,0 +1,108 @@
+import { problemCatalog } from '../data/problemCatalog';
+import type { HistoryEntry, MasteryFilter, MasteryMapItem } from '../types';
+import { isOverdue } from './dates';
+
+function byProblem(histories: HistoryEntry[]): Map<string, HistoryEntry[]> {
+  const map = new Map<string, HistoryEntry[]>();
+  histories.forEach((history) => {
+    const rows = map.get(history.problemId) ?? [];
+    rows.push(history);
+    map.set(history.problemId, rows);
+  });
+  map.forEach((rows) => rows.sort((a, b) => a.savedAt.localeCompare(b.savedAt)));
+  return map;
+}
+
+function scoreRate(score: number, maxScore: number): number | null {
+  if (!maxScore) return null;
+  return Math.round((score / maxScore) * 1000) / 10;
+}
+
+function isMastered(rows: HistoryEntry[]): boolean {
+  if (rows.length < 2) return false;
+  const latestTwo = rows.slice(-2);
+  const twoA = latestTwo.every((row) => row.rank === 'A');
+  const two80 = latestTwo.every((row) => scoreRate(row.score, row.maxScore) !== null && Number(scoreRate(row.score, row.maxScore)) >= 80);
+  const aCount = rows.filter((row) => row.rank === 'A').length;
+  const latest = rows.at(-1);
+  const latestGood = latest?.rank === 'A' || latest?.rank === 'B';
+  return twoA || two80 || (aCount >= 2 && Boolean(latestGood));
+}
+
+function actionFor(item: Omit<MasteryMapItem, 'action' | 'sortPriority'>): string {
+  if (item.attempts === 0) return 'まず1回解く';
+  if (isOverdue(item.nextReviewDate)) return '本日復習';
+  if (item.latestRank === 'C') return '白紙再現・解き直しカードを見て再演習';
+  if (item.scoreRate !== null && item.scoreRate < 70) return '失点原因を確認して再演習';
+  if (item.latestRank === 'B') return 'もう1回解いてA化';
+  if (item.status === '合格水準') return '試験前総復習まで保留';
+  return '次の弱点問題へ進む';
+}
+
+function priorityFor(item: Omit<MasteryMapItem, 'action' | 'sortPriority'>): number {
+  if (isOverdue(item.nextReviewDate) && item.latestRank === 'C') return 1;
+  if (item.attempts === 0) return 2;
+  if (item.latestRank === 'C') return 3;
+  if (item.scoreRate !== null && item.scoreRate < 70) return 4;
+  if (isOverdue(item.nextReviewDate) && item.latestRank === 'B') return 5;
+  if (item.attempts <= 1) return 6;
+  if (item.latestRank === 'B') return 7;
+  if (item.status === '合格水準') return 8;
+  return 9;
+}
+
+export function buildMasteryMap(histories: HistoryEntry[]): MasteryMapItem[] {
+  const grouped = byProblem(histories);
+  return problemCatalog.map((problem) => {
+    const rows = grouped.get(problem.id) ?? [];
+    const latest = rows.at(-1);
+    const attempts = rows.length;
+    const latestScore = latest?.score ?? null;
+    const maxScore = latest?.maxScore ?? null;
+    const rate = latest && maxScore !== null ? scoreRate(latest.score, latest.maxScore) : null;
+    const aCount = rows.filter((row) => row.rank === 'A').length;
+    const bCount = rows.filter((row) => row.rank === 'B').length;
+    const cCount = rows.filter((row) => row.rank === 'C').length;
+    const mastered = isMastered(rows);
+    const overdue = latest ? isOverdue(latest.nextReviewDate) : false;
+    const dangerous = attempts === 0 || latest?.rank === 'C' || (rate !== null && rate < 70) || overdue || cCount >= 2 || attempts <= 1;
+    let status: MasteryMapItem['status'] = '未着手';
+    if (overdue) status = '期限超過';
+    else if (dangerous && attempts > 0) status = latest?.rank === 'C' || cCount >= 2 || (rate !== null && rate < 70) ? '危険問題' : '再復習対象';
+    else if (mastered) status = '合格水準';
+    else if (attempts >= 3) status = '3回以上演習済み';
+    else if (attempts === 2) status = '2回演習済み';
+    else if (attempts === 1) status = '1回演習済み';
+
+    const base = {
+      problem,
+      latestScore,
+      maxScore,
+      scoreRate: rate,
+      latestRank: latest?.rank ?? '',
+      attempts,
+      aCount,
+      bCount,
+      cCount,
+      lastPracticedAt: latest?.savedAt ?? '',
+      nextReviewDate: latest?.nextReviewDate ?? '',
+      status,
+    };
+    const action = actionFor(base);
+    const sortPriority = priorityFor(base);
+    return { ...base, action, sortPriority };
+  }).sort((a, b) => a.sortPriority - b.sortPriority || a.problem.displayId.localeCompare(b.problem.displayId, 'ja'));
+}
+
+export function filterMasteryMap(items: MasteryMapItem[], filter: MasteryFilter): MasteryMapItem[] {
+  if (filter === '全体') return items;
+  if (filter === '未着手') return items.filter((item) => item.status === '未着手');
+  if (filter === '危険問題') return items.filter((item) => item.status === '危険問題' || item.status === '再復習対象' || item.status === '期限超過' || item.attempts === 0);
+  if (filter === '期限超過') return items.filter((item) => item.status === '期限超過');
+  if (filter === 'C判定') return items.filter((item) => item.latestRank === 'C');
+  if (filter === 'B判定') return items.filter((item) => item.latestRank === 'B');
+  if (filter === '合格水準') return items.filter((item) => item.status === '合格水準');
+  if (filter === '商業簿記') return items.filter((item) => item.problem.subject === 'commercial');
+  if (filter === '工業簿記') return items.filter((item) => item.problem.subject === 'industrial');
+  return items.filter((item) => item.problem.sectionLabel === filter);
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/recovery.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/recovery.ts
@@ -1,0 +1,84 @@
+import { problemCatalog } from '../data/problemCatalog';
+import type { ExamSetRecord, HistoryEntry, MissReason, RecoveryPlan, RecoveryPlanRow, SectionId } from '../types';
+
+const sectionLabels: Record<SectionId, string> = {
+  q1: '第1問対策',
+  q2: '第2問対策',
+  q3: '第3問対策',
+  q4: '第4問対策',
+  q5: '第5問対策',
+};
+
+function shortage(target: number, score: number): number {
+  return Math.max(0, target - score);
+}
+
+function mostFrequentMissReason(histories: HistoryEntry[]): string {
+  const counts = new Map<MissReason, number>();
+  histories.forEach((history) => history.missReasons.forEach((reason) => counts.set(reason, (counts.get(reason) ?? 0) + 1)));
+  const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  return sorted[0]?.[0] ?? '未登録';
+}
+
+function focusFor(reason: string, cCount: number): string {
+  if (cCount > 0) return 'C判定問題の白紙再現・解き直しカードを作ってから再演習';
+  if (reason === '金額ミス') return '金額欄・集計欄を重点確認';
+  if (reason === '仕訳ミス' || reason === '借方貸方逆') return '第1問対策と仕訳テーブルを優先';
+  if (reason === '集計ミス') return '第3問または第5問の表問題を優先';
+  if (reason === '時間不足') return '90分セット演習を優先';
+  if (reason === '問題文読み落とし') return '設問番号・条件整理を最初に確認';
+  if (reason === '表の入力位置ミス') return '解答欄形式と列位置を確認してから入力';
+  return '直近の低得点問題から再演習';
+}
+
+function byLatestSectionHistories(histories: HistoryEntry[]): RecoveryPlanRow[] {
+  const latestBySection = new Map<SectionId, HistoryEntry>();
+  histories.forEach((history) => {
+    const current = latestBySection.get(history.sectionId);
+    if (!current || history.savedAt > current.savedAt) latestBySection.set(history.sectionId, history);
+  });
+  return (Object.keys(sectionLabels) as SectionId[]).map((sectionId) => {
+    const latest = latestBySection.get(sectionId);
+    return {
+      sectionId,
+      sectionLabel: sectionLabels[sectionId],
+      score: latest?.score ?? 0,
+      maxScore: latest?.maxScore ?? 20,
+      lostPoints: Math.max(0, (latest?.maxScore ?? 20) - (latest?.score ?? 0)),
+    };
+  });
+}
+
+function byExamSet(record: ExamSetRecord): RecoveryPlanRow[] {
+  return (Object.keys(sectionLabels) as SectionId[]).map((sectionId) => {
+    const problem = problemCatalog.find((item) => item.sectionId === sectionId && record.selectedProblemIds.includes(item.id));
+    const score = problem ? Number(record.problemScores[problem.id] ?? 0) : 0;
+    return { sectionId, sectionLabel: sectionLabels[sectionId], score, maxScore: 20, lostPoints: Math.max(0, 20 - score) };
+  });
+}
+
+export function buildRecoveryPlan(histories: HistoryEntry[], examSets: ExamSetRecord[]): RecoveryPlan {
+  const latestExamSet = [...examSets].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+  const source: RecoveryPlan['source'] = latestExamSet ? '直近90分セット' : '問題別履歴';
+  const sectionRows = latestExamSet ? byExamSet(latestExamSet) : byLatestSectionHistories(histories);
+  const totalScore = latestExamSet ? latestExamSet.totalScore : sectionRows.reduce((sum, row) => sum + row.score, 0);
+  const maxScore = latestExamSet ? 100 : sectionRows.reduce((sum, row) => sum + row.maxScore, 0);
+  const biggest = [...sectionRows].sort((a, b) => b.lostPoints - a.lostPoints)[0];
+  const missReason = mostFrequentMissReason(histories);
+  const cCount = histories.filter((history) => history.rank === 'C').length;
+  const sortedLoss = [...sectionRows].filter((row) => row.lostPoints > 0).sort((a, b) => b.lostPoints - a.lostPoints);
+  return {
+    source,
+    totalScore,
+    maxScore,
+    shortage70: shortage(70, totalScore),
+    shortage72: shortage(72, totalScore),
+    shortage80: shortage(80, totalScore),
+    sectionRows,
+    biggestLossSection: biggest ? `${biggest.sectionLabel}（失点${biggest.lostPoints}点）` : '未判定',
+    mostFrequentMissReason: missReason,
+    nextFocus: focusFor(missReason, cCount),
+    recoveryCandidates: sortedLoss.slice(0, 2).map((row) => `${row.sectionLabel}で+${Math.min(row.lostPoints, Math.ceil(shortage(70, totalScore) / Math.max(1, sortedLoss.length)) || row.lostPoints)}点`),
+    latestExamSet,
+  };
+}


### PR DESCRIPTION
## 1. 今回の目的
このPRは、CPA日商簿記2級 試験対策編 解答・復習管理アプリの開発を一旦仕上げ、実教材を使った毎日の学習運用に入れる状態にするための最終仕上げです。

目的は見た目改善や大型機能追加ではなく、以下を最小回数の指示で実現することです。

- 試験対策編の全問題IDについて、未着手・演習済み・合格水準・再復習対象を一画面で判断できる
- 間違えた直後に、白紙再現・解き直しメモを残し、次回復習時に最初に表示できる
- 70点突破のため、どの大問・どのミス原因を潰せば点が伸びるかを表示できる
- 既存の入力効率改善、キーボード操作、金額カンマ、復習キュー、90分セット演習を壊さない

## 2. 実装した内容
### 合格到達マップ
全問題IDについて以下を表示します。

- 問題ID
- 科目
- 大問対策
- 論点名
- 最新得点
- 満点
- 得点率
- 最新A/B/C判定
- 演習回数
- A/B/C回数
- 最終演習日
- 次回復習日
- 現在の到達状態
- 次の推奨アクション

判定状態:

- 未着手
- 1回演習済み
- 2回演習済み
- 3回以上演習済み
- 合格水準
- 再復習対象
- 危険問題
- 期限超過

フィルタ:

- 全体
- 未着手
- 危険問題
- 期限超過
- C判定
- B判定
- 合格水準
- 商業簿記
- 工業簿記
- 第1問対策〜第5問対策

CSV出力:

- `mastery-map.csv`

### 白紙再現・解き直しカード
問題IDごとに複数の解き直しカードを保存できます。

入力項目:

- 正しい処理の流れ
- なぜ間違えたか
- 次回最初に見る注意点
- 次回は何を確認してから解くか
- 同じミスを防ぐ一言
- 関連するミス原因
- 重要度
- 作成日
- 更新日

仕様:

- 最新カードを問題ID画面上部に表示
- C判定または70%未満なのにカード未作成の場合は警告表示
- カードの作成・編集・削除に対応
- CSV出力に対応
- JSONバックアップ・復元対象に追加

CSV出力:

- `mistake-cards.csv`

### 70点突破リカバリー表
直近の90分セット演習、または問題別履歴から70点突破に必要な情報を表示します。

表示項目:

- 直近セット演習または問題別履歴からの合計点
- 70点までの不足点
- 72点までの不足点
- 80点までの不足点
- 第1問〜第5問ごとの得点・満点・失点
- 最も失点が大きい大問
- 最も多いミス原因
- 次回の重点対策
- 取り戻し候補点

CSV出力:

- `recovery-plan.csv`

### PRビルドチェック
簿記アプリ単体のビルドチェックworkflowを追加しました。

追加workflow:

- `.github/workflows/cpa-boki2-check.yml`

実行内容:

- `actions/checkout@v4`
- `actions/setup-node@v4`
- `npm install`
- `npm run build`

対象:

- pull_request
- push to main
- workflow_dispatch

paths:

- `cpa-boki2-trial-section-answer-manager/**`
- `.github/workflows/cpa-boki2-check.yml`

## 3. 変更ファイル一覧
- `.github/workflows/cpa-boki2-check.yml`
- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/MasteryMapPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/MistakeCardPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/RecoveryPlanPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts`
- `cpa-boki2-trial-section-answer-manager/src/types/index.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/csv.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/mastery.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/recovery.ts`
- `cpa-boki2-trial-section-answer-manager/src/styles.css`

## 4. 既存案件管理アプリへの影響
既存案件管理アプリには影響ありません。

変更していないもの:

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- 既存案件管理アプリのURL

## 5. Pages workflowへの影響
既存のPages公開workflowは変更していません。

今回追加したのは、簿記アプリ単体のPRビルドチェックworkflowのみです。

## 6. 簿記アプリ既存機能への影響
以下は維持しています。

- 問題ID選択
- テンプレート選択
- 答案入力テーブル
- 行追加
- 列追加
- 空行整理
- 行別採点
- 行別得点合計を問題得点へ反映
- A/B/C判定
- 次回復習日
- ミス原因
- 下書きメモ
- 復習メモ
- 履歴保存
- 履歴復元
- CSV出力
- JSONバックアップ
- JSON復元
- 今日の学習キュー
- 成績ダッシュボード
- 90分セット演習
- 保存安全性チェック
- 記入例・使い方
- 金額欄の3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キーによるセル移動
- ダブルクリック／F2によるセル内編集モード
- Escで編集モード解除
- メモ欄の通常時セル移動
- メモ欄の編集時内部カーソル移動

## 7. データ互換性
IndexedDBのDB_VERSIONを `3` に上げ、`mistakeCards` ストアを追加しました。

既存ストアは削除していません。

維持:

- `answers`
- `histories`
- `settings`
- `templates`
- `backups`
- `examSets`

追加:

- `mistakeCards`

JSONバックアップ・復元には `mistakeCards` を含めています。
旧JSONで `mistakeCards` が存在しない場合は、空扱いで復元されるため、旧バックアップの読み込みも壊れない想定です。

## 8. 著作権対応
以下は追加していません。

- CPA教材の問題文
- CPA教材の解答
- CPA教材の解説
- CPAロゴ
- 教材画像
- 日本商工会議所の問題文・サンプル問題

白紙再現・解き直しカードにも注意文を表示し、教材本文ではなく自分の言葉で処理手順・ミス原因・次回注意点を書く運用にしています。

## 9. 動作確認結果
この環境ではローカルの `npm install` / `npm run build` は実行できていません。

コード上で確認した項目:

- 合格到達マップの表示ロジック
- 合格到達マップCSV出力
- 白紙再現・解き直しカードの作成・編集・削除UI
- 白紙再現・解き直しカードCSV出力
- C判定または70%未満時のカード作成警告
- 70点突破リカバリー表の表示
- 70点突破リカバリーCSV出力
- IndexedDB `mistakeCards` ストア追加
- JSONバックアップ・復元への `mistakeCards` 追加
- 既存Pages workflow未変更
- 既存案件管理アプリ本体未変更

PR作成後、追加した `CPA Boki2 App Build Check` workflowで `npm install` と `npm run build` を確認してください。

## 10. 未確認事項
- GitHub Actions上での実ビルド結果
- 公開URLでの実画面確認
- 旧JSONバックアップを実際にインポートした場合の確認
- 大量履歴・大量カード作成時の表示速度

## 11. 今後の方針
このPRで、簿記2級アプリの開発は一旦仕上げとします。

以後は以下を追加しません。

- AI解説
- 自動採点
- PDF取込
- ログイン
- Supabase同期
- 弁理士モード
- 建設業経理士2級モード
- グラフライブラリ
- デザイン装飾

今後は、実際の学習運用で出た不具合のみ最小修正する方針です。