### PR TITLE
Redesign CPA Boki2 study UI into focused modes

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -7,10 +7,9 @@ import { ExamSetPanel } from './components/ExamSetPanel';
 import { ExampleGuide } from './components/ExampleGuide';
 import { HistoryPanel } from './components/HistoryPanel';
 import { MasteryMapPanel } from './components/MasteryMapPanel';
+import { MaterialSetupWorkspace } from './components/MaterialSetupWorkspace';
 import { MistakeCardPanel } from './components/MistakeCardPanel';
-import { PdfMappingPanel } from './components/PdfMappingPanel';
 import { PdfStudyPanel } from './components/PdfStudyPanel';
-import { PdfVaultPanel } from './components/PdfVaultPanel';
 import { ProblemSelector } from './components/ProblemSelector';
 import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
@@ -60,6 +59,8 @@ import { buildStudyQueue } from './utils/studyQueue';
 import './styles.css';
 
 type HistoryFilter = 'all' | 'today' | 'overdue' | 'c' | 'b';
+type AppMode = 'study' | 'grading' | 'materials' | 'progress';
+type StudyView = 'problem' | 'answer' | 'grading';
 
 function createAnswer(problemId: string, templateId: TemplateId): AnswerState {
   const template = getTemplateById(templateId);
@@ -162,6 +163,8 @@ export default function App() {
   const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
   const [historyFilter, setHistoryFilter] = useState<HistoryFilter>('all');
+  const [mode, setMode] = useState<AppMode>('study');
+  const [studyView, setStudyView] = useState<StudyView>('answer');
 
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
@@ -175,6 +178,12 @@ export default function App() {
     const quickProblem = getProblemById(quickChoice.problemId);
     return `推奨：${quickProblem.sectionLabel} ${quickProblem.displayId} ${quickProblem.topic}（${quickChoice.reason}）`;
   }, [quickChoice]);
+  const progressSummary = useMemo(() => ({
+    dueToday: studyQueue.filter((item) => item.statusLabels.includes('今日復習')).length,
+    overdue: studyQueue.filter((item) => item.statusLabels.includes('期限超過')).length,
+    cRank: masteryMap.filter((item) => item.latestRank === 'C' || item.status === '危険問題').length,
+    untouched: masteryMap.filter((item) => item.status === '未着手').length,
+  }), [studyQueue, masteryMap]);
 
   async function refreshAnswers() {
     setAnswers((await getAllAnswers()).map(normalizeAnswer));
@@ -280,13 +289,15 @@ export default function App() {
     };
   }
 
-  async function beginPractice(problemIdForSession: string, mode: TimeMode, reason: string): Promise<PracticeSession> {
-    const session = await createPracticeSession(problemIdForSession, mode);
+  async function beginPractice(problemIdForSession: string, selectedTimeMode: TimeMode, reason: string): Promise<PracticeSession> {
+    const session = await createPracticeSession(problemIdForSession, selectedTimeMode);
     await savePracticeSession(session);
     setActiveSessionId(session.id);
     await loadProblem(problemIdForSession);
     await refreshAll();
-    setMessage(`${mode}モードで演習開始：${getProblemById(problemIdForSession).displayId}（${reason}）`);
+    setMode('study');
+    setStudyView('answer');
+    setMessage(`${selectedTimeMode}モードで演習開始：${getProblemById(problemIdForSession).displayId}（${reason}）`);
     return session;
   }
 
@@ -295,15 +306,17 @@ export default function App() {
     if (unfinished) {
       setActiveSessionId(unfinished.id);
       await loadProblem(unfinished.problemId);
+      setMode('study');
+      setStudyView('answer');
       setMessage(`未完了セッションを再開しました：${getProblemById(unfinished.problemId).displayId}`);
       return;
     }
     await beginPractice(quickChoice.problemId, quickChoice.mode, quickChoice.reason);
   }
 
-  async function selectTimeMode(mode: TimeMode) {
-    const selectedProblemId = chooseProblemForTimeMode(mode, studyQueue, masteryMap, histories);
-    await beginPractice(selectedProblemId, mode, '空き時間から選択');
+  async function selectTimeMode(timeMode: TimeMode) {
+    const selectedProblemId = chooseProblemForTimeMode(timeMode, studyQueue, masteryMap, histories);
+    await beginPractice(selectedProblemId, timeMode, '空き時間から選択');
   }
 
   async function startCurrentSession(): Promise<PracticeSession> {
@@ -344,9 +357,7 @@ export default function App() {
       setMessage('履歴追加できる保存済み答案がありません');
       return;
     }
-    for (const item of rows) {
-      await addHistory(buildHistory(item));
-    }
+    for (const item of rows) await addHistory(buildHistory(item));
     await refreshAll();
     setMessage(`保存済み答案 ${rows.length}件を一括で履歴追加しました`);
   };
@@ -406,6 +417,7 @@ export default function App() {
     await savePracticeSession(completedSession);
     setAnswer(scored);
     setActiveSessionId('');
+    setMode('progress');
     await refreshAll();
     setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
   }
@@ -416,6 +428,8 @@ export default function App() {
     await saveAnswer(restored);
     setProblemId(entry.problemId);
     setAnswer(restored);
+    setMode('study');
+    setStudyView('answer');
     await refreshAll();
     setMessage('履歴を復元しました');
   };
@@ -533,69 +547,149 @@ export default function App() {
     setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。');
   };
 
+  const openNextProblem = async () => {
+    const next = studyQueue[0]?.problem.id ?? quickChoice.problemId;
+    await loadProblem(next);
+    setMode('study');
+    setStudyView('answer');
+  };
+
   return (
-    <main className="app-shell">
-      <header className="app-header">
+    <main className="app-shell redesigned-shell">
+      <header className="app-header compact-header">
         <div>
           <h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1>
-          <p>このアプリは自動採点ではありません。問題文・解答・解説はアプリ内に保存しません。紙教材・PDF・CPA画面を見ながら答案を入力し、解答解説を見ながら自己採点してください。</p>
+          <p>問題を見る → 答案を書く → 回答する → 解答/解説を見る → 自己採点する → 次回復習へ回す、の流れに集中する画面です。</p>
         </div>
         <Timer />
       </header>
 
+      <nav className="mode-nav" aria-label="学習モード切替">
+        <button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button>
+        <button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button>
+        <button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button>
+        <button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button>
+      </nav>
+
       <div className="status-bar">{message}</div>
 
-      <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
-
-      <div className="top-actions">
-        <button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button>
-        <button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button>
-        <button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button>
-        <button onClick={exportHistoryCsv}>履歴一覧CSV</button>
-        <button onClick={exportReviewCsv}>復習対象CSV</button>
-        <button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button>
-        <button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button>
-        <button onClick={exportJson}>JSONバックアップ</button>
-        <label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label>
-        <button onClick={() => window.print()}>印刷</button>
-      </div>
-
-      <section className="management-stack">
-        <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
-        <PdfVaultPanel pdfs={materialPdfs} onSavePdf={savePdf} onDeletePdf={removePdf} onMessage={setMessage} />
-        <PdfMappingPanel pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSave={savePdfMapping} onDelete={removePdfMapping} onOpenProblem={loadProblem} />
-        <MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} />
-        <RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} />
-        <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
-        <DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} />
-        <ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} />
-      </section>
-
-      <div className="main-grid">
-        <ProblemSelector selectedProblem={problem} selectedTemplateId={answer.templateId} onSelectProblem={loadProblem} onSelectTemplate={selectTemplate} />
-
-        <section className="center-column">
-          <section className="panel problem-info">
-            <h2>{problem.sectionLabel} {problem.displayId}</h2>
-            <p><strong>{problem.topic}</strong></p>
-            <p>使用テンプレート：{answer.templateName}</p>
+      {mode === 'study' && (
+        <section className="mode-section study-mode-section">
+          <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
+          <section className="study-problem-strip panel mode-card">
+            <div>
+              <p className="eyebrow">今解く問題</p>
+              <h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2>
+              <p>想定時間：{pdfMappings.find((item) => item.problemId === problem.id)?.estimatedMinutes ?? '未設定'} / 難易度：{pdfMappings.find((item) => item.problemId === problem.id)?.difficulty ?? '未設定'} / テンプレート：{answer.templateName}</p>
+            </div>
+            <button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button>
           </section>
-          <MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} />
-          <div className="practice-workspace">
-            <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} />
-            <div className="answer-workspace">
+          <div className="mobile-study-tabs">
+            <button className={studyView === 'problem' ? 'active' : ''} onClick={() => setStudyView('problem')}>問題</button>
+            <button className={studyView === 'answer' ? 'active' : ''} onClick={() => setStudyView('answer')}>答案</button>
+            <button onClick={() => { setMode('grading'); setStudyView('grading'); }}>採点</button>
+          </div>
+          <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}>
+            <div className="study-pdf-column">
+              <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} />
+            </div>
+            <div className="answer-main-column">
               <ExampleGuide template={template} />
               <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
             </div>
           </div>
