### PR TITLE
Improve CPA Boki2 PDF reader and block answer flow

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AnswerTable, createRows } from './components/AnswerTable';
+import { createRows } from './components/AnswerTable';
 import { BackupSafetyPanel } from './components/BackupSafetyPanel';
 import { DashboardPanel } from './components/DashboardPanel';
 import { DisposableStudyPanel } from './components/DisposableStudyPanel';
@@ -10,6 +10,7 @@ import { MasteryMapPanel } from './components/MasteryMapPanel';
 import { MaterialSetupWorkspace } from './components/MaterialSetupWorkspace';
 import { MistakeCardPanel } from './components/MistakeCardPanel';
 import { PdfStudyPanel } from './components/PdfStudyPanel';
+import { ProblemBlockAnswerPanel } from './components/ProblemBlockAnswerPanel';
 import { ProblemSelector } from './components/ProblemSelector';
 import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
@@ -72,6 +73,7 @@ function createAnswer(problemId: string, templateId: TemplateId): AnswerState {
     templateName: template.name,
     columns: template.columns,
     rows: createRows(template.columns.length, template.initialRows),
+    problemBlocks: [],
     draftMemo: '',
     reviewMemo: '',
     score: 0,
@@ -168,6 +170,7 @@ export default function App() {
 
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
+  const currentMapping = useMemo(() => pdfMappings.find((item) => item.problemId === problemId), [pdfMappings, problemId]);
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
@@ -189,33 +192,13 @@ export default function App() {
     setAnswers((await getAllAnswers()).map(normalizeAnswer));
   }
 
-  async function loadHistories() {
-    setHistories(await getHistories());
-  }
-
-  async function loadExamSets() {
-    setExamSets(await getExamSets());
-  }
-
-  async function loadMistakeCards() {
-    setMistakeCards(await getMistakeCards());
-  }
-
-  async function loadMaterialPdfs() {
-    setMaterialPdfs(await getMaterialPdfs());
-  }
-
-  async function loadPdfMappings() {
-    setPdfMappings(await getMaterialPdfMappings());
-  }
-
-  async function loadPracticeSessions() {
-    setPracticeSessions(await getPracticeSessions());
-  }
-
-  async function loadReviewStates() {
-    setReviewStates(await getReviewStates());
-  }
+  async function loadHistories() { setHistories(await getHistories()); }
+  async function loadExamSets() { setExamSets(await getExamSets()); }
+  async function loadMistakeCards() { setMistakeCards(await getMistakeCards()); }
+  async function loadMaterialPdfs() { setMaterialPdfs(await getMaterialPdfs()); }
+  async function loadPdfMappings() { setPdfMappings(await getMaterialPdfMappings()); }
+  async function loadPracticeSessions() { setPracticeSessions(await getPracticeSessions()); }
+  async function loadReviewStates() { setReviewStates(await getReviewStates()); }
 
   async function refreshSafety() {
     const [historyRows, answerRows, meta] = await Promise.all([getHistories(), getAllAnswers(), getBackupMetadata()]);
@@ -235,10 +218,7 @@ export default function App() {
     setAnswer(nextAnswer);
   }
 
-  useEffect(() => {
-    loadProblem(problemCatalog[0].id);
-    refreshAll();
-  }, []);
+  useEffect(() => { loadProblem(problemCatalog[0].id); refreshAll(); }, []);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -257,13 +237,7 @@ export default function App() {
     const nextTemplate = getTemplateById(templateId);
     const keep = window.confirm('テンプレートを変更すると現在の答案テーブルを新しい初期行に置き換えます。変更しますか？');
     if (!keep) return;
-    updateAnswer({
-      ...answer,
-      templateId,
-      templateName: nextTemplate.name,
-      columns: nextTemplate.columns,
-      rows: createRows(nextTemplate.columns.length, nextTemplate.initialRows),
-    });
+    updateAnswer({ ...answer, templateId, templateName: nextTemplate.name, columns: nextTemplate.columns, rows: createRows(nextTemplate.columns.length, nextTemplate.initialRows), problemBlocks: [] });
   };
 
   async function createPracticeSession(problemIdForSession: string, selectedTimeMode: TimeMode): Promise<PracticeSession> {
@@ -272,20 +246,9 @@ export default function App() {
     const baseAnswer = normalizeAnswer(stored ?? createAnswer(problemIdForSession, problemDefinition.defaultTemplateId));
     const now = nowIso();
     return {
-      id: crypto.randomUUID(),
-      examType: '日商簿記2級',
-      problemId: problemIdForSession,
-      startedAt: now,
-      submittedAt: '',
-      durationSeconds: 0,
-      selectedTimeMode,
-      answerSnapshot: baseAnswer,
-      gradingMode: 'self',
-      gradingResult: { status: '', score: 0, maxScore: baseAnswer.maxScore, scoreRate: 0, autoGraded: false, detailRows: [] },
-      openedAnswer: false,
-      openedExplanation: false,
-      memo: '',
-      completed: false,
+      id: crypto.randomUUID(), examType: '日商簿記2級', problemId: problemIdForSession, startedAt: now, submittedAt: '', durationSeconds: 0,
+      selectedTimeMode, answerSnapshot: baseAnswer, gradingMode: 'self', gradingResult: { status: '', score: 0, maxScore: baseAnswer.maxScore, scoreRate: 0, autoGraded: false, detailRows: [] },
+      openedAnswer: false, openedExplanation: false, memo: '', completed: false,
     };
   }
 
@@ -321,8 +284,7 @@ export default function App() {
 
   async function startCurrentSession(): Promise<PracticeSession> {
     if (activeSession && activeSession.problemId === problem.id && !activeSession.completed) return activeSession;
-    const mapping = pdfMappings.find((item) => item.problemId === problem.id);
-    return beginPractice(problem.id, mapping?.estimatedMinutes ?? '10分', '現在の問題ID');
+    return beginPractice(problem.id, currentMapping?.estimatedMinutes ?? '10分', '現在の問題ID');
   }
 
   async function updatePracticeSession(session: PracticeSession) {
@@ -336,11 +298,7 @@ export default function App() {
     updateAnswer({ ...answer, rowPointsTotal: total, score: total });
   };
 
-  const manualSave = async () => {
-    await saveAnswer(normalizeAnswer({ ...answer, updatedAt: nowIso() }));
-    await refreshAll();
-    setMessage('手動保存しました');
-  };
+  const manualSave = async () => { await saveAnswer(normalizeAnswer({ ...answer, updatedAt: nowIso() })); await refreshAll(); setMessage('手動保存しました'); };
 
   const clearCurrentAnswer = async () => {
     if (!window.confirm('現在問題IDの答案を全消去しますか？履歴は消えません。')) return;
@@ -353,10 +311,7 @@ export default function App() {
 
   const bulkAddAllAnswers = async () => {
     const rows = (await getAllAnswers()).map(normalizeAnswer).filter(hasMeaningfulAnswer);
-    if (rows.length === 0) {
-      setMessage('履歴追加できる保存済み答案がありません');
-      return;
-    }
+    if (rows.length === 0) { setMessage('履歴追加できる保存済み答案がありません'); return; }
     for (const item of rows) await addHistory(buildHistory(item));
     await refreshAll();
     setMessage(`保存済み答案 ${rows.length}件を一括で履歴追加しました`);
@@ -365,10 +320,7 @@ export default function App() {
   const confirmScoring = async () => {
     const rowTotal = sumRowPoints(answer.rows);
     const scored = normalizeAnswer({ ...answer, rowPointsTotal: rowTotal, score: rowTotal || answer.score, scored: true, scoredAt: nowIso(), updatedAt: nowIso() });
-    if (!hasMeaningfulAnswer(scored)) {
-      setMessage('空の答案は履歴に追加しませんでした');
-      return;
-    }
+    if (!hasMeaningfulAnswer(scored)) { setMessage('空の答案は履歴に追加しませんでした'); return; }
     await saveAnswer(scored);
     await addHistory(buildHistory(scored));
     setAnswer(scored);
@@ -380,37 +332,9 @@ export default function App() {
     const submittedAt = nowIso();
     const rank = rankFromSelfGrading(input.status, input.score, input.maxScore);
     const reviewState = updateReviewStateFromGrading({ problemId: problem.id, previous: currentReviewState, status: input.status, score: input.score, maxScore: input.maxScore });
-    const scored = normalizeAnswer({
-      ...answer,
-      score: input.score,
-      maxScore: input.maxScore,
-      scored: true,
-      scoringStarted: true,
-      scoredAt: submittedAt,
-      rank,
-      nextReviewDate: reviewState.nextReviewDate,
-      reviewMemo: input.memo || answer.reviewMemo,
-      updatedAt: submittedAt,
-    });
+    const scored = normalizeAnswer({ ...answer, score: input.score, maxScore: input.maxScore, scored: true, scoringStarted: true, scoredAt: submittedAt, rank, nextReviewDate: reviewState.nextReviewDate, reviewMemo: input.memo || answer.reviewMemo, updatedAt: submittedAt });
     const session = activeSession && activeSession.problemId === problem.id && !activeSession.completed ? activeSession : await startCurrentSession();
-    const completedSession: PracticeSession = {
-      ...session,
-      submittedAt,
-      durationSeconds: secondsBetween(session.startedAt, submittedAt),
-      answerSnapshot: scored,
-      gradingResult: {
-        status: input.status,
-        score: input.score,
-        maxScore: input.maxScore,
-        scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0,
-        autoGraded: false,
-        detailRows: [],
-      },
-      reviewState,
-      openedAnswer: true,
-      memo: input.memo,
-      completed: true,
-    };
+    const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, memo: input.memo, completed: true };
     await saveAnswer(scored);
     await addHistory(buildHistory(scored));
     await saveReviewState(reviewState);
@@ -434,56 +358,14 @@ export default function App() {
     setMessage('履歴を復元しました');
   };
 
-  const deleteHistoryEntry = async (id: string) => {
-    if (!window.confirm('この履歴を削除しますか？')) return;
-    await deleteHistory(id);
-    await refreshAll();
-    setMessage('履歴を削除しました');
-  };
-
-  const clearAllHistories = async () => {
-    if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return;
-    await clearHistories();
-    await refreshAll();
-    setMessage('履歴を全削除しました');
-  };
-
-  const saveCard = async (card: MistakeCard) => {
-    await saveMistakeCard(card);
-    await loadMistakeCards();
-    setMessage('白紙再現・解き直しカードを保存しました');
-  };
-
-  const removeCard = async (id: string) => {
-    if (!window.confirm('この解き直しカードを削除しますか？')) return;
-    await deleteMistakeCard(id);
-    await loadMistakeCards();
-    setMessage('白紙再現・解き直しカードを削除しました');
-  };
-
-  const savePdf = async (pdf: MaterialPdf) => {
-    await saveMaterialPdf(pdf);
-    await loadMaterialPdfs();
-  };
-
-  const removePdf = async (id: string) => {
-    await deleteMaterialPdf(id);
-    await Promise.all([loadMaterialPdfs(), loadPdfMappings()]);
-    setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。');
-  };
-
-  const savePdfMapping = async (mapping: MaterialPdfMapping) => {
-    await saveMaterialPdfMapping(mapping);
-    await loadPdfMappings();
-    setMessage('PDFページ紐付けを保存しました');
-  };
-
-  const removePdfMapping = async (id: string) => {
-    if (!window.confirm('このPDFページ紐付けを削除しますか？PDF教材データと答案履歴は削除されません。')) return;
-    await deleteMaterialPdfMapping(id);
-    await loadPdfMappings();
-    setMessage('PDFページ紐付けを削除しました');
-  };
+  const deleteHistoryEntry = async (id: string) => { if (!window.confirm('この履歴を削除しますか？')) return; await deleteHistory(id); await refreshAll(); setMessage('履歴を削除しました'); };
+  const clearAllHistories = async () => { if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return; await clearHistories(); await refreshAll(); setMessage('履歴を全削除しました'); };
+  const saveCard = async (card: MistakeCard) => { await saveMistakeCard(card); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを保存しました'); };
+  const removeCard = async (id: string) => { if (!window.confirm('この解き直しカードを削除しますか？')) return; await deleteMistakeCard(id); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを削除しました'); };
+  const savePdf = async (pdf: MaterialPdf) => { await saveMaterialPdf(pdf); await loadMaterialPdfs(); };
+  const removePdf = async (id: string) => { await deleteMaterialPdf(id); await Promise.all([loadMaterialPdfs(), loadPdfMappings()]); setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。'); };
+  const savePdfMapping = async (mapping: MaterialPdfMapping) => { await saveMaterialPdfMapping(mapping); await loadPdfMappings(); setMessage('PDFページ紐付けを保存しました'); };
+  const removePdfMapping = async (id: string) => { if (!window.confirm('このPDFページ紐付けを削除しますか？PDF教材データと答案履歴は削除されません。')) return; await deleteMaterialPdfMapping(id); await loadPdfMappings(); setMessage('PDFページ紐付けを削除しました'); };
 
   const exportCurrentCsv = () => downloadCsv('current-answer.csv', currentAnswerCsvRows(answer, problem));
   const exportHistoryCsv = () => downloadCsv('history.csv', historyCsvRows(histories));
@@ -509,15 +391,8 @@ export default function App() {
 
   const importJson = async (file: File | undefined) => {
     if (!file) return;
-    try {
-      const payload = JSON.parse(await file.text()) as BackupPayload;
-      await importAllData(payload);
-      await loadProblem(problemId);
-      await refreshAll();
-      setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。');
-    } catch {
-      setMessage('JSONの形式が不正です');
-    }
+    try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。'); }
+    catch { setMessage('JSONの形式が不正です'); }
   };
 
   const saveExamSetRecord = async (record: ExamSetRecord) => {
@@ -526,170 +401,36 @@ export default function App() {
       if (problemState.rank !== 'B' && problemState.rank !== 'C') continue;
       const problemDefinition = getProblemById(problemState.problemId);
       const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId);
-      const scored = normalizeAnswer({
-        ...base,
-        score: Number(problemState.score) || 0,
-        rowPointsTotal: Number(problemState.score) || 0,
-        rank: problemState.rank,
-        nextReviewDate: reviewDateForRank(problemState.rank),
-        reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`,
-        scored: true,
-        scoredAt: nowIso(),
-        updatedAt: nowIso(),
-      });
+      const scored = normalizeAnswer({ ...base, score: Number(problemState.score) || 0, rowPointsTotal: Number(problemState.score) || 0, rank: problemState.rank, nextReviewDate: reviewDateForRank(problemState.rank), reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`, scored: true, scoredAt: nowIso(), updatedAt: nowIso() });
       const history = buildHistory(scored);
       relatedHistoryIds.push(history.id);
       await addHistory(history);
     }
-
     await saveExamSet({ ...record, relatedHistoryIds });
     await refreshAll();
     setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。');
   };
 
-  const openNextProblem = async () => {
-    const next = studyQueue[0]?.problem.id ?? quickChoice.problemId;
-    await loadProblem(next);
-    setMode('study');
-    setStudyView('answer');
-  };
+  const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('study'); setStudyView('answer'); };
 
   return (
     <main className="app-shell redesigned-shell">
-      <header className="app-header compact-header">
-        <div>
-          <h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1>
-          <p>問題を見る → 答案を書く → 回答する → 解答/解説を見る → 自己採点する → 次回復習へ回す、の流れに集中する画面です。</p>
-        </div>
-        <Timer />
-      </header>
-
-      <nav className="mode-nav" aria-label="学習モード切替">
-        <button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button>
-        <button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button>
-        <button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button>
-        <button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button>
-      </nav>
-
+      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>問題を見る → 答案を書く → 回答する → 解答/解説を見る → 自己採点する → 次回復習へ回す、の流れに集中する画面です。</p></div><Timer /></header>
+      <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button></nav>
       <div className="status-bar">{message}</div>
 
-      {mode === 'study' && (
-        <section className="mode-section study-mode-section">
-          <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
-          <section className="study-problem-strip panel mode-card">
-            <div>
-              <p className="eyebrow">今解く問題</p>
-              <h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2>
-              <p>想定時間：{pdfMappings.find((item) => item.problemId === problem.id)?.estimatedMinutes ?? '未設定'} / 難易度：{pdfMappings.find((item) => item.problemId === problem.id)?.difficulty ?? '未設定'} / テンプレート：{answer.templateName}</p>
-            </div>
-            <button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button>
-          </section>
-          <div className="mobile-study-tabs">
-            <button className={studyView === 'problem' ? 'active' : ''} onClick={() => setStudyView('problem')}>問題</button>
-            <button className={studyView === 'answer' ? 'active' : ''} onClick={() => setStudyView('answer')}>答案</button>
-            <button onClick={() => { setMode('grading'); setStudyView('grading'); }}>採点</button>
-          </div>
-          <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}>
-            <div className="study-pdf-column">
-              <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} />
-            </div>
-            <div className="answer-main-column">
-              <ExampleGuide template={template} />
-              <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
-            </div>
-          </div>
-        </section>
-      )}
+      {mode === 'study' && <section className="mode-section study-mode-section">
+        <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
+        <section className="study-problem-strip panel mode-card"><div><p className="eyebrow">今解く問題</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>想定時間：{currentMapping?.estimatedMinutes ?? '未設定'} / 難易度：{currentMapping?.difficulty ?? '未設定'} / ブロック数：{currentMapping?.problemBlocks?.length ?? answer.problemBlocks?.length ?? 1}</p></div><button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button></section>
+        <div className="mobile-study-tabs"><button className={studyView === 'problem' ? 'active' : ''} onClick={() => setStudyView('problem')}>問題を見る</button><button className={studyView === 'answer' ? 'active' : ''} onClick={() => setStudyView('answer')}>答案を書く</button><button onClick={() => { setMode('grading'); setStudyView('grading'); }}>採点する</button></div>
+        <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}><div className="study-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} /></div><div className="answer-main-column"><ExampleGuide template={template} /><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} onChange={updateAnswer} /></div></div>
+      </section>}
 
-      {mode === 'grading' && (
-        <section className="mode-section grading-mode-section">
-          <section className="panel mode-card study-problem-strip">
-            <div>
-              <p className="eyebrow">採点する</p>
-              <h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2>
-              <p>回答後だけ、解答・解説PDFと自己採点欄を表示します。</p>
-            </div>
-            <button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button>
-          </section>
-          <div className="grading-layout">
-            <div className="grading-answer-column">
-              <h2>自分の答案</h2>
-              <AnswerTable answer={answer} template={template} onChange={updateAnswer} onApplyRowPoints={applyRowPoints} />
-            </div>
-            <div className="grading-pdf-column">
-              <PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} />
-              <ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} />
-            </div>
-          </div>
-        </section>
-      )}
+      {mode === 'grading' && <section className="mode-section grading-mode-section"><section className="panel mode-card study-problem-strip"><div><p className="eyebrow">採点する</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>回答後だけ、解答・解説PDFと自己採点欄を表示します。</p></div><button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button></section><div className="grading-layout"><div className="grading-answer-column"><h2>自分の答案</h2><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} onChange={updateAnswer} /></div><div className="grading-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} /><ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} /></div></div></section>}
 
-      {mode === 'materials' && (
-        <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />
-      )}
+      {mode === 'materials' && <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />}
 
-      {mode === 'progress' && (
-        <section className="mode-section progress-mode-section">
-          <section className="panel mode-card progress-overview-panel">
-            <div>
-              <p className="eyebrow">復習・進捗を見る</p>
-              <h2>今日の判断だけを先に表示</h2>
-              <p>詳細な履歴、CSV、バックアップ、白紙再現、70点リカバリーは下のカードを開いた時だけ表示します。</p>
-            </div>
-            <div className="progress-summary-grid">
-              <div><strong>{progressSummary.dueToday}</strong><span>今日やるべき問題</span></div>
-              <div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div>
-              <div><strong>{progressSummary.cRank}</strong><span>C判定・危険問題</span></div>
-              <div><strong>{progressSummary.untouched}</strong><span>未着手</span></div>
-            </div>
-            <button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button>
-          </section>
-
-          <details className="panel management-panel" open>
-            <summary>今日の復習・期限超過・C/B判定</summary>
-            <StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} />
-          </details>
-          <details className="panel management-panel">
-            <summary>合格到達マップ</summary>
-            <MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} />
-          </details>
-          <details className="panel management-panel">
-            <summary>白紙再現カード</summary>
-            <MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} />
-          </details>
-          <details className="panel management-panel">
-            <summary>70点リカバリー表・90分セット</summary>
-            <RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} />
-            <ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} />
-          </details>
-          <details className="panel management-panel">
-            <summary>履歴一覧・復習管理</summary>
-            <ReviewPanel histories={histories} />
-            <HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} />
-          </details>
-          <details className="panel management-panel">
-            <summary>CSV出力・JSONバックアップ・保存状態</summary>
-            <div className="top-actions management-actions">
-              <button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button>
-              <button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button>
-              <button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button>
-              <button onClick={exportHistoryCsv}>履歴一覧CSV</button>
-              <button onClick={exportReviewCsv}>復習対象CSV</button>
-              <button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button>
-              <button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button>
-              <button onClick={exportDashboardCsv}>ダッシュボードCSV</button>
-              <button onClick={exportExamSetCsv}>90分セットCSV</button>
-              <button onClick={exportMasteryCsv}>合格到達マップCSV</button>
-              <button onClick={exportRecoveryCsv}>70点リカバリーCSV</button>
-              <button onClick={exportJson}>JSONバックアップ</button>
-              <label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label>
-              <button onClick={() => window.print()}>印刷</button>
-            </div>
-            <BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} />
-            <DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} />
-          </details>
-        </section>
-      )}
+      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習・進捗を見る</p><h2>今日の判断だけを先に表示</h2><p>詳細な履歴、CSV、バックアップ、白紙再現、70点リカバリーは下のカードを開いた時だけ表示します。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やるべき問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定・危険問題</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
     </main>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { problemCatalog } from '../data/problemCatalog';
-import type { MaterialPdf, MaterialPdfMapping, TimeMode } from '../types';
+import { templateCatalog } from '../data/templateCatalog';
+import type { BlockDifficulty, MaterialPdf, MaterialPdfMapping, ProblemBlock, TemplateId, TimeMode } from '../types';
 import { nowIso } from '../utils/dates';
 import { timeModes } from '../utils/disposableStudy';
-import { formatFileSize, getPdfPageCount, renderPdfPageToCanvas } from '../utils/pdfRenderer';
+import { suggestPdfLinkCandidates, type PdfAutoLinkCandidate } from '../utils/pdfAutoLink';
+import { formatFileSize, getPdfPageCount } from '../utils/pdfRenderer';
+import { PdfViewerPanel } from './PdfViewerPanel';
 
 interface Props {
   pdfs: MaterialPdf[];
@@ -18,6 +21,18 @@ interface Props {
 }
 
 type RangeKind = 'problem' | 'answer' | 'explanation';
+
+function blankBlock(index: number, templateId: TemplateId = 'journal'): ProblemBlock {
+  return {
+    id: crypto.randomUUID(),
+    title: `問題文${index + 1}`,
+    description: '',
+    estimatedMinutes: 3,
+    difficulty: '標準',
+    templateId,
+    memo: '',
+  };
+}
 
 function blankMapping(problemId: string, pdfId = ''): MaterialPdfMapping {
   const problem = problemCatalog.find((item) => item.id === problemId) ?? problemCatalog[0];
@@ -36,6 +51,7 @@ function blankMapping(problemId: string, pdfId = ''): MaterialPdfMapping {
     estimatedMinutes: '10分',
     difficulty: '標準',
     memo: '',
+    problemBlocks: [blankBlock(0, problem.defaultTemplateId)],
     createdAt: now,
     updatedAt: now,
   };
@@ -46,6 +62,16 @@ function numberOrUndefined(value: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function ensureBlocks(mapping: MaterialPdfMapping): ProblemBlock[] {
+  if (mapping.problemBlocks && mapping.problemBlocks.length > 0) return mapping.problemBlocks;
+  const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
+  return [blankBlock(0, problem.defaultTemplateId)];
+}
+
+function blockDifficultyLabel(value?: BlockDifficulty): string {
+  return value ?? '標準';
+}
+
 export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSavePdf, onDeletePdf, onSaveMapping, onDeleteMapping, onOpenProblem, onMessage }: Props) {
   const [title, setTitle] = useState('');
   const [sourceName, setSourceName] = useState('CPA問題集');
@@ -54,15 +80,14 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
   const [draft, setDraft] = useState<MaterialPdfMapping>(() => blankMapping(selectedProblemId, pdfs[0]?.id ?? ''));
   const [previewKind, setPreviewKind] = useState<RangeKind>('problem');
   const [page, setPage] = useState(1);
-  const [scale, setScale] = useState(1.05);
-  const [loading, setLoading] = useState(false);
-  const [renderError, setRenderError] = useState('');
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [candidates, setCandidates] = useState<PdfAutoLinkCandidate[]>([]);
+  const [scanning, setScanning] = useState(false);
 
   const selectedPdf = useMemo(() => pdfs.find((pdf) => pdf.id === selectedPdfId) ?? pdfs[0], [pdfs, selectedPdfId]);
   const mappedProblemIds = useMemo(() => new Set(mappings.map((mapping) => mapping.problemId)), [mappings]);
   const unmapped = problemCatalog.filter((problem) => !mappedProblemIds.has(problem.id));
   const mapped = problemCatalog.filter((problem) => mappedProblemIds.has(problem.id));
+  const blocks = ensureBlocks(draft);
 
   useEffect(() => {
     if (!selectedPdfId && pdfs[0]) setSelectedPdfId(pdfs[0].id);
@@ -70,8 +95,9 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
 
   useEffect(() => {
     const existing = mappings.find((mapping) => mapping.problemId === selectedProblemId) ?? blankMapping(selectedProblemId, selectedPdf?.id ?? '');
-    setDraft({ ...existing, materialPdfId: existing.materialPdfId || selectedPdf?.id || '' });
-    setSelectedPdfId(existing.materialPdfId || selectedPdf?.id || '');
+    const next = { ...existing, materialPdfId: existing.materialPdfId || selectedPdf?.id || '', problemBlocks: ensureBlocks(existing) };
+    setDraft(next);
+    setSelectedPdfId(next.materialPdfId || selectedPdf?.id || '');
   }, [selectedProblemId, mappings, selectedPdf?.id]);
 
   const activeRange = (() => {
@@ -81,29 +107,26 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
   })();
 
   useEffect(() => {
-    if (!selectedPdf || !canvasRef.current) return;
-    let cancelled = false;
-    setLoading(true);
-    setRenderError('');
-    const safePage = Math.max(1, Math.min(page, selectedPdf.pageCount || page));
-    renderPdfPageToCanvas(selectedPdf.pdfBlob, safePage, scale, canvasRef.current)
-      .catch(() => {
-        if (!cancelled) setRenderError('PDFページの表示に失敗しました。保護PDF、破損ファイル、またはブラウザ非対応の可能性があります。');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => { cancelled = true; };
-  }, [selectedPdf, page, scale]);
-
-  useEffect(() => {
     setPage(activeRange.start || 1);
   }, [previewKind, draft.problemPageStart, draft.answerPageStart, draft.explanationPageStart]);
 
   function update(patch: Partial<MaterialPdfMapping>) {
     const nextProblemId = patch.problemId ?? draft.problemId;
     const problem = problemCatalog.find((item) => item.id === nextProblemId) ?? problemCatalog[0];
-    setDraft((current) => ({ ...current, ...patch, problemId: nextProblemId, displayId: problem.displayId, updatedAt: nowIso() }));
+    setDraft((current) => ({ ...current, ...patch, problemId: nextProblemId, displayId: problem.displayId, problemBlocks: patch.problemBlocks ?? ensureBlocks(current), updatedAt: nowIso() }));
+  }
+
+  function updateBlock(index: number, patch: Partial<ProblemBlock>) {
+    update({ problemBlocks: blocks.map((block, blockIndex) => blockIndex === index ? { ...block, ...patch } : block) });
+  }
+
+  function addBlock() {
+    update({ problemBlocks: [...blocks, blankBlock(blocks.length, blocks[blocks.length - 1]?.templateId ?? 'journal')] });
+  }
+
+  function deleteBlock(index: number) {
+    const next = blocks.filter((_, blockIndex) => blockIndex !== index);
+    update({ problemBlocks: next.length > 0 ? next : [blankBlock(0)] });
   }
 
   async function importPdf(file: File | undefined) {
@@ -133,9 +156,22 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
       setSelectedPdfId(pdf.id);
       setDraft((current) => ({ ...current, materialPdfId: pdf.id }));
       setTitle('');
+      setCandidates([]);
       onMessage('PDFを端末内IndexedDBへ保存しました。続けてページを見ながら問題IDへ紐づけてください。');
     } catch {
       onMessage('PDFの読み込みに失敗しました。破損ファイル、保護PDF、ブラウザ非対応の可能性があります。');
+    }
+  }
+
+  async function scanCandidates() {
+    if (!selectedPdf) return;
+    setScanning(true);
+    try {
+      const rows = await suggestPdfLinkCandidates(selectedPdf);
+      setCandidates(rows);
+      onMessage(rows.length ? `候補ページを${rows.length}件検出しました。必ずPDFを確認してから保存してください。` : '候補ページは検出できませんでした。PDFを見ながら手動で指定してください。');
+    } finally {
+      setScanning(false);
     }
   }
 
@@ -144,7 +180,7 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
       onMessage('先に対象PDFを選択してください');
       return;
     }
-    await onSaveMapping({ ...draft, updatedAt: nowIso() });
+    await onSaveMapping({ ...draft, problemBlocks: blocks, updatedAt: nowIso() });
   }
 
   function jumpToRange(kind: RangeKind) {
@@ -154,147 +190,54 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
     else setPage(draft.problemPageStart);
   }
 
+  function applyCandidate(pageNumber: number, target: RangeKind) {
+    if (target === 'problem') update({ problemPageStart: pageNumber, problemPageEnd: Math.max(pageNumber, draft.problemPageEnd) });
+    if (target === 'answer') update({ answerPageStart: pageNumber, answerPageEnd: pageNumber });
+    if (target === 'explanation') update({ explanationPageStart: pageNumber, explanationPageEnd: pageNumber });
+    setPage(pageNumber);
+  }
+
   return (
-    <section className="material-setup-grid">
-      <div className="panel setup-control-panel mode-card">
+    <section className="material-setup-grid wizard-setup-grid">
+      <div className="panel setup-control-panel mode-card wizard-control-panel">
         <p className="eyebrow">教材を設定する</p>
-        <h2>PDFを見ながらページ範囲を登録</h2>
+        <h2>PDF教材を登録する / 問題ページを紐づける / 問題ブロックを作る</h2>
         <p className="notice-small">PDF本体・教材本文・解答解説はGitHubや外部サーバーへ送信しません。利用者本人の端末内IndexedDBに保存します。</p>
+        <p className="notice-small">PDFの作りによっては自動候補が出ない場合があります。その場合はPDFを見ながら手動でページ範囲を指定してください。</p>
 
-        <div className="form-grid three-columns">
-          <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
-          <label>教材区分
-            <select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}>
-              <option value="商業簿記">商業簿記</option>
-              <option value="工業簿記">工業簿記</option>
-              <option value="その他">その他</option>
-            </select>
-          </label>
-          <label>出所メモ<input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" /></label>
-        </div>
-        <label className="import-label pdf-import-label">PDFを選択してプレビュー
-          <input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} />
-        </label>
+        <details open className="wizard-step-card"><summary>1. PDF教材を登録する</summary>
+          <div className="form-grid three-columns">
+            <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
+            <label>教材区分<select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}><option value="商業簿記">商業簿記</option><option value="工業簿記">工業簿記</option><option value="その他">その他</option></select></label>
+            <label>出所メモ<input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" /></label>
+          </div>
+          <label className="import-label pdf-import-label">PDFを選択してプレビュー<input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} /></label>
+        </details>
 
-        <div className="form-grid two-columns">
-          <label>対象PDF
-            <select value={draft.materialPdfId || selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); update({ materialPdfId: event.target.value }); }}>
-              <option value="">PDFを選択</option>
-              {pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P）</option>)}
-            </select>
-          </label>
-          <label>問題ID
-            <select value={draft.problemId} onChange={(event) => { const existing = mappings.find((mapping) => mapping.problemId === event.target.value); setDraft(existing ?? blankMapping(event.target.value, draft.materialPdfId || selectedPdfId)); }}>
-              {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}
-            </select>
-          </label>
-        </div>
+        <details open className="wizard-step-card"><summary>2. 問題ページを紐づける</summary>
+          <div className="form-grid two-columns"><label>対象PDF<select value={draft.materialPdfId || selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); update({ materialPdfId: event.target.value }); }}><option value="">PDFを選択</option>{pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P）</option>)}</select></label><label>問題ID<select value={draft.problemId} onChange={(event) => { const existing = mappings.find((mapping) => mapping.problemId === event.target.value); setDraft(existing ? { ...existing, problemBlocks: ensureBlocks(existing) } : blankMapping(event.target.value, draft.materialPdfId || selectedPdfId)); }}>
+            {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}</select></label></div>
+          <div className="form-grid six-columns"><label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label><label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label><label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label></div>
+          <div className="form-grid three-columns"><label>想定時間<select value={draft.estimatedMinutes} onChange={(event) => update({ estimatedMinutes: event.target.value as TimeMode })}>{timeModes.map((mode) => <option key={mode} value={mode}>{mode}</option>)}</select></label><label>難易度<select value={draft.difficulty} onChange={(event) => update({ difficulty: event.target.value as MaterialPdfMapping['difficulty'] })}><option value="易">易</option><option value="標準">標準</option><option value="難">難</option></select></label><label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れない" /></label></div>
+          <div className="button-row"><button onClick={() => { void scanCandidates(); }} disabled={!selectedPdf || scanning}>{scanning ? '候補抽出中...' : '候補ページを提案'}</button><button className={previewKind === 'problem' ? 'accent' : 'secondary'} onClick={() => jumpToRange('problem')}>問題</button><button className={previewKind === 'answer' ? 'accent' : 'secondary'} disabled={!draft.answerPageStart} onClick={() => jumpToRange('answer')}>解答</button><button className={previewKind === 'explanation' ? 'accent' : 'secondary'} disabled={!draft.explanationPageStart} onClick={() => jumpToRange('explanation')}>解説</button></div>
+          {candidates.length > 0 && <div className="auto-link-candidates"><h3>候補ページ</h3>{candidates.map((candidate) => <div key={candidate.page} className="candidate-row"><strong>P{candidate.page}</strong><span>{candidate.labels.join(' / ')}</span><small>{candidate.preview}</small><button onClick={() => setPage(candidate.page)}>このページへ移動</button><button onClick={() => applyCandidate(candidate.page, 'problem')}>問題開始</button><button onClick={() => applyCandidate(candidate.page, 'answer')}>解答開始</button><button onClick={() => applyCandidate(candidate.page, 'explanation')}>解説開始</button></div>)}</div>}
+        </details>
 
