### PR TITLE
Add disposable-time PDF study MVP

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/package.json
+++ b/cpa-boki2-trial-section-answer-manager/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "latest",
+    "pdfjs-dist": "latest",
     "react": "latest",
     "react-dom": "latest",
     "typescript": "latest",

--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -2,11 +2,15 @@ import { useEffect, useMemo, useState } from 'react';
 import { AnswerTable, createRows } from './components/AnswerTable';
 import { BackupSafetyPanel } from './components/BackupSafetyPanel';
 import { DashboardPanel } from './components/DashboardPanel';
+import { DisposableStudyPanel } from './components/DisposableStudyPanel';
 import { ExamSetPanel } from './components/ExamSetPanel';
 import { ExampleGuide } from './components/ExampleGuide';
 import { HistoryPanel } from './components/HistoryPanel';
 import { MasteryMapPanel } from './components/MasteryMapPanel';
 import { MistakeCardPanel } from './components/MistakeCardPanel';
+import { PdfMappingPanel } from './components/PdfMappingPanel';
+import { PdfStudyPanel } from './components/PdfStudyPanel';
+import { PdfVaultPanel } from './components/PdfVaultPanel';
 import { ProblemSelector } from './components/ProblemSelector';
 import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
@@ -15,12 +19,41 @@ import { StudyQueuePanel } from './components/StudyQueuePanel';
 import { Timer } from './components/Timer';
 import { getProblemById, problemCatalog } from './data/problemCatalog';
 import { getTemplateById } from './data/templateCatalog';
-import { addHistory, clearHistories, deleteHistory, deleteMistakeCard, exportAllData, getAllAnswers, getAnswer, getBackupMetadata, getExamSets, getHistories, getMistakeCards, importAllData, recordBackupMade, saveAnswer, saveExamSet, saveMistakeCard } from './storage/indexedDb';
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MistakeCard, StorageSafetyInfo, TemplateId } from './types';
+import {
+  addHistory,
+  clearHistories,
+  deleteHistory,
+  deleteMaterialPdf,
+  deleteMaterialPdfMapping,
+  deleteMistakeCard,
+  exportAllData,
+  getAllAnswers,
+  getAnswer,
+  getBackupMetadata,
+  getExamSets,
+  getHistories,
+  getMaterialPdfMappings,
+  getMaterialPdfs,
+  getMistakeCards,
+  getPracticeSessions,
+  getReviewStates,
+  importAllData,
+  recordBackupMade,
+  saveAnswer,
+  saveExamSet,
+  saveMaterialPdf,
+  saveMaterialPdfMapping,
+  saveMistakeCard,
+  savePracticeSession,
+  saveReviewState,
+} from './storage/indexedDb';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, GradingStatus, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, ReviewState, StorageSafetyInfo, TemplateId, TimeMode } from './types';
 import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, masteryMapCsvRows, missReasonCsvRows, mistakeCardCsvRows, problemStatsCsvRows, recoveryPlanCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
+import { chooseProblemForTimeMode, chooseQuickStartProblem, latestUnfinishedSession } from './utils/disposableStudy';
 import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
 import { buildMasteryMap } from './utils/mastery';
 import { buildRecoveryPlan } from './utils/recovery';
+import { rankFromSelfGrading, updateReviewStateFromGrading } from './utils/reviewScheduler';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
 import { getStorageSafetyInfo } from './utils/storageSafety';
 import { buildStudyQueue } from './utils/studyQueue';
@@ -106,6 +139,13 @@ function buildHistory(answer: AnswerState): HistoryEntry {
   };
 }
 
+function secondsBetween(start: string, end: string): number {
+  const startMs = new Date(start).getTime();
+  const endMs = new Date(end).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return 0;
+  return Math.max(0, Math.round((endMs - startMs) / 1000));
+}
+
 export default function App() {
   const [problemId, setProblemId] = useState(problemCatalog[0].id);
   const [answer, setAnswer] = useState<AnswerState>(() => createAnswer(problemCatalog[0].id, problemCatalog[0].defaultTemplateId));
@@ -113,6 +153,11 @@ export default function App() {
   const [histories, setHistories] = useState<HistoryEntry[]>([]);
   const [examSets, setExamSets] = useState<ExamSetRecord[]>([]);
   const [mistakeCards, setMistakeCards] = useState<MistakeCard[]>([]);
+  const [materialPdfs, setMaterialPdfs] = useState<MaterialPdf[]>([]);
+  const [pdfMappings, setPdfMappings] = useState<MaterialPdfMapping[]>([]);
+  const [practiceSessions, setPracticeSessions] = useState<PracticeSession[]>([]);
+  const [reviewStates, setReviewStates] = useState<ReviewState[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState('');
   const [, setBackupMeta] = useState<BackupMetadata | null>(null);
   const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
@@ -123,6 +168,13 @@ export default function App() {
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
+  const activeSession = useMemo(() => practiceSessions.find((session) => session.id === activeSessionId) ?? latestUnfinishedSession(practiceSessions) ?? null, [practiceSessions, activeSessionId]);
+  const currentReviewState = useMemo(() => reviewStates.find((state) => state.problemId === problemId), [reviewStates, problemId]);
+  const quickChoice = useMemo(() => chooseQuickStartProblem({ sessions: practiceSessions, studyQueue, masteryMap }), [practiceSessions, studyQueue, masteryMap]);
+  const quickHint = useMemo(() => {
+    const quickProblem = getProblemById(quickChoice.problemId);
+    return `推奨：${quickProblem.sectionLabel} ${quickProblem.displayId} ${quickProblem.topic}（${quickChoice.reason}）`;
+  }, [quickChoice]);
 
   async function refreshAnswers() {
     setAnswers((await getAllAnswers()).map(normalizeAnswer));
@@ -140,6 +192,22 @@ export default function App() {
     setMistakeCards(await getMistakeCards());
   }
 
+  async function loadMaterialPdfs() {
+    setMaterialPdfs(await getMaterialPdfs());
+  }
+
+  async function loadPdfMappings() {
+    setPdfMappings(await getMaterialPdfMappings());
+  }
+
+  async function loadPracticeSessions() {
+    setPracticeSessions(await getPracticeSessions());
+  }
+
+  async function loadReviewStates() {
+    setReviewStates(await getReviewStates());
+  }
+
   async function refreshSafety() {
     const [historyRows, answerRows, meta] = await Promise.all([getHistories(), getAllAnswers(), getBackupMetadata()]);
     setBackupMeta(meta);
@@ -147,7 +215,7 @@ export default function App() {
   }
 
   async function refreshAll() {
-    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), loadMistakeCards(), refreshSafety()]);
+    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), loadMistakeCards(), loadMaterialPdfs(), loadPdfMappings(), loadPracticeSessions(), loadReviewStates(), refreshSafety()]);
   }
 
   async function loadProblem(nextProblemId: string) {
@@ -188,6 +256,67 @@ export default function App() {
       rows: createRows(nextTemplate.columns.length, nextTemplate.initialRows),
     });
   };