-          <HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} />
         </section>
+      )}
 
-        <aside className="right-column">
-          <ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} />
-          <ReviewPanel histories={histories} />
-        </aside>
-      </div>
+      {mode === 'grading' && (
+        <section className="mode-section grading-mode-section">
+          <section className="panel mode-card study-problem-strip">
+            <div>
+              <p className="eyebrow">採点する</p>
+              <h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2>
+              <p>回答後だけ、解答・解説PDFと自己採点欄を表示します。</p>
+            </div>
+            <button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button>
+          </section>
+          <div className="grading-layout">
+            <div className="grading-answer-column">
+              <h2>自分の答案</h2>
+              <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
+            </div>
+            <div className="grading-pdf-column">
+              <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} />
+              <ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} />
+            </div>
+          </div>
+        </section>
+      )}
+
+      {mode === 'materials' && (
+        <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />
+      )}
+
+      {mode === 'progress' && (
+        <section className="mode-section progress-mode-section">
+          <section className="panel mode-card progress-overview-panel">
+            <div>
+              <p className="eyebrow">復習・進捗を見る</p>
+              <h2>今日の判断だけを先に表示</h2>
+              <p>詳細な履歴、CSV、バックアップ、白紙再現、70点リカバリーは下のカードを開いた時だけ表示します。</p>
+            </div>
+            <div className="progress-summary-grid">
+              <div><strong>{progressSummary.dueToday}</strong><span>今日やるべき問題</span></div>
+              <div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div>
+              <div><strong>{progressSummary.cRank}</strong><span>C判定・危険問題</span></div>
+              <div><strong>{progressSummary.untouched}</strong><span>未着手</span></div>
+            </div>
+            <button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button>
+          </section>
+
+          <details className="panel management-panel" open>
+            <summary>今日の復習・期限超過・C/B判定</summary>
+            <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
+          </details>
+          <details className="panel management-panel">
+            <summary>合格到達マップ</summary>
+            <MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} />
+          </details>
+          <details className="panel management-panel">
+            <summary>白紙再現カード</summary>
+            <MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} />
+          </details>
+          <details className="panel management-panel">
+            <summary>70点リカバリー表・90分セット</summary>
+            <RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} />
+            <ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} />
+          </details>
+          <details className="panel management-panel">
+            <summary>履歴一覧・復習管理</summary>
+            <ReviewPanel histories={histories} />
+            <HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} />
+          </details>
+          <details className="panel management-panel">
+            <summary>CSV出力・JSONバックアップ・保存状態</summary>
+            <div className="top-actions management-actions">
+              <button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button>
+              <button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button>
+              <button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button>
+              <button onClick={exportHistoryCsv}>履歴一覧CSV</button>
+              <button onClick={exportReviewCsv}>復習対象CSV</button>
+              <button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button>
+              <button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button>
+              <button onClick={exportDashboardCsv}>ダッシュボードCSV</button>
+              <button onClick={exportExamSetCsv}>90分セットCSV</button>
+              <button onClick={exportMasteryCsv}>合格到達マップCSV</button>
+              <button onClick={exportRecoveryCsv}>70点リカバリーCSV</button>
+              <button onClick={exportJson}>JSONバックアップ</button>
+              <label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label>
+              <button onClick={() => window.print()}>印刷</button>
+            </div>
+            <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
+            <DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} />
+          </details>
+        </section>
+      )}
     </main>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { problemCatalog } from '../data/problemCatalog';