-        <div className="form-grid six-columns">
-          <label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label>
-          <label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label>
-          <label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label>
-          <label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label>
-          <label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label>
-          <label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label>
-        </div>
+        <details open className="wizard-step-card"><summary>3. 問題ブロックを作る</summary>
+          <div className="button-row"><button className="accent" onClick={addBlock}>問題文ブロックを追加</button><span>現在 {blocks.length} ブロック</span></div>
+          <div className="block-editor-list">
+            {blocks.map((block, index) => <div key={block.id} className="block-editor-card"><div className="section-heading"><div><p className="eyebrow">問題文{index + 1}</p><h3>{block.title}</h3></div><button className="danger" onClick={() => deleteBlock(index)}>削除</button></div><div className="form-grid three-columns"><label>ブロック名<input value={block.title} onChange={(event) => updateBlock(index, { title: event.target.value })} /></label><label>答案テンプレート<select value={block.templateId} onChange={(event) => updateBlock(index, { templateId: event.target.value as TemplateId })}>{templateCatalog.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}</select></label><label>想定分<input type="number" value={block.estimatedMinutes ?? ''} onChange={(event) => updateBlock(index, { estimatedMinutes: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid six-columns"><label>問題開始P<input type="number" value={block.problemPageStart ?? ''} onChange={(event) => updateBlock(index, { problemPageStart: numberOrUndefined(event.target.value) })} /></label><label>問題終了P<input type="number" value={block.problemPageEnd ?? ''} onChange={(event) => updateBlock(index, { problemPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解答開始P<input type="number" value={block.answerPageStart ?? ''} onChange={(event) => updateBlock(index, { answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解答終了P<input type="number" value={block.answerPageEnd ?? ''} onChange={(event) => updateBlock(index, { answerPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" value={block.explanationPageStart ?? ''} onChange={(event) => updateBlock(index, { explanationPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説終了P<input type="number" value={block.explanationPageEnd ?? ''} onChange={(event) => updateBlock(index, { explanationPageEnd: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid three-columns"><label>難易度<select value={blockDifficultyLabel(block.difficulty)} onChange={(event) => updateBlock(index, { difficulty: event.target.value as BlockDifficulty })}><option value="易しい">易しい</option><option value="標準">標準</option><option value="やや難">やや難</option><option value="難しい">難しい</option></select></label><label>説明<input value={block.description ?? ''} onChange={(event) => updateBlock(index, { description: event.target.value })} placeholder="例：商品、収益認識、現金預金" /></label><label>メモ<input value={block.memo ?? ''} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文は入れない" /></label></div></div>)}
+          </div>
+        </details>
 
-        <div className="form-grid three-columns">
-          <label>想定時間
-            <select value={draft.estimatedMinutes} onChange={(event) => update({ estimatedMinutes: event.target.value as TimeMode })}>
-              {timeModes.map((mode) => <option key={mode} value={mode}>{mode}</option>)}
-            </select>
-          </label>
-          <label>難易度
-            <select value={draft.difficulty} onChange={(event) => update({ difficulty: event.target.value as MaterialPdfMapping['difficulty'] })}>
-              <option value="易">易</option><option value="標準">標準</option><option value="難">難</option>
-            </select>
-          </label>
-          <label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れない" /></label>
-        </div>
-
-        <div className="button-row sticky-actions">
-          <button className="accent" onClick={() => { void saveMapping(); }}>この問題IDに紐づけて保存</button>
-          <button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>この問題を開く</button>
-        </div>
+        <div className="button-row sticky-actions"><button className="accent" onClick={() => { void saveMapping(); }}>この問題IDに紐づけて保存</button><button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>この問題を開く</button></div>
       </div>
 
-      <div className="panel setup-preview-panel mode-card">
-        <div className="section-heading">
-          <div>
-            <p className="eyebrow">プレビュー：{previewKind === 'answer' ? '解答' : previewKind === 'explanation' ? '解説' : '問題'}</p>
-            <h2>{selectedPdf ? selectedPdf.title : 'PDF未選択'}</h2>
-            {selectedPdf && <p>{selectedPdf.fileName} / {selectedPdf.pageCount}P / {formatFileSize(selectedPdf.size)}</p>}
-          </div>
-          <div className="button-row">
-            <button className={previewKind === 'problem' ? 'accent' : 'secondary'} onClick={() => jumpToRange('problem')}>問題</button>
-            <button className={previewKind === 'answer' ? 'accent' : 'secondary'} disabled={!draft.answerPageStart} onClick={() => jumpToRange('answer')}>解答</button>
-            <button className={previewKind === 'explanation' ? 'accent' : 'secondary'} disabled={!draft.explanationPageStart} onClick={() => jumpToRange('explanation')}>解説</button>
-          </div>
-        </div>
-        <div className="pdf-toolbar">
-          <button disabled={!selectedPdf} onClick={() => setPage((current) => Math.max(1, current - 1))}>前ページ</button>
-          <label>ページ<input type="number" min="1" max={selectedPdf?.pageCount ?? 1} value={page} onChange={(event) => setPage(Math.max(1, Number(event.target.value) || 1))} /></label>
-          <span>登録範囲：{activeRange.start}〜{activeRange.end}ページ</span>
-          <button disabled={!selectedPdf} onClick={() => setPage((current) => Math.min(selectedPdf?.pageCount ?? current + 1, current + 1))}>次ページ</button>
-          <button onClick={() => setScale((current) => Math.max(0.7, current - 0.15))}>縮小</button>
-          <button onClick={() => setScale((current) => Math.min(2.2, current + 0.15))}>拡大</button>
-        </div>
-        {renderError && <p className="warning-text">{renderError}</p>}
-        <div className="pdf-canvas-wrap setup-canvas-wrap">
-          {!selectedPdf && <p className="empty">左側からPDFを選択してください。</p>}
-          {loading && <p className="empty">PDFを表示中...</p>}
-          <canvas ref={canvasRef} className="pdf-canvas" />
-        </div>
-      </div>
+      <div className="setup-preview-panel"><PdfViewerPanel pdf={selectedPdf} title={selectedPdf ? selectedPdf.title : 'PDF未選択'} label={previewKind === 'answer' ? '解答' : previewKind === 'explanation' ? '解説' : '問題'} page={page} pageStart={1} pageEnd={selectedPdf?.pageCount ?? 1} onPageChange={setPage} large /></div>
 
-      <details className="panel mapping-list-panel" open>
-        <summary>保存済みマッピング / 設定状況</summary>
-        <div className="panel-body">
-          <div className="progress-summary-grid">
-            <div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div>
-            <div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div>
-            <div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div>
-          </div>
-          <div className="table-wrap short-wrap">
-            <table className="compact-table">
-              <thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>操作</th></tr></thead>
-              <tbody>
-                {mappings.map((mapping) => {
-                  const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
-                  const pdf = pdfs.find((item) => item.id === mapping.materialPdfId);
-                  return (
-                    <tr key={mapping.id}>
-                      <td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td>
-                      <td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td>
-                      <td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td>
-                      <td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td>
-                      <td><button onClick={() => { setDraft(mapping); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td>
-                    </tr>
-                  );
-                })}
-                {mappings.length === 0 && <tr><td colSpan={7}>まだページ紐付けがありません。</td></tr>}
-              </tbody>
-            </table>
-          </div>
-          {unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}
-        </div>
-      </details>
+      <details className="panel mapping-list-panel" open><summary>保存済みマッピング / 設定状況</summary><div className="panel-body"><div className="progress-summary-grid"><div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div><div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div><div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div></div><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>ブロック</th><th>操作</th></tr></thead><tbody>{mappings.map((mapping) => { const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0]; const pdf = pdfs.find((item) => item.id === mapping.materialPdfId); return <tr key={mapping.id}><td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td><td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td><td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td><td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td><td>{mapping.problemBlocks?.length ?? 1}</td><td><button onClick={() => { setDraft({ ...mapping, problemBlocks: ensureBlocks(mapping) }); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td></tr>; })}{mappings.length === 0 && <tr><td colSpan={8}>まだページ紐付けがありません。</td></tr>}</tbody></table></div>{unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}</div></details>
 
-      <details className="panel mapping-list-panel">
-        <summary>PDF教材データの削除</summary>
-        <div className="panel-body">
-          <div className="table-wrap short-wrap">
-            <table className="compact-table">
-              <thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead>
-              <tbody>
-                {pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}
-                {pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </details>
+      <details className="panel mapping-list-panel"><summary>PDF教材データの削除</summary><div className="panel-body"><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead><tbody>{pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}{pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}</tbody></table></div></div></details>
     </section>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfStudyPanel.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { AnswerState, GradingStatus, MaterialPdf, MaterialPdfMapping, PracticeSession, ProblemDefinition, ReviewRank, ReviewState } from '../types';
 import { formatDateTime } from '../utils/dates';
-import { renderPdfPageToCanvas } from '../utils/pdfRenderer';
 import { rankFromSelfGrading, updateReviewStateFromGrading } from '../utils/reviewScheduler';
+import { PdfViewerPanel } from './PdfViewerPanel';
 
 type PdfViewMode = 'problem' | 'answer' | 'explanation';
 type StudyPanelMode = 'study' | 'grading';
@@ -41,24 +41,17 @@ function viewLabel(mode: PdfViewMode): string {
   return '問題';
 }
 
-function clamp(value: number, start: number, end: number): number {
-  return Math.max(start, Math.min(end, value));
-}
-
 export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, reviewState, panelMode = 'study', onStartCurrentSession, onSessionChange, onSelfGrade, onRequestGrading }: Props) {
   const mapping = useMemo(() => mappings.find((item) => item.problemId === problem.id), [mappings, problem.id]);
   const pdf = useMemo(() => pdfs.find((item) => item.id === mapping?.materialPdfId), [pdfs, mapping?.materialPdfId]);
   const [viewMode, setViewMode] = useState<PdfViewMode>(panelMode === 'grading' ? 'answer' : 'problem');
   const [page, setPage] = useState(1);
-  const [scale, setScale] = useState(panelMode === 'grading' ? 1.05 : 1.15);
-  const [loading, setLoading] = useState(false);
-  const [renderError, setRenderError] = useState('');
+  const [showPdf, setShowPdf] = useState(panelMode === 'grading');
   const [showSelfGrade, setShowSelfGrade] = useState(panelMode === 'grading');
   const [status, setStatus] = useState<GradingStatus>('正解');
   const [score, setScore] = useState(answer.score || 0);
   const [maxScore, setMaxScore] = useState(answer.maxScore || 20);
   const [memo, setMemo] = useState(answer.reviewMemo || '');
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const safeViewMode = panelMode === 'study' ? 'problem' : viewMode;
   const range = mapping ? pageRange(mapping, safeViewMode) : null;
@@ -68,25 +61,11 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
   useEffect(() => {
     const nextMode: PdfViewMode = panelMode === 'grading' && mapping?.answerPageStart ? 'answer' : 'problem';
     setViewMode(nextMode);
+    setShowPdf(panelMode === 'grading');
     setShowSelfGrade(panelMode === 'grading');
     const nextRange = mapping ? pageRange(mapping, nextMode) : null;
     setPage(nextRange?.start ?? 1);
   }, [problem.id, mapping?.id, panelMode]);
-
-  useEffect(() => {
-    if (!pdf || !canvasRef.current || !range) return;
-    let cancelled = false;
-    setLoading(true);
-    setRenderError('');
-    renderPdfPageToCanvas(pdf.pdfBlob, clamp(page, range.start, range.end), scale, canvasRef.current)
-      .catch(() => {
-        if (!cancelled) setRenderError('PDFページの表示に失敗しました。ファイル破損、保護PDF、またはブラウザ非対応の可能性があります。');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => { cancelled = true; };
-  }, [pdf, page, scale, range?.start, range?.end]);
 
   async function ensureSession(): Promise<PracticeSession> {
     if (activeSession && activeSession.problemId === problem.id && !activeSession.completed) return activeSession;
@@ -108,6 +87,7 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
     if (!nextRange) return;
     setViewMode(nextMode);
     setPage(nextRange.start);
+    setShowPdf(true);
   }
 
   async function answerNow() {
@@ -133,44 +113,46 @@ export function PdfStudyPanel({ problem, answer, pdfs, mappings, activeSession, 
   }
 
   return (
-    <section className={`panel pdf-study-panel mode-card pdf-${panelMode}`}>
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">現在表示：{viewLabel(safeViewMode)}ページ</p>
-          <h2>{panelMode === 'grading' ? '解答・解説PDF' : '問題PDF'}：{pdf.title}</h2>
-          <p>{problem.sectionLabel} {problem.displayId} / {problem.topic} / 想定 {mapping.estimatedMinutes} / 難易度 {mapping.difficulty}</p>
-        </div>
-        {panelMode === 'grading' && (
+    <section className={`pdf-study-shell pdf-${panelMode}`}>
+      <div className="panel pdf-study-panel mode-card pdf-launch-panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">現在表示：{viewLabel(safeViewMode)}ページ</p>
+            <h2>{panelMode === 'grading' ? '解答・解説PDF' : '問題PDF'}：{pdf.title}</h2>
+            <p>{problem.sectionLabel} {problem.displayId} / {problem.topic} / 想定 {mapping.estimatedMinutes} / 難易度 {mapping.difficulty}</p>
+          </div>
           <div className="button-row">
-            <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => { void openView('answer'); }}>解答</button>
-            <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => { void openView('explanation'); }}>解説</button>
-            <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => { void openView('problem'); }}>問題を確認</button>
+            {panelMode === 'study' && <button className="accent" onClick={() => { void openView('problem'); }}>問題PDFを大きく開く</button>}
+            {panelMode === 'grading' && <button className={viewMode === 'problem' ? 'accent' : 'secondary'} onClick={() => { void openView('problem'); }}>問題</button>}
+            {panelMode === 'grading' && <button className={viewMode === 'answer' ? 'accent' : 'secondary'} disabled={!mapping.answerPageStart} onClick={() => { void openView('answer'); }}>解答</button>}
+            {panelMode === 'grading' && <button className={viewMode === 'explanation' ? 'accent' : 'secondary'} disabled={!mapping.explanationPageStart} onClick={() => { void openView('explanation'); }}>解説</button>}
+            {showPdf && <button className="secondary" onClick={() => setShowPdf(false)}>PDFを閉じる</button>}
+          </div>
+        </div>
+        {activeSession && activeSession.problemId === problem.id && !activeSession.completed && <p className="ok-text">演習中：{activeSession.selectedTimeMode} / 開始 {formatDateTime(activeSession.startedAt)}</p>}
+        {panelMode === 'study' && (
+          <div className="study-actions">
+            <button className="resume-button" onClick={() => { void answerNow(); }}>回答する / 自己採点へ進む</button>
           </div>
         )}
       </div>
-      <div className="pdf-toolbar">
-        <button onClick={() => range && setPage(clamp(page - 1, range.start, range.end))}>前ページ</button>
-        <label>ページ
-          <input type="number" min={range?.start ?? 1} max={range?.end ?? pdf.pageCount} value={page} onChange={(event) => range && setPage(clamp(Number(event.target.value) || range.start, range.start, range.end))} />
-        </label>
-        <span>{range ? `${range.start}〜${range.end}ページ範囲` : 'ページ範囲なし'}</span>
-        <button onClick={() => range && setPage(clamp(page + 1, range.start, range.end))}>次ページ</button>
-        <button onClick={() => setScale((current) => Math.max(0.7, current - 0.15))}>縮小</button>
-        <button onClick={() => setScale((current) => Math.min(2.2, current + 0.15))}>拡大</button>
-      </div>
-      {activeSession && activeSession.problemId === problem.id && !activeSession.completed && <p className="ok-text">演習中：{activeSession.selectedTimeMode} / 開始 {formatDateTime(activeSession.startedAt)}</p>}
-      {renderError && <p className="warning-text">{renderError}</p>}
-      <div className="pdf-canvas-wrap">
-        {loading && <p className="empty">PDFを表示中...</p>}
-        <canvas ref={canvasRef} className="pdf-canvas" />
-      </div>
-      {panelMode === 'study' && (
-        <div className="study-actions">
-          <button className="resume-button" onClick={() => { void answerNow(); }}>回答する / 自己採点へ進む</button>
-        </div>
+
+      {showPdf && range && (
+        <PdfViewerPanel
+          pdf={pdf}
+          title={`${problem.displayId} ${problem.topic}`}
+          label={viewLabel(safeViewMode)}
+          page={page}
+          pageStart={range.start}
+          pageEnd={range.end}
+          large
+          onPageChange={setPage}
+          onClose={() => setShowPdf(false)}
+        />
       )}
+
       {panelMode === 'grading' && showSelfGrade && (
-        <div className="self-grade-panel">
+        <div className="panel self-grade-panel">
           <h3>自己採点</h3>
           <div className="form-grid four-columns">
             <label>結果

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfViewerPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfViewerPanel.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MaterialPdf } from '../types';
+import { renderPdfPageToCanvas } from '../utils/pdfRenderer';
+
+interface Props {
+  pdf?: MaterialPdf;
+  title: string;
+  page: number;
+  pageStart?: number;
+  pageEnd?: number;
+  onPageChange: (page: number) => void;
+  onClose?: () => void;
+  label?: string;
+  large?: boolean;
+}
+
+type FitMode = 'custom' | 'width' | 'height';
+
+function clamp(value: number, start: number, end: number): number {
+  return Math.max(start, Math.min(end, value));
+}
+
+export function PdfViewerPanel({ pdf, title, page, pageStart, pageEnd, onPageChange, onClose, label = '問題', large = false }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState(large ? 1.35 : 1.1);
+  const [fitMode, setFitMode] = useState<FitMode>('custom');
+  const [full, setFull] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [renderError, setRenderError] = useState('');
+
+  const start = pageStart ?? 1;
+  const end = pageEnd ?? pdf?.pageCount ?? start;
+  const safePage = clamp(page, start, end);
+
+  useEffect(() => {
+    if (!pdf || !canvasRef.current) return;
+    let cancelled = false;
+    setLoading(true);
+    setRenderError('');
+    renderPdfPageToCanvas(pdf.pdfBlob, safePage, scale, canvasRef.current)
+      .catch(() => {
+        if (!cancelled) setRenderError('PDFページの表示に失敗しました。保護PDF、破損ファイル、またはブラウザ非対応の可能性があります。');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [pdf, safePage, scale]);
+
+  useEffect(() => {
+    if (!canvasRef.current || !wrapRef.current) return;
+    if (fitMode === 'custom') return;
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas.width || !canvas.height) return;
+    const horizontalPadding = 32;
+    const verticalPadding = 32;
+    if (fitMode === 'width') setScale((current) => Math.max(0.55, Math.min(2.8, current * ((wrap.clientWidth - horizontalPadding) / canvas.clientWidth))));
+    if (fitMode === 'height') setScale((current) => Math.max(0.55, Math.min(2.8, current * ((wrap.clientHeight - verticalPadding) / canvas.clientHeight))));
+  }, [fitMode, loading]);
+
+  const movePage = (next: number) => onPageChange(clamp(next, start, end));
+
+  return (
+    <section className={`panel pdf-viewer-panel ${large ? 'pdf-viewer-large' : ''} ${full ? 'pdf-viewer-full' : ''}`}>
+      <div className="section-heading pdf-viewer-heading">
+        <div>
+          <p className="eyebrow">{label}PDF</p>
+          <h2>{title}</h2>
+          {pdf && <p>現在ページ {safePage} / 全{pdf.pageCount}ページ　登録範囲：{start}〜{end}ページ　倍率：{Math.round(scale * 100)}%</p>}
+        </div>
+        <div className="button-row">
+          <button onClick={() => setFull((current) => !current)}>{full ? '通常表示' : 'フルスクリーン風表示'}</button>
+          {onClose && <button className="secondary" onClick={onClose}>閉じる</button>}
+        </div>
+      </div>
+      <div className="pdf-toolbar pdf-toolbar-strong">
+        <button disabled={!pdf} onClick={() => movePage(safePage - 1)}>前ページ</button>
+        <label>ページ番号<input type="number" min={start} max={end} value={safePage} onChange={(event) => movePage(Number(event.target.value) || start)} /></label>
+        <button disabled={!pdf} onClick={() => movePage(safePage + 1)}>次ページ</button>
+        <button onClick={() => { setFitMode('custom'); setScale((current) => Math.max(0.55, current - 0.15)); }}>縮小</button>
+        <button onClick={() => { setFitMode('custom'); setScale((current) => Math.min(2.8, current + 0.15)); }}>拡大</button>
+        <button onClick={() => { setFitMode('custom'); setScale(1); }}>100%</button>
+        <button onClick={() => setFitMode('width')}>幅に合わせる</button>
+        <button onClick={() => setFitMode('height')}>高さに合わせる</button>
+      </div>
+      {renderError && <p className="warning-text">{renderError}</p>}
+      <div ref={wrapRef} className="pdf-canvas-wrap pdf-reader-wrap">
+        {!pdf && <p className="empty">PDFが選択されていません。</p>}
+        {loading && <p className="empty">PDFを表示中...</p>}
+        <canvas ref={canvasRef} className="pdf-canvas" />
+      </div>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getTemplateById } from '../data/templateCatalog';
+import type { AnswerBlockState, AnswerState, MaterialPdfMapping, MissReason, ProblemBlock, ReviewRank } from '../types';
+import { sumRowPoints } from '../utils/scoring';
+import { AnswerTable, createRows } from './AnswerTable';
+
+const missReasons: MissReason[] = [
+  '論点理解不足',
+  '仕訳ミス',
+  '借方貸方逆',
+  '金額ミス',
+  '集計ミス',
+  '転記ミス',
+  '表の入力位置ミス',
+  '下書き不足',
+  '時間不足',
+  '解答欄形式の誤認',
+  '問題文読み落とし',
+  'その他',
+];
+
+interface Props {
+  answer: AnswerState;
+  mapping?: MaterialPdfMapping;
+  onChange: (answer: AnswerState) => void;
+}
+
+function defaultBlockFromAnswer(answer: AnswerState): AnswerBlockState {
+  return {
+    id: 'legacy-main-block',
+    title: '問題文①',
+    description: '既存の答案入力テーブルを1ブロックとして表示しています。',
+    templateId: answer.templateId,
+    templateName: answer.templateName,
+    columns: answer.columns,
+    rows: answer.rows,
+    score: answer.score,
+    maxScore: answer.maxScore,
+    rowPointsTotal: answer.rowPointsTotal,
+    rank: answer.rank,
+    missReasons: answer.missReasons,
+    nextReviewPoint: '',
+    memo: answer.reviewMemo,
+    collapsed: false,
+  };
+}
+
+function blockFromMapping(block: ProblemBlock, index: number): AnswerBlockState {
+  const template = getTemplateById(block.templateId);
+  return {
+    id: block.id || crypto.randomUUID(),
+    title: block.title || `問題文${index + 1}`,
+    description: block.description ?? '',
+    templateId: block.templateId,
+    templateName: template.name,
+    columns: template.columns,
+    rows: block.rows && block.rows.length > 0 ? block.rows : createRows(template.columns.length, template.initialRows),
+    score: 0,
+    maxScore: 0,
+    rowPointsTotal: 0,
+    rank: '',
+    missReasons: [],
+    nextReviewPoint: '',
+    memo: block.memo ?? '',
+    collapsed: index !== 0,
+  };
+}
+
+function normalizeBlocks(answer: AnswerState, mapping?: MaterialPdfMapping): AnswerBlockState[] {
+  if (answer.problemBlocks && answer.problemBlocks.length > 0) return answer.problemBlocks;
+  if (mapping?.problemBlocks && mapping.problemBlocks.length > 0) return mapping.problemBlocks.map(blockFromMapping);
+  return [defaultBlockFromAnswer(answer)];
+}
+
+function summarize(answer: AnswerState, blocks: AnswerBlockState[]): AnswerState {
+  const score = blocks.reduce((total, block) => total + (Number(block.score) || 0), 0);
+  const maxScore = blocks.reduce((total, block) => total + (Number(block.maxScore) || 0), 0) || answer.maxScore;
+  const rowPointsTotal = blocks.reduce((total, block) => total + (Number(block.rowPointsTotal) || 0), 0);
+  const missReasons = Array.from(new Set(blocks.flatMap((block) => block.missReasons)));
+  return {
+    ...answer,
+    problemBlocks: blocks,
+    score,
+    maxScore,
+    rowPointsTotal,
+    missReasons,
+    rows: blocks[0]?.rows ?? answer.rows,
+    columns: blocks[0]?.columns ?? answer.columns,
+    templateId: blocks[0]?.templateId ?? answer.templateId,
+    templateName: blocks[0]?.templateName ?? answer.templateName,
+  };
+}
+
+function blockToAnswer(base: AnswerState, block: AnswerBlockState): AnswerState {
+  return {
+    ...base,
+    templateId: block.templateId,
+    templateName: block.templateName,
+    columns: block.columns,
+    rows: block.rows,
+    score: block.score,
+    maxScore: block.maxScore,
+    rowPointsTotal: block.rowPointsTotal,
+    rank: block.rank,
+    missReasons: block.missReasons,
+    reviewMemo: block.memo,
+  };
+}
+
+export function ProblemBlockAnswerPanel({ answer, mapping, onChange }: Props) {
+  const blocks = useMemo(() => normalizeBlocks(answer, mapping), [answer.problemBlocks, answer.problemId, mapping?.id, mapping?.problemBlocks]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!answer.problemBlocks || answer.problemBlocks.length === 0) onChange(summarize(answer, blocks));
+    // 初期化だけを目的にしているため、answer全体は依存に入れない。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [answer.problemId, mapping?.id]);
+
+  const updateBlocks = (nextBlocks: AnswerBlockState[]) => onChange(summarize(answer, nextBlocks));
+
+  const updateBlock = (index: number, patch: Partial<AnswerBlockState>) => {
+    updateBlocks(blocks.map((block, blockIndex) => blockIndex === index ? { ...block, ...patch } : block));
+  };
+
+  const updateBlockAnswer = (index: number, blockAnswer: AnswerState) => {
+    updateBlock(index, {
+      templateId: blockAnswer.templateId,
+      templateName: blockAnswer.templateName,
+      columns: blockAnswer.columns,
+      rows: blockAnswer.rows,
+      score: blockAnswer.score,
+      maxScore: blockAnswer.maxScore,
+      rowPointsTotal: blockAnswer.rowPointsTotal,
+      rank: blockAnswer.rank,
+      missReasons: blockAnswer.missReasons,
+      memo: blockAnswer.reviewMemo,
+    });
+  };
+
+  const applyRowPoints = (index: number) => {
+    const block = blocks[index];
+    const total = sumRowPoints(block.rows);
+    updateBlock(index, { rowPointsTotal: total, score: total });
+  };
+
+  const toggleReason = (index: number, reason: MissReason) => {
+    const block = blocks[index];
+    const exists = block.missReasons.includes(reason);
+    updateBlock(index, { missReasons: exists ? block.missReasons.filter((item) => item !== reason) : [...block.missReasons, reason] });
+  };
+
+  const setCollapsed = (index: number, collapsed: boolean) => updateBlock(index, { collapsed });
+  const expandAll = () => updateBlocks(blocks.map((block) => ({ ...block, collapsed: false })));
+  const collapseAll = () => updateBlocks(blocks.map((block, index) => ({ ...block, collapsed: index !== activeIndex })));
+  const moveActive = (delta: number) => {
+    const next = Math.max(0, Math.min(blocks.length - 1, activeIndex + delta));
+    setActiveIndex(next);
+    updateBlocks(blocks.map((block, index) => ({ ...block, collapsed: index !== next })));
+  };
+
+  return (
+    <section className="problem-block-answer-panel">
+      <div className="panel block-summary-panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">問題文ブロック別答案</p>
+            <h2>合計 {answer.score} / {answer.maxScore}</h2>
+            <p>問題文ごとに答案入力テーブルを分けます。既存データは1ブロックとして扱います。</p>
+          </div>
+          <div className="button-row">
+            <button onClick={expandAll}>すべて展開</button>
+            <button onClick={collapseAll}>すべて折りたたみ</button>
+            <button onClick={() => moveActive(-1)}>前の問題文へ</button>
+            <button onClick={() => moveActive(1)}>次の問題文へ</button>
+          </div>
+        </div>
+      </div>
+
+      {blocks.map((block, index) => {
+        const blockAnswer = blockToAnswer(answer, block);
+        return (
+          <section key={block.id} className={`panel problem-block-card ${index === activeIndex ? 'active-block' : ''}`}>
+            <div className="section-heading block-card-heading">
+              <div>
+                <p className="eyebrow">問題文{index + 1}</p>
+                <h2>{block.title}</h2>
+                {block.description && <p>{block.description}</p>}
+              </div>
+              <div className="block-score-box">
+                <strong>{block.score} / {block.maxScore || '-'}</strong>
+                <span>{block.rank || '未判定'}</span>
+              </div>
+            </div>
+            <div className="block-meta-grid">
+              <label>ブロック得点<input type="number" value={block.score} onChange={(event) => updateBlock(index, { score: Number(event.target.value) || 0 })} /></label>
+              <label>ブロック満点<input type="number" value={block.maxScore} onChange={(event) => updateBlock(index, { maxScore: Number(event.target.value) || 0 })} /></label>
+              <label>ブロック判定
+                <select value={block.rank} onChange={(event) => updateBlock(index, { rank: event.target.value as ReviewRank })}>
+                  <option value="">未選択</option><option value="A">A</option><option value="B">B</option><option value="C">C</option>
+                </select>
+              </label>
+              <button className="secondary" onClick={() => setCollapsed(index, !block.collapsed)}>{block.collapsed ? '開く' : '折りたたむ'}</button>
+            </div>
+            {!block.collapsed && (
+              <>
+                <AnswerTable answer={blockAnswer} template={getTemplateById(block.templateId)} onChange={(next) => updateBlockAnswer(index, next)} onApplyRowPoints={() => applyRowPoints(index)} />
+                <div className="block-review-grid">
+                  <label>次回注意点<textarea value={block.nextReviewPoint} onChange={(event) => updateBlock(index, { nextReviewPoint: event.target.value })} placeholder="次回このブロックを解く前に見る注意点" /></label>
+                  <label>ブロックメモ<textarea value={block.memo} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文・解答本文は貼らず、自分のミスと処理順だけを書く" /></label>
+                </div>
+                <div className="check-list block-miss-list">
+                  {missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={block.missReasons.includes(reason)} onChange={() => toggleReason(index, reason)} />{reason}</label>)}
+                </div>
+              </>
+            )}
+          </section>
+        );
+      })}
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
+++ b/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
@@ -45,15 +45,8 @@
   background: #174f5e;
 }
 
-.time-mode-button strong {
-  font-size: 22px;
-}
-
-.time-mode-button span {
-  font-size: 12px;
-  line-height: 1.5;
-  color: #e4f4f1;
-}
+.time-mode-button strong { font-size: 22px; }
+.time-mode-button span { font-size: 12px; line-height: 1.5; color: #e4f4f1; }
 
 .legal-notice {
   margin: 14px 0 0;
@@ -66,37 +59,19 @@
   font-weight: 700;
 }
 
-.legal-notice.compact {
-  margin-top: 0;
-}
-
-.pdf-import-label {
-  width: fit-content;
-}
-
-.form-grid.three-columns {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.form-grid.four-columns {
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.form-grid.six-columns {
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-}
+.legal-notice.compact { margin-top: 0; }
+.pdf-import-label { width: fit-content; }
+.form-grid.three-columns { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.form-grid.four-columns { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.form-grid.six-columns { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
 
 .practice-workspace,
-.answer-workspace {
-  display: grid;
-  gap: 16px;
-  min-width: 0;
-}
+.answer-workspace { display: grid; gap: 16px; min-width: 0; }
 
-.pdf-study-panel {
-  min-width: 0;
-  align-self: start;
-}
+.pdf-study-panel { min-width: 0; align-self: start; }
+
+.pdf-study-shell { display: grid; gap: 12px; }
+.pdf-launch-panel { border: 2px solid #cfe6df; }
 
 .pdf-toolbar {
   display: flex;
@@ -106,16 +81,9 @@
   margin: 10px 0;
 }
 
-.pdf-toolbar label {
-  display: grid;
-  gap: 4px;
-  font-weight: 700;
-  min-width: 90px;
-}
-
-.pdf-toolbar input {
-  max-width: 96px;
-}
+.pdf-toolbar label { display: grid; gap: 4px; font-weight: 700; min-width: 90px; }
+.pdf-toolbar input { max-width: 96px; }
+.pdf-toolbar-strong { padding: 10px; border-radius: 12px; background: #eef7f4; }
 
 .pdf-canvas-wrap {
   width: 100%;
@@ -127,18 +95,23 @@
   padding: 8px;
 }
 
-.pdf-canvas {
-  display: block;
-  max-width: none;
-  background: #fff;
-  box-shadow: 0 2px 12px rgba(0,0,0,.08);
-}
+.pdf-canvas { display: block; max-width: none; background: #fff; box-shadow: 0 2px 12px rgba(0,0,0,.08); }
 
-.study-actions {
-  margin-top: 12px;
-  display: flex;
-  justify-content: flex-end;
+.pdf-viewer-panel { display: grid; gap: 10px; }
+.pdf-viewer-large .pdf-reader-wrap { min-height: 70vh; max-height: 78vh; }
+.pdf-reader-wrap { min-height: 62vh; }
+.pdf-viewer-heading { gap: 12px; }
+.pdf-viewer-full {
+  position: fixed;
+  inset: 12px;
+  z-index: 2000;
+  overflow: auto;
+  border: 3px solid #0f5c68;
+  box-shadow: 0 20px 60px rgba(0,0,0,.35);
 }
+.pdf-viewer-full .pdf-reader-wrap { height: calc(100vh - 190px); max-height: none; }
+
+.study-actions { margin-top: 12px; display: flex; justify-content: flex-end; }
 
 .self-grade-panel {
   margin-top: 12px;
@@ -147,18 +120,10 @@
   border-radius: 12px;
   background: #f7fbf9;
 }
+.self-grade-panel h3 { margin-top: 0; }
 
-.self-grade-panel h3 {
-  margin-top: 0;
-}
-
-.redesigned-shell {
-  max-width: 1880px;
-}
-
-.compact-header {
-  margin-bottom: 10px;
-}
+.redesigned-shell { max-width: 1880px; }
+.compact-header { margin-bottom: 10px; }
 
 .mode-nav {
   position: sticky;
@@ -174,264 +139,104 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, .08);
 }
 
-.mode-nav button {
-  min-height: 52px;
-  font-size: 16px;
-  font-weight: 900;
-  background: #ebf3f1;
-  color: #143a40;
-}
+.mode-nav button { min-height: 52px; font-size: 16px; font-weight: 900; background: #ebf3f1; color: #143a40; }
+.mode-nav button.active { background: #0f5c68; color: #fff; }
 
-.mode-nav button.active {
-  background: #0f5c68;
-  color: #fff;
-}
+.mode-section { display: grid; gap: 14px; }
+.mode-card { border: 1px solid #d6e4e1; box-shadow: 0 6px 18px rgba(23, 79, 94, .08); }
 
-.mode-section {
-  display: grid;
-  gap: 14px;
-}
-
-.mode-card {
-  border: 1px solid #d6e4e1;
-  box-shadow: 0 6px 18px rgba(23, 79, 94, .08);
-}
-
-.study-problem-strip {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px;
-  align-items: center;
-}
-
-.mobile-study-tabs {
-  display: none;
-}
+.study-problem-strip { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 16px; align-items: center; }
+.mobile-study-tabs { display: none; }
 
 .focused-study-layout {
   display: grid;
-  grid-template-columns: minmax(320px, 26%) minmax(0, 74%);
+  grid-template-columns: 1fr;
   gap: 16px;
   align-items: start;
 }
 
-.focused-study-layout.show-pdf {
-  grid-template-columns: minmax(520px, 54%) minmax(0, 46%);
-}
-
-.study-pdf-column {
-  min-width: 0;
-}
-
-.study-pdf-column .pdf-study-panel {
-  position: sticky;
-  top: 88px;
-}
-
-.answer-main-column {
-  min-width: 0;
-  display: grid;
-  gap: 16px;
-}
-
-.focused-study-layout.show-answer .study-pdf-column .pdf-canvas-wrap {
-  max-height: 38vh;
-}
-
-.focused-study-layout.show-answer .answer-main-column {
-  font-size: 1.02rem;
-}
-
+.focused-study-layout.show-pdf { grid-template-columns: minmax(560px, 45%) minmax(0, 55%); }
+.study-pdf-column { min-width: 0; }
+.answer-main-column { min-width: 0; display: grid; gap: 16px; }
+.focused-study-layout.show-answer .answer-main-column { font-size: 1.02rem; }
 .focused-study-layout.show-answer .answer-main-column .panel,
-.grading-answer-column .panel {
-  border: 2px solid #b8dfc2;
-}
+.grading-answer-column .panel { border: 2px solid #b8dfc2; }
 
-.grading-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 58%) minmax(420px, 42%);
-  gap: 16px;
-  align-items: start;
-}
-
+.grading-layout { display: grid; grid-template-columns: minmax(0, 58%) minmax(420px, 42%); gap: 16px; align-items: start; }
 .grading-answer-column,
-.grading-pdf-column {
-  min-width: 0;
-  display: grid;
-  gap: 16px;
-}
+.grading-pdf-column { min-width: 0; display: grid; gap: 16px; }
 
-.material-setup-grid {
-  display: grid;
-  grid-template-columns: minmax(420px, .95fr) minmax(520px, 1.05fr);
-  gap: 16px;
-  align-items: start;
-}
-
+.material-setup-grid { display: grid; grid-template-columns: minmax(58%, 1.35fr) minmax(360px, .65fr); gap: 16px; align-items: start; }
+.wizard-setup-grid .setup-preview-panel { grid-column: 1; grid-row: 1 / span 2; position: sticky; top: 88px; }
+.wizard-setup-grid .wizard-control-panel { grid-column: 2; grid-row: 1; }
 .setup-control-panel,
-.setup-preview-panel {
-  min-width: 0;
-}
+.setup-preview-panel { min-width: 0; }
+.setup-canvas-wrap { max-height: 76vh; }
+.mapping-list-panel { grid-column: 1 / -1; }
 
-.setup-preview-panel {
-  position: sticky;
-  top: 88px;
-}
+.wizard-step-card { border: 1px solid #d8e8e4; border-radius: 14px; padding: 10px 12px; margin-top: 12px; background: #fbfdfc; }
+.wizard-step-card > summary { cursor: pointer; font-weight: 900; font-size: 16px; }
+.auto-link-candidates { display: grid; gap: 8px; margin-top: 12px; }
+.candidate-row { display: grid; grid-template-columns: auto minmax(140px, .5fr) minmax(180px, 1fr) repeat(4, auto); gap: 6px; align-items: center; padding: 8px; border-radius: 10px; background: #f2f8f6; border: 1px solid #d8e8e4; }
+.candidate-row small { color: #53676a; }
+.block-editor-list { display: grid; gap: 12px; margin-top: 12px; }
+.block-editor-card { padding: 12px; border: 1px solid #d8e8e4; border-radius: 14px; background: #fff; }
 
-.setup-canvas-wrap {
-  max-height: 76vh;
-}
+.problem-block-answer-panel { display: grid; gap: 14px; }
+.block-summary-panel { border: 2px solid #d7eadf; }
+.problem-block-card { border: 1px solid #d8e8e4; }
+.problem-block-card.active-block { border: 3px solid #0f5c68; box-shadow: 0 8px 28px rgba(15, 92, 104, .16); }
+.block-card-heading { align-items: start; }
+.block-score-box { display: grid; gap: 4px; min-width: 120px; padding: 10px; border-radius: 12px; background: #eef7f4; text-align: center; }
+.block-score-box strong { font-size: 22px; color: #0f5c68; }
+.block-meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 10px; margin-bottom: 12px; }
+.block-review-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
+.block-miss-list { margin-top: 10px; }
 
-.mapping-list-panel {
-  grid-column: 1 / -1;
-}
-
-.progress-overview-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(460px, auto);
-  gap: 18px;
-  align-items: center;
-}
-
-.progress-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(120px, 1fr));
-  gap: 10px;
-}
-
-.progress-summary-grid div {
-  display: grid;
-  gap: 4px;
-  padding: 14px;
-  border-radius: 14px;
-  background: #f2f8f6;
-  border: 1px solid #d8e8e4;
-}
-
-.progress-summary-grid strong {
-  font-size: 28px;
-  color: #0f5c68;
-}
-
-.progress-summary-grid span {
-  font-size: 12px;
-  font-weight: 800;
-}
+.progress-overview-panel { display: grid; grid-template-columns: minmax(0, 1fr) minmax(460px, auto); gap: 18px; align-items: center; }
+.progress-summary-grid { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 10px; }
+.progress-summary-grid div { display: grid; gap: 4px; padding: 14px; border-radius: 14px; background: #f2f8f6; border: 1px solid #d8e8e4; }
+.progress-summary-grid strong { font-size: 28px; color: #0f5c68; }
+.progress-summary-grid span { font-size: 12px; font-weight: 800; }
 
 .management-panel > summary,
-.mapping-list-panel > summary {
-  cursor: pointer;
-  font-weight: 900;
-  font-size: 18px;
-  padding: 8px 0;
-}
-
-.management-actions {
-  margin-top: 8px;
-}
-
-.sticky-actions {
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
-  padding: 10px 0;
-  background: linear-gradient(180deg, rgba(255,255,255,.75), #fff 35%);
-}
+.mapping-list-panel > summary { cursor: pointer; font-weight: 900; font-size: 18px; padding: 8px 0; }
+.management-actions { margin-top: 8px; }
+.sticky-actions { position: sticky; bottom: 0; z-index: 5; padding: 10px 0; background: linear-gradient(180deg, rgba(255,255,255,.75), #fff 35%); }
 
 @media (max-width: 1500px) {
-  .time-mode-grid {
-    grid-template-columns: repeat(3, minmax(160px, 1fr));
-  }
-
+  .time-mode-grid { grid-template-columns: repeat(3, minmax(160px, 1fr)); }
   .focused-study-layout,
   .focused-study-layout.show-pdf,
   .grading-layout,
   .material-setup-grid,
-  .progress-overview-panel {
-    grid-template-columns: 1fr;
-  }
-
-  .study-pdf-column .pdf-study-panel,
-  .setup-preview-panel {
-    position: static;
-  }
+  .progress-overview-panel { grid-template-columns: 1fr; }
+  .wizard-setup-grid .setup-preview-panel,
+  .wizard-setup-grid .wizard-control-panel { grid-column: auto; grid-row: auto; position: static; }
+  .candidate-row { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 900px) {
-  .mode-nav {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .mobile-study-tabs {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 8px;
-    position: sticky;
-    top: 86px;
-    z-index: 15;
-    padding: 8px;
-    border-radius: 14px;
-    background: rgba(255,255,255,.96);
-    box-shadow: 0 4px 14px rgba(0,0,0,.08);
-  }
-
-  .mobile-study-tabs button.active {
-    background: #0f5c68;
-  }
-
-  .focused-study-layout.show-answer .study-pdf-column {
-    display: none;
-  }
-
-  .focused-study-layout.show-pdf .answer-main-column {
-    display: none;
-  }
-
-  .progress-summary-grid {
-    grid-template-columns: 1fr 1fr;
-  }
+  .mode-nav { grid-template-columns: 1fr 1fr; }
+  .mobile-study-tabs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; position: sticky; top: 86px; z-index: 15; padding: 8px; border-radius: 14px; background: rgba(255,255,255,.96); box-shadow: 0 4px 14px rgba(0,0,0,.08); }
+  .mobile-study-tabs button.active { background: #0f5c68; }
+  .focused-study-layout.show-answer .study-pdf-column { display: none; }
+  .focused-study-layout.show-pdf .answer-main-column { display: none; }
+  .progress-summary-grid { grid-template-columns: 1fr 1fr; }
+  .block-review-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 760px) {
   .disposable-hero,
-  .study-problem-strip {
-    grid-template-columns: 1fr;
-  }
-
-  .resume-button {
-    width: 100%;
-  }
-
-  .time-mode-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .time-mode-button {
-    min-height: 86px;
-  }
-
-  .pdf-canvas-wrap {
-    max-height: 58vh;
-  }
-
-  .study-actions {
-    justify-content: stretch;
-  }
-
-  .study-actions .resume-button {
-    width: 100%;
-  }
-
-  .mode-nav {
-    grid-template-columns: 1fr;
-    position: static;
-  }
-
-  .mobile-study-tabs {
-    top: 0;
-  }
-
-  .progress-summary-grid {
-    grid-template-columns: 1fr;
-  }
+  .study-problem-strip { grid-template-columns: 1fr; }
+  .resume-button { width: 100%; }
+  .time-mode-grid { grid-template-columns: 1fr 1fr; }
+  .time-mode-button { min-height: 86px; }
+  .pdf-canvas-wrap { max-height: 58vh; }
+  .pdf-viewer-large .pdf-reader-wrap { min-height: 58vh; }
+  .study-actions { justify-content: stretch; }
+  .study-actions .resume-button { width: 100%; }
+  .mode-nav { grid-template-columns: 1fr; position: static; }
+  .mobile-study-tabs { top: 0; }
+  .progress-summary-grid { grid-template-columns: 1fr; }
 }

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -6,6 +6,7 @@ export type ReviewRank = '' | 'A' | 'B' | 'C';
 export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方逆' | '金額ミス' | '集計ミス' | '転記ミス' | '表の入力位置ミス' | '下書き不足' | '時間不足' | '解答欄形式の誤認' | '問題文読み落とし' | 'その他';
 export type TimeMode = '1分' | '3分' | '5分' | '10分' | '30分' | '90分';
 export type GradingStatus = '正解' | '部分正解' | '不正解' | '迷いあり';
+export type BlockDifficulty = '易しい' | '標準' | 'やや難' | '難しい';
 
 export interface ProblemDefinition {
   id: string;
@@ -41,6 +42,41 @@ export interface AnswerRow {
   points: number;
 }
 
+export interface ProblemBlock {
+  id: string;
+  title: string;
+  description?: string;
+  problemPageStart?: number;
+  problemPageEnd?: number;
+  answerPageStart?: number;
+  answerPageEnd?: number;
+  explanationPageStart?: number;
+  explanationPageEnd?: number;
+  estimatedMinutes?: number;
+  difficulty?: BlockDifficulty;
+  templateId: TemplateId;
+  rows?: AnswerRow[];
+  memo?: string;
+}
+
+export interface AnswerBlockState {
+  id: string;
+  title: string;
+  description?: string;
+  templateId: TemplateId;
+  templateName: string;
+  columns: string[];
+  rows: AnswerRow[];
+  score: number;
+  maxScore: number;
+  rowPointsTotal: number;
+  rank: ReviewRank;
+  missReasons: MissReason[];
+  nextReviewPoint: string;
+  memo: string;
+  collapsed?: boolean;
+}
+
 export interface AnswerState {
   id: string;
   problemId: string;
@@ -48,6 +84,7 @@ export interface AnswerState {
   templateName: string;
   columns: string[];
   rows: AnswerRow[];
+  problemBlocks?: AnswerBlockState[];
   draftMemo: string;
   reviewMemo: string;
   score: number;
@@ -251,6 +288,7 @@ export interface MaterialPdfMapping {
   estimatedMinutes: TimeMode;
   difficulty: '易' | '標準' | '難';
   memo: string;
+  problemBlocks?: ProblemBlock[];
   createdAt: string;
   updatedAt: string;
 }

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfAutoLink.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfAutoLink.ts
@@ -1,0 +1,27 @@
+import type { MaterialPdf } from '../types';
+import { extractPdfPageText } from './pdfRenderer';
+
+export interface PdfAutoLinkCandidate {
+  page: number;
+  labels: string[];
+  preview: string;
+}
+
+const KEYWORDS = ['第1問対策', '第2問対策', '第3問対策', '第4問対策', '第5問対策', '問題', '解答', '解説', '仕訳', '連結', 'CVP', '標準原価', '直接原価計算', '工業簿記', '商業簿記'];
+
+export async function suggestPdfLinkCandidates(pdf: MaterialPdf, maxPages = 80): Promise<PdfAutoLinkCandidate[]> {
+  const limit = Math.min(pdf.pageCount, maxPages);
+  const candidates: PdfAutoLinkCandidate[] = [];
+  for (let page = 1; page <= limit; page += 1) {
+    try {
+      const text = await extractPdfPageText(pdf.pdfBlob, page);
+      if (!text.trim()) continue;
+      const labels = KEYWORDS.filter((keyword) => text.includes(keyword));
+      if (labels.length === 0) continue;
+      candidates.push({ page, labels, preview: text.replace(/\s+/g, ' ').slice(0, 120) });
+    } catch {
+      // テキスト抽出できないページは候補なしとして扱う。OCRは行わない。
+    }
+  }
+  return candidates;
+}

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
@@ -26,6 +26,16 @@ export async function renderPdfPageToCanvas(blob: Blob, pageNumber: number, scal
   await renderTask.promise;
 }
 
+export async function extractPdfPageText(blob: Blob, pageNumber: number): Promise<string> {
+  const data = new Uint8Array(await blob.arrayBuffer());
+  const task = pdfjsLib.getDocument({ data });
+  const pdf = await task.promise;
+  const safePage = Math.max(1, Math.min(pageNumber, pdf.numPages));
+  const page = await pdf.getPage(safePage);
+  const textContent = await page.getTextContent();
+  return textContent.items.map((item) => ('str' in item ? item.str : '')).join(' ');
+}
+
 export function formatFileSize(size: number): string {
   if (size >= 1024 * 1024) return `${(size / 1024 / 1024).toFixed(1)}MB`;
   if (size >= 1024) return `${Math.round(size / 1024)}KB`;

--- a/cpa-boki2-trial-section-answer-manager/src/utils/scoring.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/scoring.ts
@@ -4,10 +4,15 @@ export function sumRowPoints(rows: AnswerRow[]): number {
   return rows.reduce((sum, row) => sum + (Number(row.points) || 0), 0);
 }
 
+function rowsHaveMeaning(rows: AnswerRow[]): boolean {
+  const hasCells = rows.some((row) => row.cells.some((cell) => cell.trim() !== ''));
+  const hasScoring = rows.some((row) => row.grade !== '未採点' || Number(row.points) !== 0);
+  return hasCells || hasScoring;
+}
+
 export function hasMeaningfulAnswer(answer: AnswerState): boolean {
-  const hasCells = answer.rows.some((row) => row.cells.some((cell) => cell.trim() !== ''));
-  const hasScoring = answer.rows.some((row) => row.grade !== '未採点' || Number(row.points) !== 0);
-  return hasCells || hasScoring || answer.score !== 0 || answer.rank !== '' || answer.missReasons.length > 0 || answer.draftMemo.trim() !== '' || answer.reviewMemo.trim() !== '' || answer.scored;
+  const hasBlockAnswer = answer.problemBlocks?.some((block) => rowsHaveMeaning(block.rows) || block.score !== 0 || block.rank !== '' || block.missReasons.length > 0 || block.memo.trim() !== '' || block.nextReviewPoint.trim() !== '') ?? false;
+  return rowsHaveMeaning(answer.rows) || hasBlockAnswer || answer.score !== 0 || answer.rank !== '' || answer.missReasons.length > 0 || answer.draftMemo.trim() !== '' || answer.reviewMemo.trim() !== '' || answer.scored;
 }
 
 export function draftSummary(value: string, length = 80): string {


### PR DESCRIPTION
## 1. 修正目的

PR #237でモード分離したCPA日商簿記2級 試験対策編 解答・復習管理アプリについて、実運用時にPDF教材を読みながら最短時間で演習できる状態へ近づけるための改善です。

今回の目的は機能を増やすことではなく、以下3点を一体で修正することです。

- PDF問題ページを大きく読めるようにする
- PDFを見ながら問題・解答・解説ページと問題文ブロックを紐づけられるようにする
- 1つの巨大答案テーブルではなく、問題文ブロックごとに答案入力テーブルを分割する

## 2. 変更ファイル一覧

変更対象は `cpa-boki2-trial-section-answer-manager/` 配下のみです。

- `src/App.tsx`
- `src/components/MaterialSetupWorkspace.tsx`
- `src/components/PdfStudyPanel.tsx`
- `src/components/PdfViewerPanel.tsx`
- `src/components/ProblemBlockAnswerPanel.tsx`
- `src/disposableStudy.css`
- `src/types/index.ts`
- `src/utils/pdfAutoLink.ts`
- `src/utils/pdfRenderer.ts`
- `src/utils/scoring.ts`

## 3. PDF表示改善内容

`PdfViewerPanel` を追加し、PDFを小さく固定表示するのではなく、必要時に大きく開ける構成にしました。

対応内容:

- 前ページ / 次ページ
- ページ番号入力
- 拡大 / 縮小
- 100%
- 幅に合わせる
- 高さに合わせる
- フルスクリーン風表示
- 閉じる
- 現在ページ / 総ページ数
- 登録ページ範囲表示
- 現在倍率表示

「今すぐ解く」では答案入力を主役にし、PDFは「問題PDFを大きく開く」導線に寄せています。スマホ・タブレットでは、問題を見る / 答案を書く / 採点する の切替を維持し、PDFと答案入力を無理に同時表示しません。

## 4. PDF自動紐づけウィザード内容

`MaterialSetupWorkspace` を拡張し、教材設定モードを以下の流れにしました。

1. PDF教材を登録する
2. 問題ページを紐づける
3. 問題ブロックを作る
4. 保存済みマッピングを確認する

登録できる内容:

- 問題ID
- 対象PDF
- 問題ページ開始 / 終了
- 解答ページ開始 / 終了
- 解説ページ開始 / 終了
- 想定時間
- 難易度
- メモ
- 問題文ブロック
- 各ブロック名
- 各ブロックのページ範囲
- 各ブロックの答案テンプレート
- 各ブロックの想定時間・難易度・メモ

PDFプレビューは `PdfViewerPanel` を使い、教材設定画面でもPDFを大きく見ながらページ範囲を指定できます。

## 5. PDF候補ページ提案

`pdfAutoLink.ts` を追加し、PDF.jsのテキストレイヤーを使って候補ページを提案できるようにしました。

検出対象例:

- 第1問対策
- 第2問対策
- 第3問対策
- 第4問対策
- 第5問対策
- 問題
- 解答
- 解説
- 仕訳
- 連結
- CVP
- 標準原価
- 直接原価計算

注意点:

- 完全自動確定はしません
- 候補は必ず利用者がPDFを確認して保存します
- OCRは実装していません
- スキャン画像PDFや画像化PDFでは候補が出ない場合があります
- 候補が出ない場合でも手動指定できます

画面上にも注意文を表示しています。

> PDFの作りによっては自動候補が出ない場合があります。その場合はPDFを見ながら手動でページ範囲を指定してください。

## 6. 問題文ブロック別答案テーブル内容

`ProblemBlockAnswerPanel` を追加し、問題文ブロックごとに独立した答案入力テーブルを表示できるようにしました。

各ブロックで管理できる内容:

- 答案入力テーブル
- ブロック得点
- ブロック満点
- ブロック判定
- ミス原因
- 次回注意点
- ブロックメモ

対応操作:

- すべて展開
- すべて折りたたみ
- 前の問題文へ
- 次の問題文へ
- 現在編集中ブロックの強調表示

問題ID全体の得点は、各ブロック得点の合計として `AnswerState.score` に反映されます。

## 7. 既存答案入力機能の維持

ブロック内の答案入力は既存の `AnswerTable` を再利用しています。

維持している内容:

- 3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリックによるセル内編集モード
- Escで編集モード解除
- Enter / Shift+Enter移動
- 行追加
- 列追加
- 空行整理
- 行別採点
- 行別得点合計反映

## 8. データ互換性

既存の `answers` / `histories` を壊さないため、`problemBlocks` は任意項目として追加しています。

既存データに `problemBlocks` がない場合は、従来の答案テーブルを1ブロック扱いで表示します。

追加した主な型:

- `ProblemBlock`
- `AnswerBlockState`
- `BlockDifficulty`

IndexedDBの新規ストア追加はしていません。既存の `MaterialPdfMapping` に任意の `problemBlocks` を持たせる形にしています。

## 9. 著作権対応

以下は行っていません。

- CPA教材PDFをGitHubに保存
- CPA教材PDFをpublicフォルダへ配置
- CPA教材PDFをsrc配下へ配置
- CPA教材の問題文・解答・解説をコードに埋め込み
- CPAロゴ・教材画像の同梱
- PDFを外部サーバーへ送信
- SupabaseへPDF保存
- OCR
- AI解説
- 自動採点

PDFは利用者本人が端末内で選択し、IndexedDBへBlob保存する既存方針を維持しています。JSONバックアップにはPDF Blob本体を含めない既存方針も維持しています。

## 10. 既存案件管理アプリへの影響

影響なしです。

以下は変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- 既存トップURL

## 11. Pages workflowへの影響

影響なしです。

以下は変更していません。

- `.github/workflows/pages.yml`
- 既存Pages workflow

## 12. 今回やらないこと

以下は今回も実装していません。

- OCR
- AI解説
- 自動採点
- Supabase同期
- ログイン
- PDF本文全文抽出
- PDF Blob込みバックアップ
- CPA教材本文のコード埋め込み
- 問題文・解答・解説の初期データ投入
- グラフ追加
- デザイン装飾の大幅変更

## 13. 動作確認結果

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 14. 実URLで確認すべき項目

マージ後、以下を確認してください。

- トップURLでは既存案件管理アプリが開く
- サブURLでは簿記2級アプリが開く
- 今すぐ解く画面で問題PDFを大きく開ける
- PDFで前ページ / 次ページ / ページ番号入力 / 拡大 / 縮小 / 100% / 幅に合わせる / 高さに合わせる / フルスクリーン風表示 / 閉じる が使える
- PDFを閉じると答案入力エリアが広く表示される
- 教材設定画面でPDFを大きくプレビューできる
- 問題ページ・解答ページ・解説ページ範囲を保存できる
- 候補ページ提案が表示される、または候補なしでも手動指定できる
- 問題文ブロックを追加できる
- ブロックごとに答案テンプレートを指定できる
- 今すぐ解く画面で問題文ブロック別に答案入力テーブルが表示される
- 各ブロックの得点合計が問題全体の得点に反映される
- 既存の履歴保存、JSONバックアップ、今日の学習キュー、90分セット演習、合格到達マップが壊れていない