+
+  async function createPracticeSession(problemIdForSession: string, selectedTimeMode: TimeMode): Promise<PracticeSession> {
+    const problemDefinition = getProblemById(problemIdForSession);
+    const stored = await getAnswer(problemIdForSession);
+    const baseAnswer = normalizeAnswer(stored ?? createAnswer(problemIdForSession, problemDefinition.defaultTemplateId));
+    const now = nowIso();
+    return {
+      id: crypto.randomUUID(),
+      examType: '日商簿記2級',
+      problemId: problemIdForSession,
+      startedAt: now,
+      submittedAt: '',
+      durationSeconds: 0,
+      selectedTimeMode,
+      answerSnapshot: baseAnswer,
+      gradingMode: 'self',
+      gradingResult: { status: '', score: 0, maxScore: baseAnswer.maxScore, scoreRate: 0, autoGraded: false, detailRows: [] },
+      openedAnswer: false,
+      openedExplanation: false,
+      memo: '',
+      completed: false,
+    };
+  }
+
+  async function beginPractice(problemIdForSession: string, mode: TimeMode, reason: string): Promise<PracticeSession> {
+    const session = await createPracticeSession(problemIdForSession, mode);
+    await savePracticeSession(session);
+    setActiveSessionId(session.id);
+    await loadProblem(problemIdForSession);
+    await refreshAll();
+    setMessage(`${mode}モードで演習開始：${getProblemById(problemIdForSession).displayId}（${reason}）`);
+    return session;
+  }
+
+  async function quickResume() {
+    const unfinished = latestUnfinishedSession(practiceSessions);
+    if (unfinished) {
+      setActiveSessionId(unfinished.id);
+      await loadProblem(unfinished.problemId);
+      setMessage(`未完了セッションを再開しました：${getProblemById(unfinished.problemId).displayId}`);
+      return;
+    }
+    await beginPractice(quickChoice.problemId, quickChoice.mode, quickChoice.reason);
+  }
+
+  async function selectTimeMode(mode: TimeMode) {
+    const selectedProblemId = chooseProblemForTimeMode(mode, studyQueue, masteryMap, histories);
+    await beginPractice(selectedProblemId, mode, '空き時間から選択');
+  }
+
+  async function startCurrentSession(): Promise<PracticeSession> {
+    if (activeSession && activeSession.problemId === problem.id && !activeSession.completed) return activeSession;
+    const mapping = pdfMappings.find((item) => item.problemId === problem.id);
+    return beginPractice(problem.id, mapping?.estimatedMinutes ?? '10分', '現在の問題ID');
+  }
+
+  async function updatePracticeSession(session: PracticeSession) {
+    await savePracticeSession(session);
+    setActiveSessionId(session.id);
+    await loadPracticeSessions();
+  }
 
   const applyRowPoints = () => {
     const total = sumRowPoints(answer.rows);
@@ -236,6 +365,51 @@ export default function App() {
     setMessage('採点確定して履歴に追加しました');
   };
 
+  async function submitSelfGrading(input: { status: GradingStatus; score: number; maxScore: number; memo: string }) {
+    const submittedAt = nowIso();
+    const rank = rankFromSelfGrading(input.status, input.score, input.maxScore);
+    const reviewState = updateReviewStateFromGrading({ problemId: problem.id, previous: currentReviewState, status: input.status, score: input.score, maxScore: input.maxScore });
+    const scored = normalizeAnswer({
+      ...answer,
+      score: input.score,
+      maxScore: input.maxScore,
+      scored: true,
+      scoringStarted: true,
+      scoredAt: submittedAt,
+      rank,
+      nextReviewDate: reviewState.nextReviewDate,
+      reviewMemo: input.memo || answer.reviewMemo,
+      updatedAt: submittedAt,
+    });
+    const session = activeSession && activeSession.problemId === problem.id && !activeSession.completed ? activeSession : await startCurrentSession();
+    const completedSession: PracticeSession = {
+      ...session,
+      submittedAt,
+      durationSeconds: secondsBetween(session.startedAt, submittedAt),
+      answerSnapshot: scored,
+      gradingResult: {
+        status: input.status,
+        score: input.score,
+        maxScore: input.maxScore,
+        scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0,
+        autoGraded: false,
+        detailRows: [],
+      },
+      reviewState,
+      openedAnswer: true,
+      memo: input.memo,
+      completed: true,
+    };
+    await saveAnswer(scored);
+    await addHistory(buildHistory(scored));
+    await saveReviewState(reviewState);
+    await savePracticeSession(completedSession);
+    setAnswer(scored);
+    setActiveSessionId('');
+    await refreshAll();
+    setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
+  }
+
   const restoreHistory = async (entry: HistoryEntry) => {
     if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return;
     const restored = normalizeAnswer(entry.snapshot);
@@ -273,6 +447,30 @@ export default function App() {
     setMessage('白紙再現・解き直しカードを削除しました');
   };
 
+  const savePdf = async (pdf: MaterialPdf) => {
+    await saveMaterialPdf(pdf);
+    await loadMaterialPdfs();
+  };
+
+  const removePdf = async (id: string) => {
+    await deleteMaterialPdf(id);
+    await Promise.all([loadMaterialPdfs(), loadPdfMappings()]);
+    setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。');
+  };
+
+  const savePdfMapping = async (mapping: MaterialPdfMapping) => {
+    await saveMaterialPdfMapping(mapping);
+    await loadPdfMappings();
+    setMessage('PDFページ紐付けを保存しました');
+  };
+
+  const removePdfMapping = async (id: string) => {
+    if (!window.confirm('このPDFページ紐付けを削除しますか？PDF教材データと答案履歴は削除されません。')) return;
+    await deleteMaterialPdfMapping(id);
+    await loadPdfMappings();
+    setMessage('PDFページ紐付けを削除しました');
+  };
+
   const exportCurrentCsv = () => downloadCsv('current-answer.csv', currentAnswerCsvRows(answer, problem));
   const exportHistoryCsv = () => downloadCsv('history.csv', historyCsvRows(histories));
   const exportReviewCsv = () => downloadCsv('review-targets.csv', reviewTargetCsvRows(histories.filter((history) => isDueTodayOrEarlier(history.nextReviewDate))));
@@ -292,7 +490,7 @@ export default function App() {
     downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8');
     setBackupMeta(meta);
     await refreshSafety();
-    setMessage('JSONバックアップを出力しました');
+    setMessage('JSONバックアップを出力しました。PDF Blob本体はPR2対象のため含めていません。');
   };
 
   const importJson = async (file: File | undefined) => {
@@ -302,7 +500,7 @@ export default function App() {
       await importAllData(payload);
       await loadProblem(problemId);
       await refreshAll();
-      setMessage('JSONバックアップを復元しました');
+      setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。');
     } catch {
       setMessage('JSONの形式が不正です');
     }
@@ -347,6 +545,8 @@ export default function App() {
 
       <div className="status-bar">{message}</div>
 
+      <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
+
       <div className="top-actions">
         <button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button>
         <button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button>
@@ -362,6 +562,8 @@ export default function App() {
 
       <section className="management-stack">
         <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
+        <PdfVaultPanel pdfs={materialPdfs} onSavePdf={savePdf} onDeletePdf={removePdf} onMessage={setMessage} />
+        <PdfMappingPanel pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSave={savePdfMapping} onDelete={removePdfMapping} onOpenProblem={loadProblem} />
         <MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} />
         <RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} />
         <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
@@ -379,8 +581,13 @@ export default function App() {
             <p>使用テンプレート：{answer.templateName}</p>
           </section>
           <MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} />
-          <ExampleGuide template={template} />
-          <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
+          <div className="practice-workspace">
+            <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} />
+            <div className="answer-workspace">
+              <ExampleGuide template={template} />
+              <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
+            </div>
+          </div>
           <HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} />
         </section>
 

--- a/cpa-boki2-trial-section-answer-manager/src/components/DisposableStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/DisposableStudyPanel.tsx
@@ -5,8 +5,8 @@ import { formatDateTime } from '../utils/dates';
 interface Props {
   activeSession: PracticeSession | null;
   quickHint: string;
-  onQuickResume: () => void;
-  onSelectMode: (mode: TimeMode) => void;
+  onQuickResume: () => void | Promise<void>;
+  onSelectMode: (mode: TimeMode) => void | Promise<void>;
 }
 
 export function DisposableStudyPanel({ activeSession, quickHint, onQuickResume, onSelectMode }: Props) {
@@ -18,13 +18,13 @@ export function DisposableStudyPanel({ activeSession, quickHint, onQuickResume, 
           <h2>30秒以内に演習開始</h2>
           <p>{activeSession ? `未完了セッション：${activeSession.selectedTimeMode} / ${formatDateTime(activeSession.startedAt)}` : quickHint}</p>
         </div>
-        <button className="resume-button" onClick={onQuickResume}>今すぐ再開</button>
+        <button className="resume-button" onClick={() => { void onQuickResume(); }}>今すぐ再開</button>
       </div>
       <div className="time-mode-panel">
         <h3>空き時間から選ぶ</h3>
         <div className="time-mode-grid">
           {timeModes.map((mode) => (
-            <button key={mode} className="time-mode-button" onClick={() => onSelectMode(mode)}>
+            <button key={mode} className="time-mode-button" onClick={() => { void onSelectMode(mode); }}>
               <strong>{mode}</strong>
               <span>{timeModeDescription(mode)}</span>
             </button>

--- a/cpa-boki2-trial-section-answer-manager/src/components/DisposableStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/DisposableStudyPanel.tsx
@@ -1,0 +1,39 @@
+import type { PracticeSession, TimeMode } from '../types';
+import { timeModeDescription, timeModes } from '../utils/disposableStudy';
+import { formatDateTime } from '../utils/dates';
+
+interface Props {
+  activeSession: PracticeSession | null;
+  quickHint: string;
+  onQuickResume: () => void;
+  onSelectMode: (mode: TimeMode) => void;
+}
+
+export function DisposableStudyPanel({ activeSession, quickHint, onQuickResume, onSelectMode }: Props) {
+  return (
+    <section className="panel disposable-panel">
+      <div className="disposable-hero">
+        <div>
+          <p className="eyebrow">可処分学習時間最大化MVP</p>
+          <h2>30秒以内に演習開始</h2>
+          <p>{activeSession ? `未完了セッション：${activeSession.selectedTimeMode} / ${formatDateTime(activeSession.startedAt)}` : quickHint}</p>
+        </div>
+        <button className="resume-button" onClick={onQuickResume}>今すぐ再開</button>
+      </div>
+      <div className="time-mode-panel">
+        <h3>空き時間から選ぶ</h3>
+        <div className="time-mode-grid">
+          {timeModes.map((mode) => (
+            <button key={mode} className="time-mode-button" onClick={() => onSelectMode(mode)}>
+              <strong>{mode}</strong>
+              <span>{timeModeDescription(mode)}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="legal-notice">
+        この機能は、正規に取得・購入した教材PDFを、利用者本人の私的学習のために端末内で整理・参照する目的のものです。教材PDF・問題文・解答・解説を第三者と共有したり、GitHub・SNS・クラウド公開領域へアップロードしたりしないでください。DRM等の技術的保護手段を回避して取り込むことはしないでください。
+      </p>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfMappingPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfMappingPanel.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react';
+import { problemCatalog } from '../data/problemCatalog';
+import type { MaterialPdf, MaterialPdfMapping, TimeMode } from '../types';
+import { nowIso } from '../utils/dates';
+import { timeModes } from '../utils/disposableStudy';
+
+interface Props {
+  pdfs: MaterialPdf[];
+  mappings: MaterialPdfMapping[];
+  selectedProblemId: string;
+  onSave: (mapping: MaterialPdfMapping) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  onOpenProblem: (problemId: string) => void;
+}
+
+function blankMapping(problemId: string, pdfId = ''): MaterialPdfMapping {
+  const problem = problemCatalog.find((item) => item.id === problemId) ?? problemCatalog[0];
+  const now = nowIso();
+  return {
+    id: crypto.randomUUID(),
+    problemId: problem.id,
+    displayId: problem.displayId,
+    materialPdfId: pdfId,
+    problemPageStart: 1,
+    problemPageEnd: 1,
+    answerPageStart: undefined,
+    answerPageEnd: undefined,
+    explanationPageStart: undefined,
+    explanationPageEnd: undefined,
+    estimatedMinutes: '10分',
+    difficulty: '標準',
+    memo: '',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function numberOrUndefined(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function PdfMappingPanel({ pdfs, mappings, selectedProblemId, onSave, onDelete, onOpenProblem }: Props) {
+  const [draft, setDraft] = useState<MaterialPdfMapping>(() => blankMapping(selectedProblemId, pdfs[0]?.id ?? ''));
+  const mappedProblemIds = useMemo(() => new Set(mappings.map((mapping) => mapping.problemId)), [mappings]);
+  const unmapped = problemCatalog.filter((problem) => !mappedProblemIds.has(problem.id));
+
+  useEffect(() => {
+    const existing = mappings.find((mapping) => mapping.problemId === selectedProblemId) ?? blankMapping(selectedProblemId, pdfs[0]?.id ?? '');
+    setDraft(existing);
+  }, [selectedProblemId, mappings, pdfs]);
+
+  const selectedProblem = problemCatalog.find((problem) => problem.id === draft.problemId) ?? problemCatalog[0];
+  const update = (patch: Partial<MaterialPdfMapping>) => setDraft((current) => ({ ...current, ...patch, displayId: (problemCatalog.find((problem) => problem.id === (patch.problemId ?? current.problemId)) ?? selectedProblem).displayId, updatedAt: nowIso() }));
+  const save = async () => {
+    if (!draft.materialPdfId) return;
+    await onSave({ ...draft, displayId: selectedProblem.displayId, updatedAt: nowIso() });
+  };
+
+  return (
+    <details className="panel management-panel">
+      <summary>PDFページ紐付け：{mappings.length}件 / 未紐付け {unmapped.length}件</summary>
+      <div className="panel-body">
+        <div className="form-grid three-columns">
+          <label>問題ID
+            <select value={draft.problemId} onChange={(event) => update({ problemId: event.target.value })}>
+              {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}
+            </select>
+          </label>
+          <label>対象PDF
+            <select value={draft.materialPdfId} onChange={(event) => update({ materialPdfId: event.target.value })}>
+              <option value="">PDFを選択</option>
+              {pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}</option>)}
+            </select>
+          </label>
+          <label>想定時間
+            <select value={draft.estimatedMinutes} onChange={(event) => update({ estimatedMinutes: event.target.value as TimeMode })}>
+              {timeModes.map((mode) => <option key={mode} value={mode}>{mode}</option>)}
+            </select>
+          </label>
+        </div>
+        <div className="form-grid six-columns">
+          <label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label>
+          <label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label>
+          <label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label>
+          <label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label>
+          <label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label>
+          <label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label>
+        </div>
+        <div className="form-grid two-columns">
+          <label>難易度
+            <select value={draft.difficulty} onChange={(event) => update({ difficulty: event.target.value as MaterialPdfMapping['difficulty'] })}>
+              <option value="易">易</option><option value="標準">標準</option><option value="難">難</option>
+            </select>
+          </label>
+          <label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れず、ページ確認用の短いメモだけ" /></label>
+        </div>
+        <div className="button-row">
+          <button className="accent" disabled={!draft.materialPdfId} onClick={save}>紐付け保存</button>
+          <button className="secondary" onClick={() => setDraft(blankMapping(selectedProblemId, pdfs[0]?.id ?? ''))}>新規作成</button>
+        </div>
+        <div className="table-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題P</th><th>解答P</th><th>解説P</th><th>時間</th><th>難易度</th><th>操作</th></tr></thead>
+            <tbody>
+              {mappings.map((mapping) => {
+                const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
+                const pdf = pdfs.find((item) => item.id === mapping.materialPdfId);
+                return (
+                  <tr key={mapping.id}>
+                    <td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td>
+                    <td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td>
+                    <td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td>
+                    <td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td>
+                    <td>{mapping.estimatedMinutes}</td><td>{mapping.difficulty}</td>
+                    <td><button onClick={() => { setDraft(mapping); onOpenProblem(mapping.problemId); }}>編集</button> <button className="danger" onClick={() => onDelete(mapping.id)}>削除</button></td>
+                  </tr>
+                );
+              })}
+              {mappings.length === 0 && <tr><td colSpan={9}>PDFページ紐付けは未登録です。</td></tr>}
+            </tbody>
+          </table>
+        </div>
+        {unmapped.length > 0 && <p className="notice-small">未紐付け例：{unmapped.slice(0, 10).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 10 ? ' ...' : ''}</p>}
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfMappingPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfMappingPanel.tsx
@@ -96,7 +96,7 @@ export function PdfMappingPanel({ pdfs, mappings, selectedProblemId, onSave, onD
           <label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れず、ページ確認用の短いメモだけ" /></label>
         </div>
         <div className="button-row">
-          <button className="accent" disabled={!draft.materialPdfId} onClick={save}>紐付け保存</button>
+          <button className="accent" disabled={!draft.materialPdfId} onClick={() => { void save(); }}>紐付け保存</button>
           <button className="secondary" onClick={() => setDraft(blankMapping(selectedProblemId, pdfs[0]?.id ?? ''))}>新規作成</button>
         </div>
         <div className="table-wrap short-wrap">
@@ -113,7 +113,7 @@ export function PdfMappingPanel({ pdfs, mappings, selectedProblemId, onSave, onD
                     <td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td>
                     <td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td>
                     <td>{mapping.estimatedMinutes}</td><td>{mapping.difficulty}</td>
-                    <td><button onClick={() => { setDraft(mapping); onOpenProblem(mapping.problemId); }}>編集</button> <button className="danger" onClick={() => onDelete(mapping.id)}>削除</button></td>
+                    <td><button onClick={() => { setDraft(mapping); onOpenProblem(mapping.problemId); }}>編集</button> <button className="danger" onClick={() => { void onDelete(mapping.id); }}>削除</button></td>
                   </tr>
                 );
               })}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { AnswerState, GradingStatus, MaterialPdf, MaterialPdfMapping, PracticeSession, ProblemDefinition, ReviewRank, ReviewState } from '../types';
+import { formatDateTime } from '../utils/dates';
+import { renderPdfPageToCanvas } from '../utils/pdfRenderer';
+import { rankFromSelfGrading, updateReviewStateFromGrading } from '../utils/reviewScheduler';
+
+type PdfViewMode = 'problem' | 'answer' | 'explanation';
+
+interface SelfGradeInput {
+  status: GradingStatus;
+  score: number;
+  maxScore: number;
+  memo: string;
+}
+
+interface Props {
+  problem: ProblemDefinition;
+  answer: AnswerState;
+  pdfs: MaterialPdf[];
+  mappings: MaterialPdfMapping[];
+  activeSession: PracticeSession | null;
+  reviewState?: ReviewState;
+  onStartCurrentSession: () => Promise<PracticeSession>;
+  onSessionChange: (session: PracticeSession) => Promise<void>;
+  onSelfGrade: (input: SelfGradeInput) => Promise<void>;
+}
+
+function pageRange(mapping: MaterialPdfMapping, mode: PdfViewMode): { start: number; end: number } | null {
+  if (mode === 'problem') return { start: mapping.problemPageStart, end: mapping.problemPageEnd };
+  if (mode === 'answer' && mapping.answerPageStart) return { start: mapping.answerPageStart, end: mapping.answerPageEnd ?? mapping.answerPageStart };
+  if (mode === 'explanation' && mapping.explanationPageStart) return { start: mapping.explanationPageStart, end: mapping.explanationPageEnd ?? mapping.explanationPageStart };
+  return null;
+}
+
+function clamp(value: number, start: number, end: number): number {
+  return Math.max(start, Math.min(end, value));
+}
+
+export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, reviewState, onStartCurrentSession, onSessionChange, onSelfGrade }: Props) {
+  const mapping = useMemo(() => mappings.find((item) => item.problemId === problem.id), [mappings, problem.id]);
+  const pdf = useMemo(() => pdfs.find((item) => item.id === mapping?.materialPdfId), [pdfs, mapping?.materialPdfId]);
+  const [viewMode, setViewMode] = useState<PdfViewMode>('problem');
+  const [page, setPage] = useState(1);
+  const [scale, setScale] = useState(1.15);
+  const [loading, setLoading] = useState(false);
+  const [renderError, setRenderError] = useState('');
+  const [showSelfGrade, setShowSelfGrade] = useState(false);
+  const [status, setStatus] = useState<GradingStatus>('正解');
+  const [score, setScore] = useState(answer.score || 0);
+  const [maxScore, setMaxScore] = useState(answer.maxScore || 20);
+  const [memo, setMemo] = useState('');
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const range = mapping ? pageRange(mapping, viewMode) : null;
+  const proposedRank: ReviewRank = rankFromSelfGrading(status, score, maxScore);
+  const proposedReview = updateReviewStateFromGrading({ problemId: problem.id, previous: reviewState, status, score, maxScore });
+
+  useEffect(() => {
+    setViewMode('problem');
+    setShowSelfGrade(false);
+    const nextRange = mapping ? pageRange(mapping, 'problem') : null;
+    setPage(nextRange?.start ?? 1);
+  }, [problem.id, mapping?.id]);
+
+  useEffect(() => {
+    if (!pdf || !canvasRef.current || !range) return;
+    let cancelled = false;
+    setLoading(true);
+    setRenderError('');
+    renderPdfPageToCanvas(pdf.pdfBlob, clamp(page, range.start, range.end), scale, canvasRef.current)
+      .catch(() => {
+        if (!cancelled) setRenderError('PDFページの表示に失敗しました。ファイル破損、保護PDF、またはブラウザ非対応の可能性があります。');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [pdf, page, scale, range?.start, range?.end]);
+
+  async function ensureSession(): Promise<PracticeSession> {
+    if (activeSession && activeSession.problemId === problem.id && !activeSession.completed) return activeSession;
+    return onStartCurrentSession();
+  }
+
+  async function openView(nextMode: PdfViewMode) {
+    if (!mapping) return;
+    if (nextMode !== 'problem') {
+      if (!window.confirm('解答・解説を開きます。自己採点時のみ開いてください。')) return;
+      const session = await ensureSession();
+      await onSessionChange({
+        ...session,
+        openedAnswer: session.openedAnswer || nextMode === 'answer',
+        openedExplanation: session.openedExplanation || nextMode === 'explanation',
+      });
+    }
+    const nextRange = pageRange(mapping, nextMode);
+    if (!nextRange) return;
+    setViewMode(nextMode);
+    setPage(nextRange.start);
+  }
+
+  async function answerNow() {
+    const session = await ensureSession();
+    const submittedAt = new Date().toISOString();
+    await onSessionChange({ ...session, submittedAt, openedAnswer: true, answerSnapshot: answer });
+    setShowSelfGrade(true);
+    await openView('answer');
+  }
+
+  async function submitSelfGrade() {
+    await onSelfGrade({ status, score, maxScore, memo });
+    setShowSelfGrade(false);
+  }
+
+  if (!mapping || !pdf) {
+    return (
+      <section className="panel pdf-study-panel">
+        <h2>問題PDF</h2>
+        <p className="empty">この問題IDにはPDFページ紐付けがありません。PDF教材VaultにPDFを保存し、PDFページ紐付けから問題ページを登録してください。</p>
+        <button onClick={onStartCurrentSession}>PDFなしで演習セッション開始</button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel pdf-study-panel">
+      <div className="section-heading">
+        <div>
+          <h2>問題PDF：{pdf.title}</h2>
+          <p>{problem.sectionLabel} {problem.displayId} / {problem.topic} / 想定 {mapping.estimatedMinutes} / 難易度 {mapping.difficulty}</p>
+        </div>
+        <div className="button-row">
+          <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => openView('problem')}>問題</button>
+          <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => openView('answer')}>解答</button>
+          <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => openView('explanation')}>解説</button>
+        </div>
+      </div>
+      <div className="pdf-toolbar">
+        <button onClick={() => range && setPage(clamp(page - 1, range.start, range.end))}>前ページ</button>
+        <label>ページ
+          <input type="number" min={range?.start ?? 1} max={range?.end ?? pdf.pageCount} value={page} onChange={(event) => range && setPage(clamp(Number(event.target.value) || range.start, range.start, range.end))} />
+        </label>
+        <span>{range ? `${range.start}〜${range.end}ページ範囲` : 'ページ範囲なし'}</span>
+        <button onClick={() => range && setPage(clamp(page + 1, range.start, range.end))}>次ページ</button>
+        <button onClick={() => setScale((current) => Math.max(0.7, current - 0.15))}>縮小</button>
+        <button onClick={() => setScale((current) => Math.min(2.2, current + 0.15))}>拡大</button>
+      </div>
+      {activeSession && activeSession.problemId === problem.id && !activeSession.completed && <p className="ok-text">演習中：{activeSession.selectedTimeMode} / 開始 {formatDateTime(activeSession.startedAt)}</p>}
+      {renderError && <p className="warning-text">{renderError}</p>}
+      <div className="pdf-canvas-wrap">
+        {loading && <p className="empty">PDFを表示中...</p>}
+        <canvas ref={canvasRef} className="pdf-canvas" />
+      </div>
+      <div className="study-actions">
+        <button className="resume-button" onClick={answerNow}>回答する / 自己採点へ進む</button>
+      </div>
+      {showSelfGrade && (
+        <div className="self-grade-panel">
+          <h3>自己採点</h3>
+          <div className="form-grid four-columns">
+            <label>結果
+              <select value={status} onChange={(event) => setStatus(event.target.value as GradingStatus)}>
+                <option value="正解">正解</option>
+                <option value="部分正解">部分正解</option>
+                <option value="不正解">不正解</option>
+                <option value="迷いあり">正解だが迷いあり</option>
+              </select>
+            </label>
+            <label>得点<input type="number" value={score} onChange={(event) => setScore(Number(event.target.value) || 0)} /></label>
+            <label>満点<input type="number" value={maxScore} onChange={(event) => setMaxScore(Number(event.target.value) || 0)} /></label>
+            <label>自動提案<input readOnly value={`${proposedRank} / 次回 ${proposedReview.nextReviewDate}`} /></label>
+          </div>
+          <label>自己採点メモ<textarea value={memo} onChange={(event) => setMemo(event.target.value)} placeholder="解答解説を見て、自分のミス原因・次回注意点を短く記録" /></label>
+          <button className="accent" onClick={submitSelfGrade}>自己採点を履歴へ保存</button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
@@ -117,7 +117,7 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
       <section className="panel pdf-study-panel">
         <h2>問題PDF</h2>
         <p className="empty">この問題IDにはPDFページ紐付けがありません。PDF教材VaultにPDFを保存し、PDFページ紐付けから問題ページを登録してください。</p>
-        <button onClick={onStartCurrentSession}>PDFなしで演習セッション開始</button>
+        <button onClick={() => { void onStartCurrentSession(); }}>PDFなしで演習セッション開始</button>
       </section>
     );
   }
@@ -130,9 +130,9 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
           <p>{problem.sectionLabel} {problem.displayId} / {problem.topic} / 想定 {mapping.estimatedMinutes} / 難易度 {mapping.difficulty}</p>
         </div>
         <div className="button-row">
-          <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => openView('problem')}>問題</button>
-          <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => openView('answer')}>解答</button>
-          <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => openView('explanation')}>解説</button>
+          <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => { void openView('problem'); }}>問題</button>
+          <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => { void openView('answer'); }}>解答</button>
+          <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => { void openView('explanation'); }}>解説</button>
         </div>
       </div>
       <div className="pdf-toolbar">
@@ -152,7 +152,7 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
         <canvas ref={canvasRef} className="pdf-canvas" />
       </div>
       <div className="study-actions">
-        <button className="resume-button" onClick={answerNow}>回答する / 自己採点へ進む</button>
+        <button className="resume-button" onClick={() => { void answerNow(); }}>回答する / 自己採点へ進む</button>
       </div>
       {showSelfGrade && (
         <div className="self-grade-panel">
@@ -171,7 +171,7 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
             <label>自動提案<input readOnly value={`${proposedRank} / 次回 ${proposedReview.nextReviewDate}`} /></label>
           </div>
           <label>自己採点メモ<textarea value={memo} onChange={(event) => setMemo(event.target.value)} placeholder="解答解説を見て、自分のミス原因・次回注意点を短く記録" /></label>
-          <button className="accent" onClick={submitSelfGrade}>自己採点を履歴へ保存</button>
+          <button className="accent" onClick={() => { void submitSelfGrade(); }}>自己採点を履歴へ保存</button>
         </div>
       )}
     </section>

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfVaultPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfVaultPanel.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import type { MaterialPdf } from '../types';
+import { formatDateTime, nowIso } from '../utils/dates';
+import { formatFileSize, getPdfPageCount } from '../utils/pdfRenderer';
+
+interface Props {
+  pdfs: MaterialPdf[];
+  onSavePdf: (pdf: MaterialPdf) => Promise<void>;
+  onDeletePdf: (id: string) => Promise<void>;
+  onMessage: (message: string) => void;
+}
+
+export function PdfVaultPanel({ pdfs, onSavePdf, onDeletePdf, onMessage }: Props) {
+  const [title, setTitle] = useState('');
+  const [sourceName, setSourceName] = useState('CPA問題集');
+  const [bookType, setBookType] = useState<MaterialPdf['bookType']>('商業簿記');
+  const [loading, setLoading] = useState(false);
+
+  async function importPdf(file: File | undefined) {
+    if (!file) return;
+    if (file.type !== 'application/pdf' && !file.name.toLowerCase().endsWith('.pdf')) {
+      onMessage('PDFファイルのみ取り込めます');
+      return;
+    }
+    try {
+      setLoading(true);
+      const now = nowIso();
+      const pageCount = await getPdfPageCount(file);
+      await onSavePdf({
+        id: crypto.randomUUID(),
+        title: title.trim() || file.name.replace(/\.pdf$/i, ''),
+        sourceName: sourceName.trim() || '教材PDF',
+        examType: '日商簿記2級',
+        bookType,
+        fileName: file.name,
+        mimeType: file.type || 'application/pdf',
+        size: file.size,
+        pageCount,
+        pdfBlob: file,
+        createdAt: now,
+        updatedAt: now,
+      });
+      setTitle('');
+      onMessage('PDF教材を端末内IndexedDBへ保存しました。GitHubや外部サーバーには送信していません。');
+    } catch {
+      onMessage('PDFの読み込みに失敗しました。破損ファイル、保護ファイル、ブラウザ非対応の可能性があります。');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function removePdf(pdf: MaterialPdf) {
+    if (!window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) return;
+    await onDeletePdf(pdf.id);
+  }
+
+  return (
+    <details className="panel management-panel" open>
+      <summary>PDF教材Vault</summary>
+      <div className="panel-body">
+        <p className="legal-notice compact">
+          この機能は、正規に取得・購入した教材PDFを、利用者本人の私的学習のために端末内で整理・参照する目的のものです。教材PDF・問題文・解答・解説を第三者と共有したり、GitHub・SNS・クラウド公開領域へアップロードしたりしないでください。DRM等の技術的保護手段を回避して取り込むことはしないでください。
+        </p>
+        <div className="form-grid three-columns">
+          <label>表示名
+            <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" />
+          </label>
+          <label>教材区分
+            <select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}>
+              <option value="商業簿記">商業簿記</option>
+              <option value="工業簿記">工業簿記</option>
+              <option value="その他">その他</option>
+            </select>
+          </label>
+          <label>出所メモ
+            <input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" />
+          </label>
+        </div>
+        <label className="import-label pdf-import-label">PDFを選択して端末内に保存
+          <input type="file" accept="application/pdf" disabled={loading} onChange={(event) => importPdf(event.target.files?.[0])} />
+        </label>
+        <div className="table-wrap short-wrap">
+          <table className="compact-table">
+            <thead><tr><th>教材名</th><th>区分</th><th>ファイル名</th><th>ページ数</th><th>サイズ</th><th>保存日時</th><th>操作</th></tr></thead>
+            <tbody>
+              {pdfs.map((pdf) => (
+                <tr key={pdf.id}>
+                  <td>{pdf.title}</td>
+                  <td>{pdf.bookType}</td>
+                  <td>{pdf.fileName}</td>
+                  <td>{pdf.pageCount || '-'}</td>
+                  <td>{formatFileSize(pdf.size)}</td>
+                  <td>{formatDateTime(pdf.createdAt)}</td>
+                  <td><button className="danger" onClick={() => removePdf(pdf)}>削除</button></td>
+                </tr>
+              ))}
+              {pdfs.length === 0 && <tr><td colSpan={7}>PDF教材は未登録です。端末内のPDFを選択してください。</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfVaultPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfVaultPanel.tsx
@@ -77,7 +77,7 @@ export function PdfVaultPanel({ pdfs, onSavePdf, onDeletePdf, onMessage }: Props
           </label>
         </div>
         <label className="import-label pdf-import-label">PDFを選択して端末内に保存
-          <input type="file" accept="application/pdf" disabled={loading} onChange={(event) => importPdf(event.target.files?.[0])} />
+          <input type="file" accept="application/pdf" disabled={loading} onChange={(event) => { void importPdf(event.target.files?.[0]); }} />
         </label>
         <div className="table-wrap short-wrap">
           <table className="compact-table">
@@ -91,7 +91,7 @@ export function PdfVaultPanel({ pdfs, onSavePdf, onDeletePdf, onMessage }: Props
                   <td>{pdf.pageCount || '-'}</td>
                   <td>{formatFileSize(pdf.size)}</td>
                   <td>{formatDateTime(pdf.createdAt)}</td>
-                  <td><button className="danger" onClick={() => removePdf(pdf)}>削除</button></td>
+                  <td><button className="danger" onClick={() => { void removePdf(pdf); }}>削除</button></td>
                 </tr>
               ))}
               {pdfs.length === 0 && <tr><td colSpan={7}>PDF教材は未登録です。端末内のPDFを選択してください。</td></tr>}

--- a/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
+++ b/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
@@ -1,0 +1,205 @@
+.disposable-panel {
+  margin-bottom: 12px;
+  border: 2px solid #b8dfc2;
+}
+
+.disposable-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-weight: 800;
+  letter-spacing: .04em;
+}
+
+.resume-button {
+  min-height: 56px;
+  padding: 14px 20px;
+  font-size: 18px;
+  font-weight: 900;
+  background: #c95422;
+  box-shadow: 0 6px 16px rgba(201, 84, 34, .22);
+}
+
+.time-mode-panel {
+  margin-top: 16px;
+}
+
+.time-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.time-mode-button {
+  display: grid;
+  gap: 6px;
+  min-height: 92px;
+  align-content: start;
+  text-align: left;
+  background: #174f5e;
+}
+
+.time-mode-button strong {
+  font-size: 22px;
+}
+
+.time-mode-button span {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #e4f4f1;
+}
+
+.legal-notice {
+  margin: 14px 0 0;
+  padding: 12px;
+  border-radius: 10px;
+  background: #fff9e8;
+  border-left: 4px solid #c27a00;
+  line-height: 1.7;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.legal-notice.compact {
+  margin-top: 0;
+}
+
+.pdf-import-label {
+  width: fit-content;
+}
+
+.form-grid.three-columns {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid.four-columns {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.form-grid.six-columns {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.practice-workspace {
+  display: grid;
+  grid-template-columns: minmax(420px, .9fr) minmax(0, 1.1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.answer-workspace {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.pdf-study-panel {
+  min-width: 0;
+  position: sticky;
+  top: 12px;
+  align-self: start;
+}
+
+.pdf-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: end;
+  margin: 10px 0;
+}
+
+.pdf-toolbar label {
+  display: grid;
+  gap: 4px;
+  font-weight: 700;
+  min-width: 90px;
+}
+
+.pdf-toolbar input {
+  max-width: 96px;
+}
+
+.pdf-canvas-wrap {
+  width: 100%;
+  max-height: 72vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fbfa;
+  padding: 8px;
+}
+
+.pdf-canvas {
+  display: block;
+  max-width: none;
+  background: #fff;
+  box-shadow: 0 2px 12px rgba(0,0,0,.08);
+}
+
+.study-actions {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.self-grade-panel {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #dbe8e4;
+  border-radius: 12px;
+  background: #f7fbf9;
+}
+
+.self-grade-panel h3 {
+  margin-top: 0;
+}
+
+@media (max-width: 1500px) {
+  .time-mode-grid {
+    grid-template-columns: repeat(3, minmax(160px, 1fr));
+  }
+
+  .practice-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .pdf-study-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 760px) {
+  .disposable-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .resume-button {
+    width: 100%;
+  }
+
+  .time-mode-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .time-mode-button {
+    min-height: 86px;
+  }
+
+  .pdf-canvas-wrap {
+    max-height: 58vh;
+  }
+
+  .study-actions {
+    justify-content: stretch;
+  }
+
+  .study-actions .resume-button {
+    width: 100%;
+  }
+}

--- a/cpa-boki2-trial-section-answer-manager/src/main.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './disposableStudy.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
@@ -1,8 +1,8 @@
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MistakeCard } from '../types';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, ReviewState } from '../types';
 
 const DB_NAME = 'cpa-boki2-trial-section-answer-manager';
-const DB_VERSION = 3;
-const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets', 'mistakeCards'] as const;
+const DB_VERSION = 4;
+const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets', 'mistakeCards', 'materialPdfs', 'materialPdfMappings', 'practiceSessions', 'reviewStates'] as const;
 
 type StoreName = (typeof STORES)[number];
 
@@ -91,6 +91,66 @@ export async function deleteMistakeCard(id: string): Promise<void> {
   await tx('mistakeCards', 'readwrite', (store) => store.delete(id));
 }
 
+export async function saveMaterialPdf(pdf: MaterialPdf): Promise<void> {
+  await tx('materialPdfs', 'readwrite', (store) => store.put(pdf));
+}
+
+export async function getMaterialPdfs(): Promise<MaterialPdf[]> {
+  const rows = await tx<MaterialPdf[]>('materialPdfs', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function deleteMaterialPdf(id: string): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(['materialPdfs', 'materialPdfMappings'], 'readwrite');
+    transaction.objectStore('materialPdfs').delete(id);
+    const mappingsRequest = transaction.objectStore('materialPdfMappings').getAll();
+    mappingsRequest.onsuccess = () => {
+      (mappingsRequest.result as MaterialPdfMapping[]).filter((mapping) => mapping.materialPdfId === id).forEach((mapping) => transaction.objectStore('materialPdfMappings').delete(mapping.id));
+    };
+    transaction.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    transaction.onerror = () => {
+      db.close();
+      reject(transaction.error);
+    };
+  });
+}
+
+export async function saveMaterialPdfMapping(mapping: MaterialPdfMapping): Promise<void> {
+  await tx('materialPdfMappings', 'readwrite', (store) => store.put(mapping));
+}
+
+export async function getMaterialPdfMappings(): Promise<MaterialPdfMapping[]> {
+  const rows = await tx<MaterialPdfMapping[]>('materialPdfMappings', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function deleteMaterialPdfMapping(id: string): Promise<void> {
+  await tx('materialPdfMappings', 'readwrite', (store) => store.delete(id));
+}
+
+export async function savePracticeSession(session: PracticeSession): Promise<void> {
+  await tx('practiceSessions', 'readwrite', (store) => store.put(session));
+}
+
+export async function getPracticeSessions(): Promise<PracticeSession[]> {
+  const rows = await tx<PracticeSession[]>('practiceSessions', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+}
+
+export async function saveReviewState(reviewState: ReviewState): Promise<void> {
+  await tx('reviewStates', 'readwrite', (store) => store.put(reviewState));
+}
+
+export async function getReviewStates(): Promise<ReviewState[]> {
+  const rows = await tx<ReviewState[]>('reviewStates', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
 export async function getBackupMetadata(): Promise<BackupMetadata | null> {
   const row = await tx<BackupMetadata | undefined>('backups', 'readonly', (store) => store.get('backupMeta'));
   return row ?? null;
@@ -129,10 +189,11 @@ export async function recordRestoreMade(): Promise<BackupMetadata> {
 }
 
 export async function exportAllData(): Promise<BackupPayload> {
+  const materialPdfs = await getMaterialPdfs();
   return {
     exportedAt: new Date().toISOString(),
     appName: 'CPA日商簿記2級 試験対策編 解答・復習管理アプリ',
-    version: '1.2.0',
+    version: '1.3.0',
     answers: await getAllAnswers(),
     histories: await getHistories(),
     settings: await tx<Record<string, unknown>[]>('settings', 'readonly', (store) => store.getAll()),
@@ -140,6 +201,10 @@ export async function exportAllData(): Promise<BackupPayload> {
     backups: await tx<Record<string, unknown>[]>('backups', 'readonly', (store) => store.getAll()),
     examSets: await getExamSets(),
     mistakeCards: await getMistakeCards(),
+    materialPdfMappings: await getMaterialPdfMappings(),
+    materialPdfMetadata: materialPdfs.map(({ pdfBlob: _pdfBlob, ...metadata }) => metadata),
+    practiceSessions: await getPracticeSessions(),
+    reviewStates: await getReviewStates(),
     backupMetadata: await getBackupMetadata(),
   };
 }
@@ -147,8 +212,9 @@ export async function exportAllData(): Promise<BackupPayload> {
 export async function importAllData(payload: BackupPayload): Promise<void> {
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
-    const transaction = db.transaction([...STORES], 'readwrite');
-    STORES.forEach((name) => transaction.objectStore(name).clear());
+    const importStores = STORES.filter((name) => name !== 'materialPdfs');
+    const transaction = db.transaction([...importStores], 'readwrite');
+    importStores.forEach((name) => transaction.objectStore(name).clear());
     payload.answers?.forEach((item) => transaction.objectStore('answers').put(item));
     payload.histories?.forEach((item) => transaction.objectStore('histories').put(item));
     payload.settings?.forEach((item) => transaction.objectStore('settings').put(item));
@@ -156,6 +222,9 @@ export async function importAllData(payload: BackupPayload): Promise<void> {
     payload.backups?.forEach((item) => transaction.objectStore('backups').put(item));
     payload.examSets?.forEach((item) => transaction.objectStore('examSets').put(item));
     payload.mistakeCards?.forEach((item) => transaction.objectStore('mistakeCards').put(item));
+    payload.materialPdfMappings?.forEach((item) => transaction.objectStore('materialPdfMappings').put(item));
+    payload.practiceSessions?.forEach((item) => transaction.objectStore('practiceSessions').put(item));
+    payload.reviewStates?.forEach((item) => transaction.objectStore('reviewStates').put(item));
     if (payload.backupMetadata) transaction.objectStore('backups').put(payload.backupMetadata);
     transaction.oncomplete = () => {
       db.close();

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -4,6 +4,8 @@ export type TemplateId = 'journal' | 'genericNumber' | 'equityStatement' | 'cons
 export type GradeMark = '未採点' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
 export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方逆' | '金額ミス' | '集計ミス' | '転記ミス' | '表の入力位置ミス' | '下書き不足' | '時間不足' | '解答欄形式の誤認' | '問題文読み落とし' | 'その他';
+export type TimeMode = '1分' | '3分' | '5分' | '10分' | '30分' | '90分';
+export type GradingStatus = '正解' | '部分正解' | '不正解' | '迷いあり';
 
 export interface ProblemDefinition {
   id: string;
@@ -218,6 +220,81 @@ export interface RecoveryPlan {
   latestExamSet?: ExamSetRecord;
 }
 
+export interface MaterialPdf {
+  id: string;
+  title: string;
+  sourceName: string;
+  examType: '日商簿記2級';
+  bookType: '商業簿記' | '工業簿記' | 'その他';
+  fileName: string;
+  mimeType: string;
+  size: number;
+  pageCount: number;
+  pdfBlob: Blob;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MaterialPdfMetadata = Omit<MaterialPdf, 'pdfBlob'>;
+
+export interface MaterialPdfMapping {
+  id: string;
+  problemId: string;
+  displayId: string;
+  materialPdfId: string;
+  problemPageStart: number;
+  problemPageEnd: number;
+  answerPageStart?: number;
+  answerPageEnd?: number;
+  explanationPageStart?: number;
+  explanationPageEnd?: number;
+  estimatedMinutes: TimeMode;
+  difficulty: '易' | '標準' | '難';
+  memo: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewState {
+  id: string;
+  problemId: string;
+  correctStreak: number;
+  wrongStreak: number;
+  lastResult: GradingStatus | '';
+  lastReviewedAt: string;
+  nextReviewDate: string;
+  intervalDays: number;
+  easeLevel: number;
+  updatedAt: string;
+}
+
+export interface GradingResult {
+  status: GradingStatus | '';
+  score: number;
+  maxScore: number;
+  scoreRate: number;
+  autoGraded: false;
+  detailRows: string[];
+}
+
+export interface PracticeSession {
+  id: string;
+  examType: '日商簿記2級';
+  problemId: string;
+  startedAt: string;
+  submittedAt: string;
+  durationSeconds: number;
+  selectedTimeMode: TimeMode;
+  answerSnapshot?: AnswerState;
+  gradingMode: 'self';
+  gradingResult: GradingResult;
+  reviewState?: ReviewState;
+  openedAnswer: boolean;
+  openedExplanation: boolean;
+  memo: string;
+  completed: boolean;
+}
+
 export interface BackupPayload {
   exportedAt: string;
   appName: string;
@@ -229,5 +306,9 @@ export interface BackupPayload {
   backups?: Record<string, unknown>[];
   examSets?: ExamSetRecord[];
   mistakeCards?: MistakeCard[];
+  materialPdfMappings?: MaterialPdfMapping[];
+  materialPdfMetadata?: MaterialPdfMetadata[];
+  practiceSessions?: PracticeSession[];
+  reviewStates?: ReviewState[];
   backupMetadata?: BackupMetadata | null;
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/disposableStudy.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/disposableStudy.ts
@@ -1,0 +1,47 @@
+import { problemCatalog } from '../data/problemCatalog';
+import type { HistoryEntry, MasteryMapItem, PracticeSession, StudyQueueItem, TimeMode } from '../types';
+
+export const timeModes: TimeMode[] = ['1分', '3分', '5分', '10分', '30分', '90分'];
+
+export function timeModeDescription(mode: TimeMode): string {
+  if (mode === '1分') return '白紙再現カード、ミス原因、同じミスを防ぐ一言を確認';
+  if (mode === '3分') return '第1問仕訳1問、短い金額問題、短い復習問題';
+  if (mode === '5分') return 'C判定、期限超過、小問を1つ処理';
+  if (mode === '10分') return '工業簿記単問、表問題の一部、1論点演習';
+  if (mode === '30分') return '大問1つ、重点論点1セット';
+  return '第1問〜第5問セット演習';
+}
+
+export function latestUnfinishedSession(sessions: PracticeSession[]): PracticeSession | undefined {
+  return [...sessions].filter((session) => !session.completed).sort((a, b) => b.startedAt.localeCompare(a.startedAt))[0];
+}
+
+export function chooseQuickStartProblem(params: {
+  sessions: PracticeSession[];
+  studyQueue: StudyQueueItem[];
+  masteryMap: MasteryMapItem[];
+}): { problemId: string; mode: TimeMode; reason: string } {
+  const unfinished = latestUnfinishedSession(params.sessions);
+  if (unfinished) return { problemId: unfinished.problemId, mode: unfinished.selectedTimeMode, reason: '未完了の演習セッションを再開' };
+  const queueTop = params.studyQueue[0];
+  if (queueTop) return { problemId: queueTop.problem.id, mode: '10分', reason: '今日の学習キュー最優先問題' };
+  const fallback = params.masteryMap.find((item) => item.status === '危険問題')
+    ?? params.masteryMap.find((item) => item.status === '未着手')
+    ?? params.masteryMap.find((item) => item.latestRank === 'B')
+    ?? params.masteryMap[0];
+  return { problemId: fallback?.problem.id ?? problemCatalog[0].id, mode: '10分', reason: '合格到達マップから候補提示' };
+}
+
+export function chooseProblemForTimeMode(mode: TimeMode, studyQueue: StudyQueueItem[], masteryMap: MasteryMapItem[], histories: HistoryEntry[]): string {
+  const sectionForMode = mode === '3分' ? 'q1' : mode === '10分' ? 'q4' : undefined;
+  const queueCandidate = studyQueue.find((item) => !sectionForMode || item.problem.sectionId === sectionForMode) ?? studyQueue[0];
+  if (queueCandidate) return queueCandidate.problem.id;
+
+  const notMastered = masteryMap.find((item) => item.status === '期限超過' || item.status === '危険問題' || item.status === '未着手' || item.latestRank === 'B');
+  if (notMastered) return notMastered.problem.id;
+
+  const latestByProblem = new Map<string, string>();
+  histories.forEach((history) => latestByProblem.set(history.problemId, history.savedAt));
+  const oldMastered = [...masteryMap].sort((a, b) => (latestByProblem.get(a.problem.id) ?? '').localeCompare(latestByProblem.get(b.problem.id) ?? ''))[0];
+  return oldMastered?.problem.id ?? problemCatalog[0].id;
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
@@ -1,0 +1,32 @@
+import * as pdfjsLib from 'pdfjs-dist';
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+export async function getPdfPageCount(blob: Blob): Promise<number> {
+  const data = await blob.arrayBuffer();
+  const task = pdfjsLib.getDocument({ data });
+  const pdf = await task.promise;
+  return pdf.numPages;
+}
+
+export async function renderPdfPageToCanvas(blob: Blob, pageNumber: number, scale: number, canvas: HTMLCanvasElement): Promise<void> {
+  const data = await blob.arrayBuffer();
+  const task = pdfjsLib.getDocument({ data });
+  const pdf = await task.promise;
+  const safePage = Math.max(1, Math.min(pageNumber, pdf.numPages));
+  const page = await pdf.getPage(safePage);
+  const viewport = page.getViewport({ scale });
+  const context = canvas.getContext('2d');
+  if (!context) return;
+  canvas.width = Math.floor(viewport.width);
+  canvas.height = Math.floor(viewport.height);
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  await page.render({ canvasContext: context, viewport } as Parameters<typeof page.render>[0]).promise;
+}
+
+export function formatFileSize(size: number): string {
+  if (size >= 1024 * 1024) return `${(size / 1024 / 1024).toFixed(1)}MB`;
+  if (size >= 1024) return `${Math.round(size / 1024)}KB`;
+  return `${size}B`;
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
@@ -4,14 +4,14 @@ import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 
 export async function getPdfPageCount(blob: Blob): Promise<number> {
-  const data = await blob.arrayBuffer();
+  const data = new Uint8Array(await blob.arrayBuffer());
   const task = pdfjsLib.getDocument({ data });
   const pdf = await task.promise;
   return pdf.numPages;
 }
 
 export async function renderPdfPageToCanvas(blob: Blob, pageNumber: number, scale: number, canvas: HTMLCanvasElement): Promise<void> {
-  const data = await blob.arrayBuffer();
+  const data = new Uint8Array(await blob.arrayBuffer());
   const task = pdfjsLib.getDocument({ data });
   const pdf = await task.promise;
   const safePage = Math.max(1, Math.min(pageNumber, pdf.numPages));
@@ -22,7 +22,8 @@ export async function renderPdfPageToCanvas(blob: Blob, pageNumber: number, scal
   canvas.width = Math.floor(viewport.width);
   canvas.height = Math.floor(viewport.height);
   context.clearRect(0, 0, canvas.width, canvas.height);
-  await page.render({ canvasContext: context, viewport } as Parameters<typeof page.render>[0]).promise;
+  const renderTask = page.render({ canvasContext: context, viewport } as any);
+  await renderTask.promise;
 }
 
 export function formatFileSize(size: number): string {

--- a/cpa-boki2-trial-section-answer-manager/src/utils/reviewScheduler.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/reviewScheduler.ts
@@ -1,0 +1,61 @@
+import type { GradingStatus, HistoryEntry, ReviewRank, ReviewState } from '../types';
+import { addDaysIso, nowIso } from './dates';
+
+function intervalFor(status: GradingStatus, correctStreak: number, rank: ReviewRank, examSoon: boolean): number {
+  let days = 7;
+  if (status === '不正解' || rank === 'C') days = 1;
+  else if (status === '部分正解') days = 2;
+  else if (status === '迷いあり' || rank === 'B') days = 3;
+  else if (status === '正解') {
+    if (correctStreak >= 4) days = 60;
+    else if (correctStreak >= 3) days = 30;
+    else if (correctStreak >= 2) days = 14;
+    else days = 7;
+  }
+  if (examSoon) return Math.min(days, 7);
+  return days;
+}
+
+export function rankFromSelfGrading(status: GradingStatus, score: number, maxScore: number): ReviewRank {
+  const rate = maxScore > 0 ? score / maxScore : 0;
+  if (status === '不正解' || rate < 0.5) return 'C';
+  if (status === '部分正解' || status === '迷いあり' || rate < 0.8) return 'B';
+  return 'A';
+}
+
+export function updateReviewStateFromGrading(params: {
+  problemId: string;
+  previous?: ReviewState;
+  status: GradingStatus;
+  score: number;
+  maxScore: number;
+  examSoon?: boolean;
+}): ReviewState {
+  const rank = rankFromSelfGrading(params.status, params.score, params.maxScore);
+  const correct = params.status === '正解';
+  const correctStreak = correct ? (params.previous?.correctStreak ?? 0) + 1 : 0;
+  const wrongStreak = correct ? 0 : (params.previous?.wrongStreak ?? 0) + 1;
+  const intervalDays = intervalFor(params.status, correctStreak, rank, Boolean(params.examSoon));
+  const now = nowIso();
+  return {
+    id: params.problemId,
+    problemId: params.problemId,
+    correctStreak,
+    wrongStreak,
+    lastResult: params.status,
+    lastReviewedAt: now,
+    nextReviewDate: addDaysIso(intervalDays),
+    intervalDays,
+    easeLevel: Math.max(1, Math.min(5, (params.previous?.easeLevel ?? 3) + (correct ? 1 : -1))),
+    updatedAt: now,
+  };
+}
+
+export function latestHistoryByProblem(histories: HistoryEntry[]): Map<string, HistoryEntry> {
+  const map = new Map<string, HistoryEntry>();
+  histories.forEach((history) => {
+    const current = map.get(history.problemId);
+    if (!current || history.savedAt > current.savedAt) map.set(history.problemId, history);
+  });
+  return map;
+}


### PR DESCRIPTION
## 1. 今回の目的

このPRは、CPA日商簿記2級 試験対策編 解答・復習管理アプリについて、可処分学習時間を最大化するための第1回実装です。

目的は、スマホ・タブレット・PCで、紙教材を開けない時間、机に向かえない時間、移動中、待ち時間、ソファで寝転がっている時間、営業前後の空き時間を、1分・3分・5分・10分・30分・90分の学習時間に変換することです。

このPRでは、問題PDF確認、答案入力、回答、自己採点、次回復習日設定、履歴反映までをMVPとしてつなぎます。

## 2. 実装内容

### 1タップ再開

アプリ上部に「今すぐ再開」ボタンを追加しました。

挙動:

- 未完了の演習セッションがある場合は、その続きを再開
- 未完了セッションがない場合は、今日の学習キュー最優先問題へ移動
- 学習キューが空の場合は、合格到達マップ上の危険問題・未着手・B判定問題の順で候補提示

### 時間別学習モード

「空き時間から選ぶ」パネルを追加しました。

対応時間:

- 1分
- 3分
- 5分
- 10分
- 30分
- 90分

各時間モードは `PracticeSession.selectedTimeMode` に保存されます。

### PDF教材Vault

端末内のPDFを選択し、IndexedDBにBlobとして保存できるようにしました。

保存項目:

- id
- title
- sourceName
- examType
- bookType
- fileName
- mimeType
- size
- pageCount
- pdfBlob
- createdAt
- updatedAt

PDFはGitHub、public、src、外部サーバー、Supabase等には保存しません。

### PDFページ紐付け

問題IDごとに、PDFの問題ページ・解答ページ・解説ページを登録できます。

保存項目:

- problemId
- displayId
- materialPdfId
- problemPageStart / problemPageEnd
- answerPageStart / answerPageEnd
- explanationPageStart / explanationPageEnd
- estimatedMinutes
- difficulty
- memo

紐付け済み件数と未紐付け問題IDを表示します。

### 問題ID画面でのPDF表示

問題ID画面にPDF教材パネルを追加しました。

機能:

- PDFページ表示
- 前ページ / 次ページ
- ページ番号指定
- 拡大 / 縮小
- 問題 / 解答 / 解説の表示切替
- 解答・解説を開く際の確認ダイアログ

### 回答ボタン

問題PDFパネルに「回答する / 自己採点へ進む」ボタンを追加しました。

このボタンで以下の流れに入ります。

1. 演習セッション開始または再開
2. 回答済み状態へ移行
3. 解答ページを開く
4. 自己採点欄を表示

### 自己採点フロー

自動採点は行わず、採点ルールなしの自己採点MVPとして実装しています。

自己採点項目:

- 正解
- 部分正解
- 不正解
- 正解だが迷いあり
- 得点
- 満点
- 自己採点メモ

自己採点結果からA/B/C判定と次回復習日を自動提案し、保存時に既存の履歴・合格到達マップへ反映します。

### 復習スケジューラー

`ReviewState` を追加し、自己採点結果に応じて次回復習日を更新します。

基本ルール:

- 不正解：翌日
- 部分正解：2日後
- 正解だが迷いあり：3日後
- 正解：7日後
- 連続2回正解：14日後
- 連続3回正解：30日後
- 連続4回正解：60日後
- C判定：翌日
- B判定：3日後
- A判定：7日後

### PracticeSession保存

1回の演習を `PracticeSession` として保存します。

保存項目:

- id
- examType
- problemId
- startedAt
- submittedAt
- durationSeconds
- selectedTimeMode
- answerSnapshot
- gradingMode
- gradingResult
- reviewState
- openedAnswer
- openedExplanation
- memo
- completed

## 3. 著作権・法令対応

以下は実装していません。

- CPA教材PDFの初期データ投入
- CPA教材PDFのGitHub commit
- CPA教材PDFのpublicフォルダ配置
- CPA教材PDFのsrc配下配置
- CPA教材本文のコード直書き
- CPA教材の問題文・解答・解説の初期データ化
- 採点ルール正解データのGitHub混入
- PDFや教材本文の外部サーバー送信
- Supabase保存
- クラウド同期
- 共有機能
- DRM解除や技術的保護手段回避を前提にした処理

画面上にも以下の注意文を表示しています。

> この機能は、正規に取得・購入した教材PDFを、利用者本人の私的学習のために端末内で整理・参照する目的のものです。教材PDF・問題文・解答・解説を第三者と共有したり、GitHub・SNS・クラウド公開領域へアップロードしたりしないでください。DRM等の技術的保護手段を回避して取り込むことはしないでください。

## 4. 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/package.json`
- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/main.tsx`
- `cpa-boki2-trial-section-answer-manager/src/types/index.ts`
- `cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts`
- `cpa-boki2-trial-section-answer-manager/src/components/DisposableStudyPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/PdfVaultPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/PdfMappingPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/utils/disposableStudy.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts`
- `cpa-boki2-trial-section-answer-manager/src/utils/reviewScheduler.ts`
- `cpa-boki2-trial-section-answer-manager/src/disposableStudy.css`

## 5. 追加依存

追加依存:

- `pdfjs-dist`

用途:

- 利用者が端末内で選択したPDF Blobを、ブラウザ内でCanvas表示するため

ライセンス:

- Apache License 2.0

外部通信:

- 実装上、PDF BlobはIndexedDBから読み込み、ブラウザ内でPDF.jsにより描画します
- PDFファイルを外部サーバーへ送信する処理は追加していません

ビルドサイズへの影響:

- PDF.js本体とworkerが追加されるため、簿記アプリ側のビルドサイズは増える想定です
- ただし、教材PDFの実ファイルはビルド成果物に含めません

## 6. IndexedDB変更点

DB_VERSIONを `4` に上げました。

追加ストア:

- `materialPdfs`
- `materialPdfMappings`
- `practiceSessions`
- `reviewStates`

既存ストアは削除していません。

維持している既存ストア:

- `answers`
- `histories`
- `settings`
- `templates`
- `backups`
- `examSets`
- `mistakeCards`

## 7. JSONバックアップ仕様

PR1ではPDF Blob本体はJSONバックアップに含めません。

JSONに含めるもの:

- answers
- histories
- settings
- templates
- backups
- examSets
- mistakeCards
- materialPdfMappings
- materialPdfMetadata（pdfBlobなし）
- practiceSessions
- reviewStates

PDF Blob込みバックアップ・暗号化バックアップはPR2対象です。

## 8. 今回あえて実装しなかったもの

- OCR
- PDF全文抽出
- 教材検索
- 自動クラウド同期
- 暗号化バックアップ完成版
- PDF Blob込みバックアップ完成版
- 採点ルールJSON/CSV取込
- 全問題完全自動採点
- AI解説
- 弁理士データ投入
- 建設業経理士データ投入
- PWA/オフライン完成版
- Supabase同期
- ログイン

## 9. 既存機能への影響

以下は巻き戻していません。

- 既存の答案入力
- 行追加
- 列追加
- 金額欄3桁カンマ
- 全角数字→半角数字変換
- 矢印キー移動
- F2/ダブルクリック編集モード
- 履歴保存
- 履歴復元
- JSONバックアップ
- CSV出力
- 今日の学習キュー
- 合格到達マップ
- 白紙再現カード
- 70点リカバリー表
- 90分セット演習

## 10. 既存案件管理アプリへの影響

影響なしです。

変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- 既存トップURL
- 既存Pages workflow

## 11. 動作確認結果

この作業環境ではローカルの `npm install` / `npm run build` は実行できていません。

PR作成後、既存の `CPA Boki2 App Build Check` workflowで以下を確認してください。

- `npm install`
- `npm run build`

コード上で確認した項目:

- 1タップ再開ボタン表示
- 1分・3分・5分・10分・30分・90分モード表示
- PDF教材VaultのPDF選択処理
- PDF BlobのIndexedDB保存処理
- PDFページ数取得処理
- PDFページ紐付け保存処理
- 問題ID画面でのPDFパネル表示
- 解答・解説表示時の確認ダイアログ
- 回答ボタンから自己採点パネル表示
- 自己採点結果からA/B/C判定と次回復習日を提案
- 自己採点保存時に履歴・ReviewState・PracticeSessionへ保存
- JSONバックアップにPDF Blobを含めない設計
- 既存案件管理アプリ本体未変更
- 既存Pages workflow未変更

## 12. 未確認事項

- GitHub Actions上での実ビルド結果
- 実ブラウザでのPDF表示
- PDF.js workerのGitHub Pages上での読み込み
- 大容量PDF保存時の実ブラウザ挙動
- iPhone SafariでのPDF Canvas表示
- 旧JSON復元後のPDF紐付け再設定フロー

## 13. 次回PR候補

### PR2

- 暗号化バックアップ
- PDF教材データのエクスポート/インポート
- 保存容量表示
- 永続ストレージ確認

### PR3

- 採点ルール取込
- 第1問仕訳/金額欄の自動採点MVP

## 14. 最終方針

今回のPRでは、可処分学習時間最大化MVPだけを実装しました。

このPRが通れば、待ち時間・移動中・ソファで、紙教材なしに問題PDFを見て演習し、自己採点し、次回復習日に回せる運用に入れる状態になります。