+import type { MaterialPdf, MaterialPdfMapping, TimeMode } from '../types';
+import { nowIso } from '../utils/dates';
+import { timeModes } from '../utils/disposableStudy';
+import { formatFileSize, getPdfPageCount, renderPdfPageToCanvas } from '../utils/pdfRenderer';
+
+interface Props {
+  pdfs: MaterialPdf[];
+  mappings: MaterialPdfMapping[];
+  selectedProblemId: string;
+  onSavePdf: (pdf: MaterialPdf) => Promise<void>;
+  onDeletePdf: (id: string) => Promise<void>;
+  onSaveMapping: (mapping: MaterialPdfMapping) => Promise<void>;
+  onDeleteMapping: (id: string) => Promise<void>;
+  onOpenProblem: (problemId: string) => void | Promise<void>;
+  onMessage: (message: string) => void;
+}
+
+type RangeKind = 'problem' | 'answer' | 'explanation';
+
+function blankMapping(problemId: string, pdfId = ''): MaterialPdfMapping {
+  const problem = problemCatalog.find((item) => item.id === problemId) ?? problemCatalog[0];
+  const now = nowIso();
+  return {
+    id: crypto.randomUUID(),
+    problemId: problem.id,
+    displayId: problem.displayId,
+    materialPdfId: pdfId,
+    problemPageStart: 1,
+    problemPageEnd: 1,
+    answerPageStart: undefined,
+    answerPageEnd: undefined,
+    explanationPageStart: undefined,
+    explanationPageEnd: undefined,
+    estimatedMinutes: '10分',
+    difficulty: '標準',
+    memo: '',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function numberOrUndefined(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSavePdf, onDeletePdf, onSaveMapping, onDeleteMapping, onOpenProblem, onMessage }: Props) {
+  const [title, setTitle] = useState('');
+  const [sourceName, setSourceName] = useState('CPA問題集');
+  const [bookType, setBookType] = useState<MaterialPdf['bookType']>('商業簿記');
+  const [selectedPdfId, setSelectedPdfId] = useState(pdfs[0]?.id ?? '');
+  const [draft, setDraft] = useState<MaterialPdfMapping>(() => blankMapping(selectedProblemId, pdfs[0]?.id ?? ''));
+  const [previewKind, setPreviewKind] = useState<RangeKind>('problem');
+  const [page, setPage] = useState(1);
+  const [scale, setScale] = useState(1.05);
+  const [loading, setLoading] = useState(false);
+  const [renderError, setRenderError] = useState('');
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const selectedPdf = useMemo(() => pdfs.find((pdf) => pdf.id === selectedPdfId) ?? pdfs[0], [pdfs, selectedPdfId]);
+  const mappedProblemIds = useMemo(() => new Set(mappings.map((mapping) => mapping.problemId)), [mappings]);
+  const unmapped = problemCatalog.filter((problem) => !mappedProblemIds.has(problem.id));
+  const mapped = problemCatalog.filter((problem) => mappedProblemIds.has(problem.id));
+
+  useEffect(() => {
+    if (!selectedPdfId && pdfs[0]) setSelectedPdfId(pdfs[0].id);
+  }, [pdfs, selectedPdfId]);
+
+  useEffect(() => {
+    const existing = mappings.find((mapping) => mapping.problemId === selectedProblemId) ?? blankMapping(selectedProblemId, selectedPdf?.id ?? '');
+    setDraft({ ...existing, materialPdfId: existing.materialPdfId || selectedPdf?.id || '' });
+    setSelectedPdfId(existing.materialPdfId || selectedPdf?.id || '');
+  }, [selectedProblemId, mappings, selectedPdf?.id]);
+
+  const activeRange = (() => {
+    if (previewKind === 'answer' && draft.answerPageStart) return { start: draft.answerPageStart, end: draft.answerPageEnd ?? draft.answerPageStart };
+    if (previewKind === 'explanation' && draft.explanationPageStart) return { start: draft.explanationPageStart, end: draft.explanationPageEnd ?? draft.explanationPageStart };
+    return { start: draft.problemPageStart, end: draft.problemPageEnd };
+  })();
+
+  useEffect(() => {
+    if (!selectedPdf || !canvasRef.current) return;
+    let cancelled = false;
+    setLoading(true);
+    setRenderError('');
+    const safePage = Math.max(1, Math.min(page, selectedPdf.pageCount || page));
+    renderPdfPageToCanvas(selectedPdf.pdfBlob, safePage, scale, canvasRef.current)
+      .catch(() => {
+        if (!cancelled) setRenderError('PDFページの表示に失敗しました。保護PDF、破損ファイル、またはブラウザ非対応の可能性があります。');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [selectedPdf, page, scale]);
+
+  useEffect(() => {
+    setPage(activeRange.start || 1);
+  }, [previewKind, draft.problemPageStart, draft.answerPageStart, draft.explanationPageStart]);
+
+  function update(patch: Partial<MaterialPdfMapping>) {
+    const nextProblemId = patch.problemId ?? draft.problemId;
+    const problem = problemCatalog.find((item) => item.id === nextProblemId) ?? problemCatalog[0];
+    setDraft((current) => ({ ...current, ...patch, problemId: nextProblemId, displayId: problem.displayId, updatedAt: nowIso() }));
+  }
+
+  async function importPdf(file: File | undefined) {
+    if (!file) return;
+    if (file.type !== 'application/pdf' && !file.name.toLowerCase().endsWith('.pdf')) {
+      onMessage('PDFファイルのみ取り込めます');
+      return;
+    }
+    try {
+      const now = nowIso();
+      const pageCount = await getPdfPageCount(file);
+      const pdf: MaterialPdf = {
+        id: crypto.randomUUID(),
+        title: title.trim() || file.name.replace(/\.pdf$/i, ''),
+        sourceName: sourceName.trim() || '教材PDF',
+        examType: '日商簿記2級',
+        bookType,
+        fileName: file.name,
+        mimeType: file.type || 'application/pdf',
+        size: file.size,
+        pageCount,
+        pdfBlob: file,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await onSavePdf(pdf);
+      setSelectedPdfId(pdf.id);
+      setDraft((current) => ({ ...current, materialPdfId: pdf.id }));
+      setTitle('');
+      onMessage('PDFを端末内IndexedDBへ保存しました。続けてページを見ながら問題IDへ紐づけてください。');
+    } catch {
+      onMessage('PDFの読み込みに失敗しました。破損ファイル、保護PDF、ブラウザ非対応の可能性があります。');
+    }
+  }
+
+  async function saveMapping() {
+    if (!draft.materialPdfId) {
+      onMessage('先に対象PDFを選択してください');
+      return;
+    }
+    await onSaveMapping({ ...draft, updatedAt: nowIso() });
+  }
+
+  function jumpToRange(kind: RangeKind) {
+    setPreviewKind(kind);
+    if (kind === 'answer' && draft.answerPageStart) setPage(draft.answerPageStart);
+    else if (kind === 'explanation' && draft.explanationPageStart) setPage(draft.explanationPageStart);
+    else setPage(draft.problemPageStart);
+  }
+
+  return (
+    <section className="material-setup-grid">
+      <div className="panel setup-control-panel mode-card">
+        <p className="eyebrow">教材を設定する</p>
+        <h2>PDFを見ながらページ範囲を登録</h2>
+        <p className="notice-small">PDF本体・教材本文・解答解説はGitHubや外部サーバーへ送信しません。利用者本人の端末内IndexedDBに保存します。</p>
+
+        <div className="form-grid three-columns">
+          <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
+          <label>教材区分
+            <select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}>
+              <option value="商業簿記">商業簿記</option>
+              <option value="工業簿記">工業簿記</option>
+              <option value="その他">その他</option>
+            </select>
+          </label>
+          <label>出所メモ<input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" /></label>
+        </div>
+        <label className="import-label pdf-import-label">PDFを選択してプレビュー
+          <input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} />
+        </label>
+
+        <div className="form-grid two-columns">
+          <label>対象PDF
+            <select value={draft.materialPdfId || selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); update({ materialPdfId: event.target.value }); }}>
+              <option value="">PDFを選択</option>
+              {pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P）</option>)}
+            </select>
+          </label>
+          <label>問題ID
+            <select value={draft.problemId} onChange={(event) => { const existing = mappings.find((mapping) => mapping.problemId === event.target.value); setDraft(existing ?? blankMapping(event.target.value, draft.materialPdfId || selectedPdfId)); }}>
+              {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}
+            </select>
+          </label>
+        </div>
+
+        <div className="form-grid six-columns">
+          <label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label>
+          <label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label>
+          <label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label>
+          <label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label>
+          <label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label>
+          <label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label>
+        </div>
+
+        <div className="form-grid three-columns">
+          <label>想定時間
+            <select value={draft.estimatedMinutes} onChange={(event) => update({ estimatedMinutes: event.target.value as TimeMode })}>
+              {timeModes.map((mode) => <option key={mode} value={mode}>{mode}</option>)}
+            </select>
+          </label>
+          <label>難易度
+            <select value={draft.difficulty} onChange={(event) => update({ difficulty: event.target.value as MaterialPdfMapping['difficulty'] })}>
+              <option value="易">易</option><option value="標準">標準</option><option value="難">難</option>
+            </select>
+          </label>
+          <label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れない" /></label>
+        </div>
+
+        <div className="button-row sticky-actions">
+          <button className="accent" onClick={() => { void saveMapping(); }}>この問題IDに紐づけて保存</button>
+          <button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>この問題を開く</button>
+        </div>
+      </div>
+
+      <div className="panel setup-preview-panel mode-card">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">プレビュー：{previewKind === 'answer' ? '解答' : previewKind === 'explanation' ? '解説' : '問題'}</p>
+            <h2>{selectedPdf ? selectedPdf.title : 'PDF未選択'}</h2>
+            {selectedPdf && <p>{selectedPdf.fileName} / {selectedPdf.pageCount}P / {formatFileSize(selectedPdf.size)}</p>}
+          </div>
+          <div className="button-row">
+            <button className={previewKind === 'problem' ? 'accent' : 'secondary'} onClick={() => jumpToRange('problem')}>問題</button>
+            <button className={previewKind === 'answer' ? 'accent' : 'secondary'} disabled={!draft.answerPageStart} onClick={() => jumpToRange('answer')}>解答</button>
+            <button className={previewKind === 'explanation' ? 'accent' : 'secondary'} disabled={!draft.explanationPageStart} onClick={() => jumpToRange('explanation')}>解説</button>
+          </div>
+        </div>
+        <div className="pdf-toolbar">
+          <button disabled={!selectedPdf} onClick={() => setPage((current) => Math.max(1, current - 1))}>前ページ</button>
+          <label>ページ<input type="number" min="1" max={selectedPdf?.pageCount ?? 1} value={page} onChange={(event) => setPage(Math.max(1, Number(event.target.value) || 1))} /></label>
+          <span>登録範囲：{activeRange.start}〜{activeRange.end}ページ</span>
+          <button disabled={!selectedPdf} onClick={() => setPage((current) => Math.min(selectedPdf?.pageCount ?? current + 1, current + 1))}>次ページ</button>
+          <button onClick={() => setScale((current) => Math.max(0.7, current - 0.15))}>縮小</button>
+          <button onClick={() => setScale((current) => Math.min(2.2, current + 0.15))}>拡大</button>
+        </div>
+        {renderError && <p className="warning-text">{renderError}</p>}
+        <div className="pdf-canvas-wrap setup-canvas-wrap">
+          {!selectedPdf && <p className="empty">左側からPDFを選択してください。</p>}
+          {loading && <p className="empty">PDFを表示中...</p>}
+          <canvas ref={canvasRef} className="pdf-canvas" />
+        </div>
+      </div>
+
+      <details className="panel mapping-list-panel" open>
+        <summary>保存済みマッピング / 設定状況</summary>
+        <div className="panel-body">
+          <div className="progress-summary-grid">
+            <div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div>
+            <div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div>
+            <div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div>
+          </div>
+          <div className="table-wrap short-wrap">
+            <table className="compact-table">
+              <thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>操作</th></tr></thead>
+              <tbody>
+                {mappings.map((mapping) => {
+                  const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
+                  const pdf = pdfs.find((item) => item.id === mapping.materialPdfId);
+                  return (
+                    <tr key={mapping.id}>
+                      <td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td>
+                      <td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td>
+                      <td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td>
+                      <td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td>
+                      <td><button onClick={() => { setDraft(mapping); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td>
+                    </tr>
+                  );
+                })}
+                {mappings.length === 0 && <tr><td colSpan={7}>まだページ紐付けがありません。</td></tr>}
+              </tbody>
+            </table>
+          </div>
+          {unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}
+        </div>
+      </details>
+
+      <details className="panel mapping-list-panel">
+        <summary>PDF教材データの削除</summary>
+        <div className="panel-body">
+          <div className="table-wrap short-wrap">
+            <table className="compact-table">
+              <thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead>
+              <tbody>
+                {pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}
+                {pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
@@ -5,6 +5,7 @@ import { renderPdfPageToCanvas } from '../utils/pdfRenderer';
 import { rankFromSelfGrading, updateReviewStateFromGrading } from '../utils/reviewScheduler';
 
 type PdfViewMode = 'problem' | 'answer' | 'explanation';
+type StudyPanelMode = 'study' | 'grading';
 
 interface SelfGradeInput {
   status: GradingStatus;
@@ -20,9 +21,11 @@ interface Props {
   mappings: MaterialPdfMapping[];
   activeSession: PracticeSession | null;
   reviewState?: ReviewState;
+  panelMode?: StudyPanelMode;
   onStartCurrentSession: () => Promise<PracticeSession>;
   onSessionChange: (session: PracticeSession) => Promise<void>;
   onSelfGrade: (input: SelfGradeInput) => Promise<void>;
+  onRequestGrading?: () => void;
 }
 
 function pageRange(mapping: MaterialPdfMapping, mode: PdfViewMode): { start: number; end: number } | null {
@@ -32,35 +35,43 @@ function pageRange(mapping: MaterialPdfMapping, mode: PdfViewMode): { start: num
   return null;
 }
 
+function viewLabel(mode: PdfViewMode): string {
+  if (mode === 'answer') return '解答';
+  if (mode === 'explanation') return '解説';
+  return '問題';
+}
+
 function clamp(value: number, start: number, end: number): number {
   return Math.max(start, Math.min(end, value));
 }
 
-export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, reviewState, onStartCurrentSession, onSessionChange, onSelfGrade }: Props) {
+export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, reviewState, panelMode = 'study', onStartCurrentSession, onSessionChange, onSelfGrade, onRequestGrading }: Props) {
   const mapping = useMemo(() => mappings.find((item) => item.problemId === problem.id), [mappings, problem.id]);
   const pdf = useMemo(() => pdfs.find((item) => item.id === mapping?.materialPdfId), [pdfs, mapping?.materialPdfId]);
-  const [viewMode, setViewMode] = useState<PdfViewMode>('problem');
+  const [viewMode, setViewMode] = useState<PdfViewMode>(panelMode === 'grading' ? 'answer' : 'problem');
   const [page, setPage] = useState(1);
-  const [scale, setScale] = useState(1.15);
+  const [scale, setScale] = useState(panelMode === 'grading' ? 1.05 : 1.15);
   const [loading, setLoading] = useState(false);
   const [renderError, setRenderError] = useState('');
-  const [showSelfGrade, setShowSelfGrade] = useState(false);
+  const [showSelfGrade, setShowSelfGrade] = useState(panelMode === 'grading');
   const [status, setStatus] = useState<GradingStatus>('正解');
   const [score, setScore] = useState(answer.score || 0);
   const [maxScore, setMaxScore] = useState(answer.maxScore || 20);
-  const [memo, setMemo] = useState('');
+  const [memo, setMemo] = useState(answer.reviewMemo || '');
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const range = mapping ? pageRange(mapping, viewMode) : null;
+  const safeViewMode = panelMode === 'study' ? 'problem' : viewMode;
+  const range = mapping ? pageRange(mapping, safeViewMode) : null;
   const proposedRank: ReviewRank = rankFromSelfGrading(status, score, maxScore);
   const proposedReview = updateReviewStateFromGrading({ problemId: problem.id, previous: reviewState, status, score, maxScore });
 
   useEffect(() => {
-    setViewMode('problem');
-    setShowSelfGrade(false);
-    const nextRange = mapping ? pageRange(mapping, 'problem') : null;
+    const nextMode: PdfViewMode = panelMode === 'grading' && mapping?.answerPageStart ? 'answer' : 'problem';
+    setViewMode(nextMode);
+    setShowSelfGrade(panelMode === 'grading');
+    const nextRange = mapping ? pageRange(mapping, nextMode) : null;
     setPage(nextRange?.start ?? 1);
-  }, [problem.id, mapping?.id]);
+  }, [problem.id, mapping?.id, panelMode]);
 
   useEffect(() => {
     if (!pdf || !canvasRef.current || !range) return;
@@ -84,8 +95,8 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
 
   async function openView(nextMode: PdfViewMode) {
     if (!mapping) return;
+    if (panelMode === 'study' && nextMode !== 'problem') return;
     if (nextMode !== 'problem') {
-      if (!window.confirm('解答・解説を開きます。自己採点時のみ開いてください。')) return;
       const session = await ensureSession();
       await onSessionChange({
         ...session,
@@ -102,9 +113,8 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
   async function answerNow() {
     const session = await ensureSession();
     const submittedAt = new Date().toISOString();
-    await onSessionChange({ ...session, submittedAt, openedAnswer: true, answerSnapshot: answer });
-    setShowSelfGrade(true);
-    await openView('answer');
+    await onSessionChange({ ...session, submittedAt, openedAnswer: false, answerSnapshot: answer });
+    onRequestGrading?.();
   }
 
   async function submitSelfGrade() {
@@ -114,26 +124,29 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
 
   if (!mapping || !pdf) {
     return (
-      <section className="panel pdf-study-panel">
+      <section className="panel pdf-study-panel mode-card">
         <h2>問題PDF</h2>
-        <p className="empty">この問題IDにはPDFページ紐付けがありません。PDF教材VaultにPDFを保存し、PDFページ紐付けから問題ページを登録してください。</p>
+        <p className="empty">この問題IDにはPDFページ紐付けがありません。「教材を設定する」からPDFを開き、問題・解答・解説ページを登録してください。</p>
         <button onClick={() => { void onStartCurrentSession(); }}>PDFなしで演習セッション開始</button>
       </section>
     );
   }
 
   return (
-    <section className="panel pdf-study-panel">
+    <section className={`panel pdf-study-panel mode-card pdf-${panelMode}`}>
       <div className="section-heading">
         <div>
-          <h2>問題PDF：{pdf.title}</h2>
+          <p className="eyebrow">現在表示：{viewLabel(safeViewMode)}ページ</p>
+          <h2>{panelMode === 'grading' ? '解答・解説PDF' : '問題PDF'}：{pdf.title}</h2>
           <p>{problem.sectionLabel} {problem.displayId} / {problem.topic} / 想定 {mapping.estimatedMinutes} / 難易度 {mapping.difficulty}</p>
         </div>
-        <div className="button-row">
-          <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => { void openView('problem'); }}>問題</button>
-          <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => { void openView('answer'); }}>解答</button>
-          <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => { void openView('explanation'); }}>解説</button>
-        </div>
+        {panelMode === 'grading' && (
+          <div className="button-row">
+            <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => { void openView('answer'); }}>解答</button>
+            <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => { void openView('explanation'); }}>解説</button>
+            <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => { void openView('problem'); }}>問題を確認</button>
+          </div>
+        )}
       </div>
       <div className="pdf-toolbar">
         <button onClick={() => range && setPage(clamp(page - 1, range.start, range.end))}>前ページ</button>
@@ -151,10 +164,12 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
         {loading && <p className="empty">PDFを表示中...</p>}
         <canvas ref={canvasRef} className="pdf-canvas" />
       </div>
-      <div className="study-actions">
-        <button className="resume-button" onClick={() => { void answerNow(); }}>回答する / 自己採点へ進む</button>
-      </div>
-      {showSelfGrade && (
+      {panelMode === 'study' && (
+        <div className="study-actions">
+          <button className="resume-button" onClick={() => { void answerNow(); }}>回答する / 自己採点へ進む</button>
+        </div>
+      )}
+      {panelMode === 'grading' && showSelfGrade && (
         <div className="self-grade-panel">
           <h3>自己採点</h3>
           <div className="form-grid four-columns">

--- a/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
+++ b/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
@@ -86,13 +86,7 @@
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
-.practice-workspace {
-  display: grid;
-  grid-template-columns: minmax(420px, .9fr) minmax(0, 1.1fr);
-  gap: 16px;
-  align-items: start;
-}
-
+.practice-workspace,
 .answer-workspace {
   display: grid;
   gap: 16px;
@@ -101,8 +95,6 @@
 
 .pdf-study-panel {
   min-width: 0;
-  position: sticky;
-  top: 12px;
   align-self: start;
 }
 
@@ -160,22 +152,249 @@
   margin-top: 0;
 }
 
+.redesigned-shell {
+  max-width: 1880px;
+}
+
+.compact-header {
+  margin-bottom: 10px;
+}
+
+.mode-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
+  gap: 8px;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, .96);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .08);
+}
+
+.mode-nav button {
+  min-height: 52px;
+  font-size: 16px;
+  font-weight: 900;
+  background: #ebf3f1;
+  color: #143a40;
+}
+
+.mode-nav button.active {
+  background: #0f5c68;
+  color: #fff;
+}
+
+.mode-section {
+  display: grid;
+  gap: 14px;
+}
+
+.mode-card {
+  border: 1px solid #d6e4e1;
+  box-shadow: 0 6px 18px rgba(23, 79, 94, .08);
+}
+
+.study-problem-strip {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.mobile-study-tabs {
+  display: none;
+}
+
+.focused-study-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 26%) minmax(0, 74%);
+  gap: 16px;
+  align-items: start;
+}
+
+.focused-study-layout.show-pdf {
+  grid-template-columns: minmax(520px, 54%) minmax(0, 46%);
+}
+
+.study-pdf-column {
+  min-width: 0;
+}
+
+.study-pdf-column .pdf-study-panel {
+  position: sticky;
+  top: 88px;
+}
+
+.answer-main-column {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.focused-study-layout.show-answer .study-pdf-column .pdf-canvas-wrap {
+  max-height: 38vh;
+}
+
+.focused-study-layout.show-answer .answer-main-column {
+  font-size: 1.02rem;
+}
+
+.focused-study-layout.show-answer .answer-main-column .panel,
+.grading-answer-column .panel {
+  border: 2px solid #b8dfc2;
+}
+
+.grading-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 58%) minmax(420px, 42%);
+  gap: 16px;
+  align-items: start;
+}
+
+.grading-answer-column,
+.grading-pdf-column {
+  min-width: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.material-setup-grid {
+  display: grid;
+  grid-template-columns: minmax(420px, .95fr) minmax(520px, 1.05fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.setup-control-panel,
+.setup-preview-panel {
+  min-width: 0;
+}
+
+.setup-preview-panel {
+  position: sticky;
+  top: 88px;
+}
+
+.setup-canvas-wrap {
+  max-height: 76vh;
+}
+
+.mapping-list-panel {
+  grid-column: 1 / -1;
+}
+
+.progress-overview-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(460px, auto);
+  gap: 18px;
+  align-items: center;
+}
+
+.progress-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.progress-summary-grid div {
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border-radius: 14px;
+  background: #f2f8f6;
+  border: 1px solid #d8e8e4;
+}
+
+.progress-summary-grid strong {
+  font-size: 28px;
+  color: #0f5c68;
+}
+
+.progress-summary-grid span {
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.management-panel > summary,
+.mapping-list-panel > summary {
+  cursor: pointer;
+  font-weight: 900;
+  font-size: 18px;
+  padding: 8px 0;
+}
+
+.management-actions {
+  margin-top: 8px;
+}
+
+.sticky-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  padding: 10px 0;
+  background: linear-gradient(180deg, rgba(255,255,255,.75), #fff 35%);
+}
+
 @media (max-width: 1500px) {
   .time-mode-grid {
     grid-template-columns: repeat(3, minmax(160px, 1fr));
   }
 
-  .practice-workspace {
+  .focused-study-layout,
+  .focused-study-layout.show-pdf,
+  .grading-layout,
+  .material-setup-grid,
+  .progress-overview-panel {
     grid-template-columns: 1fr;
   }
 
-  .pdf-study-panel {
+  .study-pdf-column .pdf-study-panel,
+  .setup-preview-panel {
     position: static;
   }
 }
 
+@media (max-width: 900px) {
+  .mode-nav {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .mobile-study-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    position: sticky;
+    top: 86px;
+    z-index: 15;
+    padding: 8px;
+    border-radius: 14px;
+    background: rgba(255,255,255,.96);
+    box-shadow: 0 4px 14px rgba(0,0,0,.08);
+  }
+
+  .mobile-study-tabs button.active {
+    background: #0f5c68;
+  }
+
+  .focused-study-layout.show-answer .study-pdf-column {
+    display: none;
+  }
+
+  .focused-study-layout.show-pdf .answer-main-column {
+    display: none;
+  }
+
+  .progress-summary-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 @media (max-width: 760px) {
-  .disposable-hero {
+  .disposable-hero,
+  .study-problem-strip {
     grid-template-columns: 1fr;
   }
 
@@ -201,5 +420,18 @@
 
   .study-actions .resume-button {
     width: 100%;
+  }
+
+  .mode-nav {
+    grid-template-columns: 1fr;
+    position: static;
+  }
+
+  .mobile-study-tabs {
+    top: 0;
+  }
+
+  .progress-summary-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## 1. 今回の目的

このPRは、PR #236で入れたPDF取込・PDF表示・自己採点・復習管理機能を前提に、CPA日商簿記2級 試験対策編 解答・復習管理アプリの画面設計を再構築するものです。

今回の目的は機能追加ではなく、実際の学習時に迷わないUIへ整理することです。

最優先方針:

- 1画面に全機能を並べない
- 答案入力テーブルを主役に戻す
- 学習中は「問題を見る → 答案を書く → 回答する → 解答/解説を見る → 自己採点する → 次回復習へ回す」の流れだけに集中する
- PDF取込後、PDFを確認しながら問題・解答・解説ページ範囲を問題IDに紐づけられるようにする
- 管理系機能は初期表示から退避する

## 2. 変更対象ファイル

変更対象はCPA簿記2級アプリ配下のみです。

- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx`
- `cpa-boki2-trial-section-answer-manager/src/disposableStudy.css`

## 3. 既存案件管理アプリへの影響

影響なしです。

以下は変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- 既存トップURL

## 4. Pages workflowへの影響

影響なしです。

GitHub Pages workflow、既存Actions設定、既存デプロイ構成は変更していません。

## 5. PDF教材・著作権対応

以下は今回も行っていません。

- CPA教材PDFをGitHubへ保存
- CPA教材PDFをpublic配下へ配置
- CPA教材PDFをsrc配下へ配置
- CPA教材の問題文・解答・解説をコードに埋め込み
- CPAロゴ・教材画像の追加
- 採点ルール正解データのGitHub混入
- Supabase同期
- ログイン機能
- AI解説
- 自動採点
- グラフライブラリ追加

PR #236と同じく、PDFは利用者本人が端末内で選択し、IndexedDB内にBlob保存する設計を維持しています。

## 6. 4モードへの分離

上部に大きなモード切替ナビを追加し、UI表示名を以下に整理しました。

- 今すぐ解く
- 採点する
- 教材を設定する
- 復習・進捗を見る

内部名や技術名はUI上に出していません。

## 7. 今すぐ解くモード

学習時に必要なものだけを表示する構成に変更しました。

表示するもの:

- 現在の問題ID
- 論点名
- 想定時間
- 難易度
- PDF問題ページ
- 答案入力テーブル
- 回答する / 自己採点へ進むボタン
- 必要最小限のタイマー

初期表示から外したもの:

- 履歴一覧
- 合格到達マップ詳細
- 白紙再現カード一覧
- 70点リカバリー表
- PDF Vault
- バックアップ
- CSV出力ボタン群
- 復習キュー詳細

PCでは答案入力テーブルを主役に戻し、答案入力側を広く表示するレイアウトにしています。

スマホ・タブレットでは、PDFと答案入力を無理に同時表示せず、問題・答案・採点の切替導線を設けました。

## 8. 採点するモード

回答後の自己採点に集中する画面へ分離しました。

表示するもの:

- 自分の答案
- 解答PDFページ
- 解説PDFページ
- 自己採点欄
- 正解 / 部分正解 / 不正解 / 正解だが迷いあり
- 得点
- 満点
- 次回復習日提案
- 保存ボタン

学習モードでは解答・解説PDFを常時表示せず、採点モードで解答・解説を確認する流れに整理しています。

## 9. 教材を設定するモード

新しく `MaterialSetupWorkspace` を追加し、PDFを見ながらページ範囲を指定できる専用画面にしました。

実装内容:

1. PDFを選択
2. PDFをアプリ内でプレビュー表示
3. 前ページ / 次ページ / ページ番号指定 / 拡大 / 縮小
4. 問題IDを選択
5. 問題ページ開始・終了を指定
6. 解答ページ開始・終了を指定
7. 解説ページ開始・終了を指定
8. 想定時間・難易度・メモを指定
9. 「この問題IDに紐づけて保存」ボタン
10. 保存済みマッピング一覧
11. 未設定問題ID数・設定済み問題ID数の表示
12. PDF教材データの削除

PDF保存後に保存だけで終わらず、その場でPDFを見ながら問題・解答・解説のページ範囲を登録できる構成にしました。

保存項目はPR #236の `MaterialPdfMapping` 仕様を維持しています。

- problemId
- materialPdfId
- problemPageStart
- problemPageEnd
- answerPageStart
- answerPageEnd
- explanationPageStart
- explanationPageEnd
- estimatedMinutes
- difficulty
- memo
- updatedAt

## 10. 復習・進捗を見るモード

管理系機能をこのモードに集約しました。

初期表示で見せるもの:

- 今日やるべき問題数
- 期限超過数
- C判定・危険問題数
- 未着手数
- 次にやる問題ボタン

詳細はアコーディオンで必要なものだけ開く構成にしています。

集約した機能:

- 今日の復習
- 期限超過
- C判定
- B判定
- 合格到達マップ
- 白紙再現カード
- 70点リカバリー表
- 履歴一覧
- CSV出力
- JSONバックアップ
- 保存状態確認

## 11. 答案入力テーブルが主役に戻っていること

学習モードでは、答案入力テーブルを広く表示するため、PDF・履歴・管理パネルの常時表示をやめました。

維持している答案入力機能:

- 3桁カンマ
- 矢印キー移動
- F2 / ダブルクリック編集
- Escで編集解除
- 行追加
- 列追加
- 空行整理
- 行別採点
- 行別得点合計を問題得点へ反映

## 12. PC・タブレット・スマホの表示方針

### PC

- 学習モードは答案入力テーブルを広く表示
- PDFは左側パネルまたは必要時に開く表示
- 採点モードは答案と解答/解説PDF・自己採点欄を横並び

### タブレット

- 1カラムに落とし、PDFと答案を無理に同時表示しない
- 問題/答案/採点の切替を使いやすくする

### スマホ

- 問題、答案、採点の切替を明確化
- 答案入力時はPDFを隠し、答案入力欄だけに集中
- 管理系機能は復習・進捗モードの奥へ退避

## 13. npm install / npm run build の結果

この作業環境ではローカルの `npm install` / `npm run build` は直接実行していません。

PR作成後、既存の `CPA Boki2 App Build Check` workflowで以下を確認してください。

- `npm install`
- `npm run build`

## 14. GitHub Actions / Pages build の確認方法

PR作成後に以下を確認してください。

- PR Checks の `CPA Boki2 App Build Check`
- GitHub Pages のデプロイ結果
- mainマージ後の公開URL

## 15. 実URLで確認すべき項目

マージ後、実URLで以下を確認してください。

- トップURLでは既存案件管理アプリが開く
- サブURLでは簿記アプリが開く
- 簿記アプリ上部に「今すぐ解く」「採点する」「教材を設定する」「復習・進捗を見る」が表示される
- 今すぐ解く画面では答案入力テーブルが小さくなりすぎない
- PDFは必要時に開閉またはタブ切替できる
- 教材設定画面でPDFを開き、ページを見ながら問題/解答/解説範囲を指定できる
- スマホではPDFと答案入力を無理に同時表示しない
- 履歴や管理系機能が初期画面に出すぎない
- 従来の答案入力、履歴保存、自己採点、復習管理が壊れていない

## 16. 今回あえてやっていないこと

以下は追加していません。

- 自動採点
- AI解説
- Supabase同期
- ログイン
- グラフライブラリ
- 教材本文検索
- OCR
- PDF全文抽出
- 暗号化バックアップ完成版
- PDF Blob込みバックアップ完成版

## 17. 最終方針

今回のPRは、機能追加ではなく「使える学習アプリにするためのUI再設計」です。

PR #236で入った機能を、実際の学習導線に沿って4モードへ分離し、答案入力テーブルを主役に戻すことを目的にしています。