### PR TITLE
Redesign CPA Boki2 practice UI as question-based flow

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -11,7 +11,6 @@ import { MaterialSetupWorkspace } from './components/MaterialSetupWorkspace';
 import { MistakeCardPanel } from './components/MistakeCardPanel';
 import { PdfStudyPanel } from './components/PdfStudyPanel';
 import { ProblemBlockAnswerPanel } from './components/ProblemBlockAnswerPanel';
-import { ProblemSelector } from './components/ProblemSelector';
 import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
 import { ScoringPanel } from './components/ScoringPanel';
@@ -104,13 +103,7 @@ function normalizeAnswer(answer: AnswerState): AnswerState {
     return { ...row, cells: columns.map((_, index) => cells[index] ?? '') };
   });
 
-  return {
-    ...answer,
-    columns,
-    rows,
-    templateName: template.name,
-    updatedAt: nowIso(),
-  };
+  return { ...answer, columns, rows, templateName: template.name, updatedAt: nowIso() };
 }
 
 function buildHistory(answer: AnswerState): HistoryEntry {
@@ -171,6 +164,7 @@ export default function App() {
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
   const currentMapping = useMemo(() => pdfMappings.find((item) => item.problemId === problemId), [pdfMappings, problemId]);
+  const currentPdf = useMemo(() => materialPdfs.find((item) => item.id === currentMapping?.materialPdfId), [materialPdfs, currentMapping?.materialPdfId]);
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
@@ -188,10 +182,7 @@ export default function App() {
     untouched: masteryMap.filter((item) => item.status === '未着手').length,
   }), [studyQueue, masteryMap]);
 
-  async function refreshAnswers() {
-    setAnswers((await getAllAnswers()).map(normalizeAnswer));
-  }
-
+  async function refreshAnswers() { setAnswers((await getAllAnswers()).map(normalizeAnswer)); }
   async function loadHistories() { setHistories(await getHistories()); }
   async function loadExamSets() { setExamSets(await getExamSets()); }
   async function loadMistakeCards() { setMistakeCards(await getMistakeCards()); }
@@ -232,13 +223,6 @@ export default function App() {
   }, [answer]);
 
   const updateAnswer = (next: AnswerState) => setAnswer(normalizeAnswer({ ...next, updatedAt: nowIso() }));
-
-  const selectTemplate = (templateId: TemplateId) => {
-    const nextTemplate = getTemplateById(templateId);
-    const keep = window.confirm('テンプレートを変更すると現在の答案テーブルを新しい初期行に置き換えます。変更しますか？');
-    if (!keep) return;
-    updateAnswer({ ...answer, templateId, templateName: nextTemplate.name, columns: nextTemplate.columns, rows: createRows(nextTemplate.columns.length, nextTemplate.initialRows), problemBlocks: [] });
-  };
 
   async function createPracticeSession(problemIdForSession: string, selectedTimeMode: TimeMode): Promise<PracticeSession> {
     const problemDefinition = getProblemById(problemIdForSession);
@@ -287,46 +271,12 @@ export default function App() {
     return beginPractice(problem.id, currentMapping?.estimatedMinutes ?? '10分', '現在の問題ID');
   }
 
-  async function updatePracticeSession(session: PracticeSession) {
-    await savePracticeSession(session);
-    setActiveSessionId(session.id);
-    await loadPracticeSessions();
-  }
-
-  const applyRowPoints = () => {
-    const total = sumRowPoints(answer.rows);
-    updateAnswer({ ...answer, rowPointsTotal: total, score: total });
-  };
+  async function updatePracticeSession(session: PracticeSession) { await savePracticeSession(session); setActiveSessionId(session.id); await loadPracticeSessions(); }
 
   const manualSave = async () => { await saveAnswer(normalizeAnswer({ ...answer, updatedAt: nowIso() })); await refreshAll(); setMessage('手動保存しました'); };
-
-  const clearCurrentAnswer = async () => {
-    if (!window.confirm('現在問題IDの答案を全消去しますか？履歴は消えません。')) return;
-    const cleared = createAnswer(problemId, answer.templateId);
-    await saveAnswer(cleared);
-    setAnswer(cleared);
-    await refreshAll();
-    setMessage('現在問題IDの答案を全消去しました');
-  };
-
-  const bulkAddAllAnswers = async () => {
-    const rows = (await getAllAnswers()).map(normalizeAnswer).filter(hasMeaningfulAnswer);
-    if (rows.length === 0) { setMessage('履歴追加できる保存済み答案がありません'); return; }
-    for (const item of rows) await addHistory(buildHistory(item));
-    await refreshAll();
-    setMessage(`保存済み答案 ${rows.length}件を一括で履歴追加しました`);
-  };
-
-  const confirmScoring = async () => {
-    const rowTotal = sumRowPoints(answer.rows);
-    const scored = normalizeAnswer({ ...answer, rowPointsTotal: rowTotal, score: rowTotal || answer.score, scored: true, scoredAt: nowIso(), updatedAt: nowIso() });
-    if (!hasMeaningfulAnswer(scored)) { setMessage('空の答案は履歴に追加しませんでした'); return; }
-    await saveAnswer(scored);
-    await addHistory(buildHistory(scored));
-    setAnswer(scored);
-    await refreshAll();
-    setMessage('採点確定して履歴に追加しました');
-  };
+  const clearCurrentAnswer = async () => { if (!window.confirm('現在問題IDの答案を全消去しますか？履歴は消えません。')) return; const cleared = createAnswer(problemId, answer.templateId); await saveAnswer(cleared); setAnswer(cleared); await refreshAll(); setMessage('現在問題IDの答案を全消去しました'); };
+  const bulkAddAllAnswers = async () => { const rows = (await getAllAnswers()).map(normalizeAnswer).filter(hasMeaningfulAnswer); if (rows.length === 0) { setMessage('履歴追加できる保存済み答案がありません'); return; } for (const item of rows) await addHistory(buildHistory(item)); await refreshAll(); setMessage(`保存済み答案 ${rows.length}件を一括で履歴追加しました`); };
+  const confirmScoring = async () => { const rowTotal = sumRowPoints(answer.rows); const scored = normalizeAnswer({ ...answer, rowPointsTotal: rowTotal, score: rowTotal || answer.score, scored: true, scoredAt: nowIso(), updatedAt: nowIso() }); if (!hasMeaningfulAnswer(scored)) { setMessage('空の答案は履歴に追加しませんでした'); return; } await saveAnswer(scored); await addHistory(buildHistory(scored)); setAnswer(scored); await refreshAll(); setMessage('採点確定して履歴に追加しました'); };
 
   async function submitSelfGrading(input: { status: GradingStatus; score: number; maxScore: number; memo: string }) {
     const submittedAt = nowIso();
@@ -335,29 +285,10 @@ export default function App() {
     const scored = normalizeAnswer({ ...answer, score: input.score, maxScore: input.maxScore, scored: true, scoringStarted: true, scoredAt: submittedAt, rank, nextReviewDate: reviewState.nextReviewDate, reviewMemo: input.memo || answer.reviewMemo, updatedAt: submittedAt });
     const session = activeSession && activeSession.problemId === problem.id && !activeSession.completed ? activeSession : await startCurrentSession();
     const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, memo: input.memo, completed: true };
-    await saveAnswer(scored);
-    await addHistory(buildHistory(scored));
-    await saveReviewState(reviewState);
-    await savePracticeSession(completedSession);
-    setAnswer(scored);
-    setActiveSessionId('');
-    setMode('progress');
-    await refreshAll();
-    setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
+    await saveAnswer(scored); await addHistory(buildHistory(scored)); await saveReviewState(reviewState); await savePracticeSession(completedSession); setAnswer(scored); setActiveSessionId(''); setMode('progress'); await refreshAll(); setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
   }
 
-  const restoreHistory = async (entry: HistoryEntry) => {
-    if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return;
-    const restored = normalizeAnswer(entry.snapshot);
-    await saveAnswer(restored);
-    setProblemId(entry.problemId);
-    setAnswer(restored);
-    setMode('study');
-    setStudyView('answer');
-    await refreshAll();
-    setMessage('履歴を復元しました');
-  };
-
+  const restoreHistory = async (entry: HistoryEntry) => { if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return; const restored = normalizeAnswer(entry.snapshot); await saveAnswer(restored); setProblemId(entry.problemId); setAnswer(restored); setMode('study'); setStudyView('answer'); await refreshAll(); setMessage('履歴を復元しました'); };
   const deleteHistoryEntry = async (id: string) => { if (!window.confirm('この履歴を削除しますか？')) return; await deleteHistory(id); await refreshAll(); setMessage('履歴を削除しました'); };
   const clearAllHistories = async () => { if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return; await clearHistories(); await refreshAll(); setMessage('履歴を全削除しました'); };
   const saveCard = async (card: MistakeCard) => { await saveMistakeCard(card); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを保存しました'); };
@@ -378,55 +309,27 @@ export default function App() {
   const exportMasteryCsv = () => downloadCsv('mastery-map.csv', masteryMapCsvRows(masteryMap));
   const exportMistakeCardsCsv = () => downloadCsv('mistake-cards.csv', mistakeCardCsvRows(mistakeCards, getProblemById));
   const exportRecoveryCsv = () => downloadCsv('recovery-plan.csv', recoveryPlanCsvRows(recoveryPlan));
+  const exportJson = async () => { const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]); const meta = await recordBackupMade(historyRows.length, answerRows.length); const payload = await exportAllData(); downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8'); setBackupMeta(meta); await refreshSafety(); setMessage('JSONバックアップを出力しました。PDF Blob本体はPR2対象のため含めていません。'); };
+  const importJson = async (file: File | undefined) => { if (!file) return; try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。'); } catch { setMessage('JSONの形式が不正です'); } };
 
-  const exportJson = async () => {
-    const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]);
-    const meta = await recordBackupMade(historyRows.length, answerRows.length);
-    const payload = await exportAllData();
-    downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8');
-    setBackupMeta(meta);
-    await refreshSafety();
-    setMessage('JSONバックアップを出力しました。PDF Blob本体はPR2対象のため含めていません。');
-  };
-
-  const importJson = async (file: File | undefined) => {
-    if (!file) return;
-    try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。'); }
-    catch { setMessage('JSONの形式が不正です'); }
-  };
-
-  const saveExamSetRecord = async (record: ExamSetRecord) => {
-    const relatedHistoryIds: string[] = [];
-    for (const problemState of record.problemStates) {
-      if (problemState.rank !== 'B' && problemState.rank !== 'C') continue;
-      const problemDefinition = getProblemById(problemState.problemId);
-      const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId);
-      const scored = normalizeAnswer({ ...base, score: Number(problemState.score) || 0, rowPointsTotal: Number(problemState.score) || 0, rank: problemState.rank, nextReviewDate: reviewDateForRank(problemState.rank), reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`, scored: true, scoredAt: nowIso(), updatedAt: nowIso() });
-      const history = buildHistory(scored);
-      relatedHistoryIds.push(history.id);
-      await addHistory(history);
-    }
-    await saveExamSet({ ...record, relatedHistoryIds });
-    await refreshAll();
-    setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。');
-  };
-
+  const saveExamSetRecord = async (record: ExamSetRecord) => { const relatedHistoryIds: string[] = []; for (const problemState of record.problemStates) { if (problemState.rank !== 'B' && problemState.rank !== 'C') continue; const problemDefinition = getProblemById(problemState.problemId); const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId); const scored = normalizeAnswer({ ...base, score: Number(problemState.score) || 0, rowPointsTotal: Number(problemState.score) || 0, rank: problemState.rank, nextReviewDate: reviewDateForRank(problemState.rank), reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`, scored: true, scoredAt: nowIso(), updatedAt: nowIso() }); const history = buildHistory(scored); relatedHistoryIds.push(history.id); await addHistory(history); } await saveExamSet({ ...record, relatedHistoryIds }); await refreshAll(); setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。'); };
   const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('study'); setStudyView('answer'); };
 
   return (
     <main className="app-shell redesigned-shell">
-      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>問題を見る → 答案を書く → 回答する → 解答/解説を見る → 自己採点する → 次回復習へ回す、の流れに集中する画面です。</p></div><Timer /></header>
+      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>PDFの設問を見る → 直下の答案欄に入力する → 次の設問へ進む → 最後に採点する、の流れに集中する画面です。</p></div><Timer /></header>
       <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button></nav>
       <div className="status-bar">{message}</div>
 
       {mode === 'study' && <section className="mode-section study-mode-section">
+        {!currentMapping && <section className="panel first-use-steps"><h2>最初にやること</h2><div><span>1. 教材を設定する</span><span>2. 設問ごとにPDF範囲を登録する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
         <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
-        <section className="study-problem-strip panel mode-card"><div><p className="eyebrow">今解く問題</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>想定時間：{currentMapping?.estimatedMinutes ?? '未設定'} / 難易度：{currentMapping?.difficulty ?? '未設定'} / ブロック数：{currentMapping?.problemBlocks?.length ?? answer.problemBlocks?.length ?? 1}</p></div><button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button></section>
+        <section className="study-problem-strip panel mode-card"><div><p className="eyebrow">今解く問題</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>1. PDFの設問を読む　2. 直下の答案欄に入力する　3. 次の設問へ進む　4. 解答・解説を見る　5. 自己採点する　6. 次回復習日に回す</p><p>想定時間：{currentMapping?.estimatedMinutes ?? '未設定'} / 難易度：{currentMapping?.difficulty ?? '未設定'} / 設問数：{currentMapping?.problemBlocks?.length ?? answer.problemBlocks?.length ?? 1}</p></div><button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button></section>
         <div className="mobile-study-tabs"><button className={studyView === 'problem' ? 'active' : ''} onClick={() => setStudyView('problem')}>問題を見る</button><button className={studyView === 'answer' ? 'active' : ''} onClick={() => setStudyView('answer')}>答案を書く</button><button onClick={() => { setMode('grading'); setStudyView('grading'); }}>採点する</button></div>
-        <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}><div className="study-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} /></div><div className="answer-main-column"><ExampleGuide template={template} /><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} onChange={updateAnswer} /></div></div>
+        <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}><div className="study-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} /></div><div className="answer-main-column"><ExampleGuide template={template} /><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} pdf={currentPdf} mode="practice" onChange={updateAnswer} /></div></div>
       </section>}
 
-      {mode === 'grading' && <section className="mode-section grading-mode-section"><section className="panel mode-card study-problem-strip"><div><p className="eyebrow">採点する</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>回答後だけ、解答・解説PDFと自己採点欄を表示します。</p></div><button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button></section><div className="grading-layout"><div className="grading-answer-column"><h2>自分の答案</h2><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} onChange={updateAnswer} /></div><div className="grading-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} /><ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} /></div></div></section>}
+      {mode === 'grading' && <section className="mode-section grading-mode-section"><section className="panel mode-card study-problem-strip"><div><p className="eyebrow">採点する</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>解答・解説PDFを確認し、必要な設問だけ「採点・メモを開く」から記録します。</p></div><button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button></section><div className="grading-layout"><div className="grading-answer-column"><h2>自分の答案</h2><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} pdf={currentPdf} mode="grading" onChange={updateAnswer} /></div><div className="grading-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} /><ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} /></div></div></section>}
 
       {mode === 'materials' && <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />}
 

--- a/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
@@ -6,6 +6,7 @@ import { nowIso } from '../utils/dates';
 import { timeModes } from '../utils/disposableStudy';
 import { suggestPdfLinkCandidates, type PdfAutoLinkCandidate } from '../utils/pdfAutoLink';
 import { formatFileSize, getPdfPageCount } from '../utils/pdfRenderer';
+import { PdfQuestionPreview } from './PdfQuestionPreview';
 import { PdfViewerPanel } from './PdfViewerPanel';
 
 interface Props {
@@ -23,10 +24,15 @@ interface Props {
 type RangeKind = 'problem' | 'answer' | 'explanation';
 
 function blankBlock(index: number, templateId: TemplateId = 'journal'): ProblemBlock {
+  const start = Math.min(90, index * 30);
   return {
     id: crypto.randomUUID(),
-    title: `問題文${index + 1}`,
+    title: `設問${index + 1}`,
     description: '',
+    problemPageStart: 1,
+    problemPageEnd: 1,
+    cropTopPercent: start,
+    cropBottomPercent: Math.min(100, start + 30),
     estimatedMinutes: 3,
     difficulty: '標準',
     templateId,
@@ -62,8 +68,29 @@ function numberOrUndefined(value: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function percentOrDefault(value: string, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(100, parsed));
+}
+
+function questionTitle(index: number, title?: string): string {
+  const trimmed = title?.trim();
+  if (!trimmed || trimmed.startsWith('問題文')) return `設問${index + 1}`;
+  return trimmed;
+}
+
 function ensureBlocks(mapping: MaterialPdfMapping): ProblemBlock[] {
-  if (mapping.problemBlocks && mapping.problemBlocks.length > 0) return mapping.problemBlocks;
+  if (mapping.problemBlocks && mapping.problemBlocks.length > 0) {
+    return mapping.problemBlocks.map((block, index) => ({
+      ...block,
+      title: questionTitle(index, block.title),
+      problemPageStart: block.problemPageStart ?? mapping.problemPageStart,
+      problemPageEnd: block.problemPageEnd ?? mapping.problemPageEnd,
+      cropTopPercent: block.cropTopPercent ?? 0,
+      cropBottomPercent: block.cropBottomPercent ?? 100,
+    }));
+  }
   const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
   return [blankBlock(0, problem.defaultTemplateId)];
 }
@@ -157,7 +184,7 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
       setDraft((current) => ({ ...current, materialPdfId: pdf.id }));
       setTitle('');
       setCandidates([]);
-      onMessage('PDFを端末内IndexedDBへ保存しました。続けてページを見ながら問題IDへ紐づけてください。');
+      onMessage('PDFを端末内IndexedDBへ保存しました。続けて問題IDと設問ごとの表示範囲を登録してください。');
     } catch {
       onMessage('PDFの読み込みに失敗しました。破損ファイル、保護PDF、ブラウザ非対応の可能性があります。');
     }
@@ -201,11 +228,11 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
     <section className="material-setup-grid wizard-setup-grid">
       <div className="panel setup-control-panel mode-card wizard-control-panel">
         <p className="eyebrow">教材を設定する</p>
-        <h2>PDF教材を登録する / 問題ページを紐づける / 問題ブロックを作る</h2>
-        <p className="notice-small">PDF本体・教材本文・解答解説はGitHubや外部サーバーへ送信しません。利用者本人の端末内IndexedDBに保存します。</p>
+        <h2>PDF教材を選ぶ → 問題IDを選ぶ → 設問ごとの表示範囲を登録</h2>
+        <p className="notice-small">PDF本文をアプリに保存するのではなく、購入済みPDFの該当ページ範囲だけを端末内で参照します。</p>
         <p className="notice-small">PDFの作りによっては自動候補が出ない場合があります。その場合はPDFを見ながら手動でページ範囲を指定してください。</p>
 
-        <details open className="wizard-step-card"><summary>1. PDF教材を登録する</summary>
+        <details open className="wizard-step-card"><summary>1. PDF教材を選ぶ</summary>
           <div className="form-grid three-columns">
             <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
             <label>教材区分<select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}><option value="商業簿記">商業簿記</option><option value="工業簿記">工業簿記</option><option value="その他">その他</option></select></label>
@@ -214,7 +241,7 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
           <label className="import-label pdf-import-label">PDFを選択してプレビュー<input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} /></label>
         </details>
 
-        <details open className="wizard-step-card"><summary>2. 問題ページを紐づける</summary>
+        <details open className="wizard-step-card"><summary>2. 問題IDとページを選ぶ</summary>
           <div className="form-grid two-columns"><label>対象PDF<select value={draft.materialPdfId || selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); update({ materialPdfId: event.target.value }); }}><option value="">PDFを選択</option>{pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P）</option>)}</select></label><label>問題ID<select value={draft.problemId} onChange={(event) => { const existing = mappings.find((mapping) => mapping.problemId === event.target.value); setDraft(existing ? { ...existing, problemBlocks: ensureBlocks(existing) } : blankMapping(event.target.value, draft.materialPdfId || selectedPdfId)); }}>
             {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}</select></label></div>
           <div className="form-grid six-columns"><label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label><label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label><label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label></div>
@@ -223,19 +250,19 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
           {candidates.length > 0 && <div className="auto-link-candidates"><h3>候補ページ</h3>{candidates.map((candidate) => <div key={candidate.page} className="candidate-row"><strong>P{candidate.page}</strong><span>{candidate.labels.join(' / ')}</span><small>{candidate.preview}</small><button onClick={() => setPage(candidate.page)}>このページへ移動</button><button onClick={() => applyCandidate(candidate.page, 'problem')}>問題開始</button><button onClick={() => applyCandidate(candidate.page, 'answer')}>解答開始</button><button onClick={() => applyCandidate(candidate.page, 'explanation')}>解説開始</button></div>)}</div>}
         </details>
 
-        <details open className="wizard-step-card"><summary>3. 問題ブロックを作る</summary>
-          <div className="button-row"><button className="accent" onClick={addBlock}>問題文ブロックを追加</button><span>現在 {blocks.length} ブロック</span></div>
+        <details open className="wizard-step-card"><summary>3. 設問ごとのPDF表示範囲と答案欄を作る</summary>
+          <div className="button-row"><button className="accent" onClick={addBlock}>設問を追加</button><span>現在 {blocks.length} 設問</span></div>
           <div className="block-editor-list">
-            {blocks.map((block, index) => <div key={block.id} className="block-editor-card"><div className="section-heading"><div><p className="eyebrow">問題文{index + 1}</p><h3>{block.title}</h3></div><button className="danger" onClick={() => deleteBlock(index)}>削除</button></div><div className="form-grid three-columns"><label>ブロック名<input value={block.title} onChange={(event) => updateBlock(index, { title: event.target.value })} /></label><label>答案テンプレート<select value={block.templateId} onChange={(event) => updateBlock(index, { templateId: event.target.value as TemplateId })}>{templateCatalog.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}</select></label><label>想定分<input type="number" value={block.estimatedMinutes ?? ''} onChange={(event) => updateBlock(index, { estimatedMinutes: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid six-columns"><label>問題開始P<input type="number" value={block.problemPageStart ?? ''} onChange={(event) => updateBlock(index, { problemPageStart: numberOrUndefined(event.target.value) })} /></label><label>問題終了P<input type="number" value={block.problemPageEnd ?? ''} onChange={(event) => updateBlock(index, { problemPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解答開始P<input type="number" value={block.answerPageStart ?? ''} onChange={(event) => updateBlock(index, { answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解答終了P<input type="number" value={block.answerPageEnd ?? ''} onChange={(event) => updateBlock(index, { answerPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" value={block.explanationPageStart ?? ''} onChange={(event) => updateBlock(index, { explanationPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説終了P<input type="number" value={block.explanationPageEnd ?? ''} onChange={(event) => updateBlock(index, { explanationPageEnd: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid three-columns"><label>難易度<select value={blockDifficultyLabel(block.difficulty)} onChange={(event) => updateBlock(index, { difficulty: event.target.value as BlockDifficulty })}><option value="易しい">易しい</option><option value="標準">標準</option><option value="やや難">やや難</option><option value="難しい">難しい</option></select></label><label>説明<input value={block.description ?? ''} onChange={(event) => updateBlock(index, { description: event.target.value })} placeholder="例：商品、収益認識、現金預金" /></label><label>メモ<input value={block.memo ?? ''} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文は入れない" /></label></div></div>)}
+            {blocks.map((block, index) => <div key={block.id} className="block-editor-card"><div className="section-heading"><div><p className="eyebrow">設問{index + 1}</p><h3>{questionTitle(index, block.title)}</h3></div><button className="danger" onClick={() => deleteBlock(index)}>削除</button></div><div className="form-grid three-columns"><label>設問名<input value={questionTitle(index, block.title)} onChange={(event) => updateBlock(index, { title: event.target.value })} /></label><label>答案テンプレート<select value={block.templateId} onChange={(event) => updateBlock(index, { templateId: event.target.value as TemplateId })}>{templateCatalog.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}</select></label><label>想定分<input type="number" value={block.estimatedMinutes ?? ''} onChange={(event) => updateBlock(index, { estimatedMinutes: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid six-columns"><label>問題P<input type="number" value={block.problemPageStart ?? draft.problemPageStart} onChange={(event) => updateBlock(index, { problemPageStart: numberOrUndefined(event.target.value) })} /></label><label>問題終了P<input type="number" value={block.problemPageEnd ?? block.problemPageStart ?? draft.problemPageEnd} onChange={(event) => updateBlock(index, { problemPageEnd: numberOrUndefined(event.target.value) })} /></label><label>上から％<input type="number" min="0" max="100" value={block.cropTopPercent ?? 0} onChange={(event) => updateBlock(index, { cropTopPercent: percentOrDefault(event.target.value, 0) })} /></label><label>下まで％<input type="number" min="0" max="100" value={block.cropBottomPercent ?? 100} onChange={(event) => updateBlock(index, { cropBottomPercent: percentOrDefault(event.target.value, 100) })} /></label><label>解答開始P<input type="number" value={block.answerPageStart ?? ''} onChange={(event) => updateBlock(index, { answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" value={block.explanationPageStart ?? ''} onChange={(event) => updateBlock(index, { explanationPageStart: numberOrUndefined(event.target.value) })} /></label></div><PdfQuestionPreview pdf={selectedPdf} page={block.problemPageStart ?? draft.problemPageStart} cropTopPercent={block.cropTopPercent} cropBottomPercent={block.cropBottomPercent} title="この設問で表示されるPDF範囲" compact /><div className="form-grid three-columns"><label>難易度<select value={blockDifficultyLabel(block.difficulty)} onChange={(event) => updateBlock(index, { difficulty: event.target.value as BlockDifficulty })}><option value="易しい">易しい</option><option value="標準">標準</option><option value="やや難">やや難</option><option value="難しい">難しい</option></select></label><label>補足<input value={block.description ?? ''} onChange={(event) => updateBlock(index, { description: event.target.value })} placeholder="例：商品、収益認識、現金預金" /></label><label>メモ<input value={block.memo ?? ''} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文は入れない" /></label></div></div>)}
           </div>
         </details>
 
-        <div className="button-row sticky-actions"><button className="accent" onClick={() => { void saveMapping(); }}>この問題IDに紐づけて保存</button><button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>この問題を開く</button></div>
+        <div className="button-row sticky-actions"><button className="accent" onClick={() => { void saveMapping(); }}>保存する</button><button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>今すぐ解くで開く</button></div>
       </div>
 
       <div className="setup-preview-panel"><PdfViewerPanel pdf={selectedPdf} title={selectedPdf ? selectedPdf.title : 'PDF未選択'} label={previewKind === 'answer' ? '解答' : previewKind === 'explanation' ? '解説' : '問題'} page={page} pageStart={1} pageEnd={selectedPdf?.pageCount ?? 1} onPageChange={setPage} large /></div>
 
-      <details className="panel mapping-list-panel" open><summary>保存済みマッピング / 設定状況</summary><div className="panel-body"><div className="progress-summary-grid"><div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div><div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div><div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div></div><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>ブロック</th><th>操作</th></tr></thead><tbody>{mappings.map((mapping) => { const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0]; const pdf = pdfs.find((item) => item.id === mapping.materialPdfId); return <tr key={mapping.id}><td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td><td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td><td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td><td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td><td>{mapping.problemBlocks?.length ?? 1}</td><td><button onClick={() => { setDraft({ ...mapping, problemBlocks: ensureBlocks(mapping) }); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td></tr>; })}{mappings.length === 0 && <tr><td colSpan={8}>まだページ紐付けがありません。</td></tr>}</tbody></table></div>{unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}</div></details>
+      <details className="panel mapping-list-panel" open><summary>保存済み設定 / 設問数</summary><div className="panel-body"><div className="progress-summary-grid"><div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div><div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div><div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div></div><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>設問</th><th>操作</th></tr></thead><tbody>{mappings.map((mapping) => { const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0]; const pdf = pdfs.find((item) => item.id === mapping.materialPdfId); return <tr key={mapping.id}><td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td><td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td><td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td><td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td><td>{mapping.problemBlocks?.length ?? 1}</td><td><button onClick={() => { setDraft({ ...mapping, problemBlocks: ensureBlocks(mapping) }); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td></tr>; })}{mappings.length === 0 && <tr><td colSpan={8}>まだページ紐付けがありません。</td></tr>}</tbody></table></div>{unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}</div></details>
 
       <details className="panel mapping-list-panel"><summary>PDF教材データの削除</summary><div className="panel-body"><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead><tbody>{pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}{pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}</tbody></table></div></div></details>
     </section>

--- a/cpa-boki2-trial-section-answer-manager/src/components/PdfQuestionPreview.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/PdfQuestionPreview.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MaterialPdf } from '../types';
+import { renderPdfPageToCanvas } from '../utils/pdfRenderer';
+
+interface Props {
+  pdf?: MaterialPdf;
+  page?: number;
+  cropTopPercent?: number;
+  cropBottomPercent?: number;
+  title?: string;
+  compact?: boolean;
+}
+
+function clampPercent(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(100, value));
+}
+
+export function PdfQuestionPreview({ pdf, page, cropTopPercent, cropBottomPercent, title = 'PDFの該当部分', compact = false }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [canvasHeight, setCanvasHeight] = useState(0);
+  const [canvasWidth, setCanvasWidth] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const top = clampPercent(cropTopPercent, 0);
+  const rawBottom = clampPercent(cropBottomPercent, 100);
+  const bottom = Math.max(top + 8, rawBottom);
+  const safePage = page && page > 0 ? page : 1;
+  const cropHeight = canvasHeight > 0 ? Math.max(120, Math.round(canvasHeight * ((bottom - top) / 100))) : compact ? 180 : 240;
+  const translateY = canvasHeight > 0 ? -Math.round(canvasHeight * (top / 100)) : 0;
+
+  useEffect(() => {
+    if (!pdf || !canvasRef.current) return;
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    renderPdfPageToCanvas(pdf.pdfBlob, Math.min(safePage, pdf.pageCount), compact ? 0.9 : 1.05, canvasRef.current)
+      .then(() => {
+        if (!cancelled && canvasRef.current) {
+          setCanvasHeight(canvasRef.current.height);
+          setCanvasWidth(canvasRef.current.width);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError('PDFプレビューを表示できませんでした。');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [pdf, safePage, compact]);
+
+  if (!pdf) {
+    return <div className="question-pdf-preview empty-preview"><strong>{title}</strong><p>この設問にPDFが紐づいていません。教材設定でPDFページと表示範囲を登録してください。</p></div>;
+  }
+
+  return (
+    <div className={`question-pdf-preview ${compact ? 'compact-preview' : ''}`}>
+      <div className="question-pdf-preview-header">
+        <strong>{title}</strong>
+        <span>P{Math.min(safePage, pdf.pageCount)} / {pdf.pageCount}　表示範囲：上{top}%〜{bottom}%</span>
+      </div>
+      {loading && <p className="empty">PDFを表示中...</p>}
+      {error && <p className="warning-text">{error}</p>}
+      <div className="question-pdf-crop-window" style={{ height: cropHeight }}>
+        <canvas
+          ref={canvasRef}
+          className="question-pdf-canvas"
+          style={{ transform: `translateY(${translateY}px)`, width: canvasWidth ? '100%' : undefined }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getTemplateById } from '../data/templateCatalog';
-import type { AnswerBlockState, AnswerState, MaterialPdf, MaterialPdfMapping, MissReason, ProblemBlock, ReviewRank } from '../types';
+import type { AnswerBlockState, AnswerRow, AnswerState, MaterialPdf, MaterialPdfMapping, MissReason, ProblemBlock, ReviewRank } from '../types';
 import { sumRowPoints } from '../utils/scoring';
 import { AnswerTable, createRows } from './AnswerTable';
 import { PdfQuestionPreview } from './PdfQuestionPreview';
@@ -34,6 +34,14 @@ function questionTitle(index: number, title?: string): string {
   return trimmed;
 }
 
+function renumberRows(rows: AnswerRow[]): AnswerRow[] {
+  return rows.map((row, index) => {
+    const cells = [...row.cells];
+    if (cells.length > 0) cells[0] = String(index + 1);
+    return { ...row, cells };
+  });
+}
+
 function defaultBlockFromAnswer(answer: AnswerState): AnswerBlockState {
   return {
     id: 'legacy-main-block',
@@ -42,7 +50,7 @@ function defaultBlockFromAnswer(answer: AnswerState): AnswerBlockState {
     templateId: answer.templateId,
     templateName: answer.templateName,
     columns: answer.columns,
-    rows: answer.rows,
+    rows: renumberRows(answer.rows),
     score: answer.score,
     maxScore: answer.maxScore,
     rowPointsTotal: answer.rowPointsTotal,
@@ -73,7 +81,7 @@ function blockFromMapping(block: ProblemBlock, index: number): AnswerBlockState 
     templateId: block.templateId,
     templateName: template.name,
     columns: template.columns,
-    rows: block.rows && block.rows.length > 0 ? block.rows : createRows(template.columns.length, template.initialRows),
+    rows: block.rows && block.rows.length > 0 ? renumberRows(block.rows) : createRows(template.columns.length, template.initialRows),
     score: 0,
     maxScore: 0,
     rowPointsTotal: 0,
@@ -87,28 +95,29 @@ function blockFromMapping(block: ProblemBlock, index: number): AnswerBlockState 
 
 function normalizeBlocks(answer: AnswerState, mapping?: MaterialPdfMapping): AnswerBlockState[] {
   if (answer.problemBlocks && answer.problemBlocks.length > 0) {
-    return answer.problemBlocks.map((block, index) => ({ ...block, title: questionTitle(index, block.title) }));
+    return answer.problemBlocks.map((block, index) => ({ ...block, title: questionTitle(index, block.title), rows: renumberRows(block.rows) }));
   }
   if (mapping?.problemBlocks && mapping.problemBlocks.length > 0) return mapping.problemBlocks.map(blockFromMapping);
   return [defaultBlockFromAnswer(answer)];
 }
 
 function summarize(answer: AnswerState, blocks: AnswerBlockState[]): AnswerState {
-  const score = blocks.reduce((total, block) => total + (Number(block.score) || 0), 0);
-  const maxScore = blocks.reduce((total, block) => total + (Number(block.maxScore) || 0), 0) || answer.maxScore;
-  const rowPointsTotal = blocks.reduce((total, block) => total + (Number(block.rowPointsTotal) || 0), 0);
-  const missReasons = Array.from(new Set(blocks.flatMap((block) => block.missReasons)));
+  const normalizedBlocks = blocks.map((block) => ({ ...block, rows: renumberRows(block.rows) }));
+  const score = normalizedBlocks.reduce((total, block) => total + (Number(block.score) || 0), 0);
+  const maxScore = normalizedBlocks.reduce((total, block) => total + (Number(block.maxScore) || 0), 0) || answer.maxScore;
+  const rowPointsTotal = normalizedBlocks.reduce((total, block) => total + (Number(block.rowPointsTotal) || 0), 0);
+  const missReasons = Array.from(new Set(normalizedBlocks.flatMap((block) => block.missReasons)));
   return {
     ...answer,
-    problemBlocks: blocks,
+    problemBlocks: normalizedBlocks,
     score,
     maxScore,
     rowPointsTotal,
     missReasons,
-    rows: blocks[0]?.rows ?? answer.rows,
-    columns: blocks[0]?.columns ?? answer.columns,
-    templateId: blocks[0]?.templateId ?? answer.templateId,
-    templateName: blocks[0]?.templateName ?? answer.templateName,
+    rows: normalizedBlocks[0]?.rows ?? answer.rows,
+    columns: normalizedBlocks[0]?.columns ?? answer.columns,
+    templateId: normalizedBlocks[0]?.templateId ?? answer.templateId,
+    templateName: normalizedBlocks[0]?.templateName ?? answer.templateName,
   };
 }
 
@@ -118,7 +127,7 @@ function blockToAnswer(base: AnswerState, block: AnswerBlockState): AnswerState 
     templateId: block.templateId,
     templateName: block.templateName,
     columns: block.columns,
-    rows: block.rows,
+    rows: renumberRows(block.rows),
     score: block.score,
     maxScore: block.maxScore,
     rowPointsTotal: block.rowPointsTotal,
@@ -149,7 +158,7 @@ export function ProblemBlockAnswerPanel({ answer, mapping, pdf, mode = 'practice
       templateId: blockAnswer.templateId,
       templateName: blockAnswer.templateName,
       columns: blockAnswer.columns,
-      rows: blockAnswer.rows,
+      rows: renumberRows(blockAnswer.rows),
       score: blockAnswer.score,
       maxScore: blockAnswer.maxScore,
       rowPointsTotal: blockAnswer.rowPointsTotal,

--- a/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/ProblemBlockAnswerPanel.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getTemplateById } from '../data/templateCatalog';
-import type { AnswerBlockState, AnswerState, MaterialPdfMapping, MissReason, ProblemBlock, ReviewRank } from '../types';
+import type { AnswerBlockState, AnswerState, MaterialPdf, MaterialPdfMapping, MissReason, ProblemBlock, ReviewRank } from '../types';
 import { sumRowPoints } from '../utils/scoring';
 import { AnswerTable, createRows } from './AnswerTable';
+import { PdfQuestionPreview } from './PdfQuestionPreview';
 
 const missReasons: MissReason[] = [
   '論点理解不足',
@@ -22,14 +23,22 @@ const missReasons: MissReason[] = [
 interface Props {
   answer: AnswerState;
   mapping?: MaterialPdfMapping;
+  pdf?: MaterialPdf;
+  mode?: 'practice' | 'grading';
   onChange: (answer: AnswerState) => void;
+}
+
+function questionTitle(index: number, title?: string): string {
+  const trimmed = title?.trim();
+  if (!trimmed || trimmed.startsWith('問題文')) return `設問${index + 1}`;
+  return trimmed;
 }
 
 function defaultBlockFromAnswer(answer: AnswerState): AnswerBlockState {
   return {
     id: 'legacy-main-block',
-    title: '問題文①',
-    description: '既存の答案入力テーブルを1ブロックとして表示しています。',
+    title: '設問1',
+    description: 'PDFの該当部分を見て、直下の答案欄へ入力します。',
     templateId: answer.templateId,
     templateName: answer.templateName,
     columns: answer.columns,
@@ -49,8 +58,18 @@ function blockFromMapping(block: ProblemBlock, index: number): AnswerBlockState 
   const template = getTemplateById(block.templateId);
   return {
     id: block.id || crypto.randomUUID(),
-    title: block.title || `問題文${index + 1}`,
+    title: questionTitle(index, block.title),
     description: block.description ?? '',
+    problemPageStart: block.problemPageStart,
+    problemPageEnd: block.problemPageEnd,
+    cropTopPercent: block.cropTopPercent,
+    cropBottomPercent: block.cropBottomPercent,
+    answerPageStart: block.answerPageStart,
+    answerPageEnd: block.answerPageEnd,
+    explanationPageStart: block.explanationPageStart,
+    explanationPageEnd: block.explanationPageEnd,
+    estimatedMinutes: block.estimatedMinutes,
+    difficulty: block.difficulty,
     templateId: block.templateId,
     templateName: template.name,
     columns: template.columns,
@@ -62,12 +81,14 @@ function blockFromMapping(block: ProblemBlock, index: number): AnswerBlockState 
     missReasons: [],
     nextReviewPoint: '',
     memo: block.memo ?? '',
-    collapsed: index !== 0,
+    collapsed: false,
   };
 }
 
 function normalizeBlocks(answer: AnswerState, mapping?: MaterialPdfMapping): AnswerBlockState[] {
-  if (answer.problemBlocks && answer.problemBlocks.length > 0) return answer.problemBlocks;
+  if (answer.problemBlocks && answer.problemBlocks.length > 0) {
+    return answer.problemBlocks.map((block, index) => ({ ...block, title: questionTitle(index, block.title) }));
+  }
   if (mapping?.problemBlocks && mapping.problemBlocks.length > 0) return mapping.problemBlocks.map(blockFromMapping);
   return [defaultBlockFromAnswer(answer)];
 }
@@ -107,7 +128,7 @@ function blockToAnswer(base: AnswerState, block: AnswerBlockState): AnswerState 
   };
 }
 
-export function ProblemBlockAnswerPanel({ answer, mapping, onChange }: Props) {
+export function ProblemBlockAnswerPanel({ answer, mapping, pdf, mode = 'practice', onChange }: Props) {
   const blocks = useMemo(() => normalizeBlocks(answer, mapping), [answer.problemBlocks, answer.problemId, mapping?.id, mapping?.problemBlocks]);
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -150,70 +171,72 @@ export function ProblemBlockAnswerPanel({ answer, mapping, onChange }: Props) {
     updateBlock(index, { missReasons: exists ? block.missReasons.filter((item) => item !== reason) : [...block.missReasons, reason] });
   };
 
-  const setCollapsed = (index: number, collapsed: boolean) => updateBlock(index, { collapsed });
-  const expandAll = () => updateBlocks(blocks.map((block) => ({ ...block, collapsed: false })));
-  const collapseAll = () => updateBlocks(blocks.map((block, index) => ({ ...block, collapsed: index !== activeIndex })));
-  const moveActive = (delta: number) => {
-    const next = Math.max(0, Math.min(blocks.length - 1, activeIndex + delta));
-    setActiveIndex(next);
-    updateBlocks(blocks.map((block, index) => ({ ...block, collapsed: index !== next })));
-  };
+  const moveActive = (delta: number) => setActiveIndex((current) => Math.max(0, Math.min(blocks.length - 1, current + delta)));
 
   return (
-    <section className="problem-block-answer-panel">
-      <div className="panel block-summary-panel">
+    <section className="question-practice-panel">
+      <div className="panel question-practice-summary">
         <div className="section-heading">
           <div>
-            <p className="eyebrow">問題文ブロック別答案</p>
-            <h2>合計 {answer.score} / {answer.maxScore}</h2>
-            <p>問題文ごとに答案入力テーブルを分けます。既存データは1ブロックとして扱います。</p>
+            <p className="eyebrow">設問別演習</p>
+            <h2>PDFを読む → 直下に入力する</h2>
+            <p>設問ごとに、問題PDFの該当部分を見ながら答案を入力します。採点・メモは必要な時だけ開きます。</p>
           </div>
           <div className="button-row">
-            <button onClick={expandAll}>すべて展開</button>
-            <button onClick={collapseAll}>すべて折りたたみ</button>
-            <button onClick={() => moveActive(-1)}>前の問題文へ</button>
-            <button onClick={() => moveActive(1)}>次の問題文へ</button>
+            <button onClick={() => moveActive(-1)}>前の設問へ</button>
+            <button onClick={() => moveActive(1)}>次の設問へ</button>
           </div>
         </div>
       </div>
 
       {blocks.map((block, index) => {
         const blockAnswer = blockToAnswer(answer, block);
+        const page = block.problemPageStart ?? mapping?.problemPageStart ?? 1;
         return (
-          <section key={block.id} className={`panel problem-block-card ${index === activeIndex ? 'active-block' : ''}`}>
-            <div className="section-heading block-card-heading">
+          <section key={block.id} className={`panel question-card ${index === activeIndex ? 'active-question-card' : ''}`}>
+            <div className="question-card-header">
               <div>
-                <p className="eyebrow">問題文{index + 1}</p>
-                <h2>{block.title}</h2>
+                <p className="eyebrow">設問{index + 1}</p>
+                <h2>{questionTitle(index, block.title)}</h2>
                 {block.description && <p>{block.description}</p>}
               </div>
-              <div className="block-score-box">
-                <strong>{block.score} / {block.maxScore || '-'}</strong>
-                <span>{block.rank || '未判定'}</span>
+              <div className="question-card-meta">
+                {block.estimatedMinutes && <span>目安 {block.estimatedMinutes}分</span>}
+                {block.difficulty && <span>{block.difficulty}</span>}
               </div>
             </div>
-            <div className="block-meta-grid">
-              <label>ブロック得点<input type="number" value={block.score} onChange={(event) => updateBlock(index, { score: Number(event.target.value) || 0 })} /></label>
-              <label>ブロック満点<input type="number" value={block.maxScore} onChange={(event) => updateBlock(index, { maxScore: Number(event.target.value) || 0 })} /></label>
-              <label>ブロック判定
-                <select value={block.rank} onChange={(event) => updateBlock(index, { rank: event.target.value as ReviewRank })}>
-                  <option value="">未選択</option><option value="A">A</option><option value="B">B</option><option value="C">C</option>
-                </select>
-              </label>
-              <button className="secondary" onClick={() => setCollapsed(index, !block.collapsed)}>{block.collapsed ? '開く' : '折りたたむ'}</button>
-            </div>
-            {!block.collapsed && (
-              <>
-                <AnswerTable answer={blockAnswer} template={getTemplateById(block.templateId)} onChange={(next) => updateBlockAnswer(index, next)} onApplyRowPoints={() => applyRowPoints(index)} />
-                <div className="block-review-grid">
-                  <label>次回注意点<textarea value={block.nextReviewPoint} onChange={(event) => updateBlock(index, { nextReviewPoint: event.target.value })} placeholder="次回このブロックを解く前に見る注意点" /></label>
-                  <label>ブロックメモ<textarea value={block.memo} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文・解答本文は貼らず、自分のミスと処理順だけを書く" /></label>
-                </div>
-                <div className="check-list block-miss-list">
-                  {missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={block.missReasons.includes(reason)} onChange={() => toggleReason(index, reason)} />{reason}</label>)}
-                </div>
-              </>
-            )}
+
+            <PdfQuestionPreview
+              pdf={pdf}
+              page={page}
+              cropTopPercent={block.cropTopPercent}
+              cropBottomPercent={block.cropBottomPercent}
+              title="PDFの該当部分"
+              compact={mode === 'practice'}
+            />
+
+            <div className="answer-input-label">答案入力</div>
+            <AnswerTable answer={blockAnswer} template={getTemplateById(block.templateId)} onChange={(next) => updateBlockAnswer(index, next)} onApplyRowPoints={() => applyRowPoints(index)} />
+
+            <details className="question-review-details" open={mode === 'grading'}>
+              <summary>採点・メモを開く</summary>
+              <div className="block-meta-grid question-score-grid">
+                <label>得点<input type="number" value={block.score} onChange={(event) => updateBlock(index, { score: Number(event.target.value) || 0 })} /></label>
+                <label>満点<input type="number" value={block.maxScore} onChange={(event) => updateBlock(index, { maxScore: Number(event.target.value) || 0 })} /></label>
+                <label>判定
+                  <select value={block.rank} onChange={(event) => updateBlock(index, { rank: event.target.value as ReviewRank })}>
+                    <option value="">未選択</option><option value="A">A</option><option value="B">B</option><option value="C">C</option>
+                  </select>
+                </label>
+              </div>
+              <div className="block-review-grid">
+                <label>次回注意点<textarea value={block.nextReviewPoint} onChange={(event) => updateBlock(index, { nextReviewPoint: event.target.value })} placeholder="次回この設問を解く前に見る注意点" /></label>
+                <label>メモ<textarea value={block.memo} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文・解答本文は貼らず、自分のミスと処理順だけを書く" /></label>
+              </div>
+              <div className="check-list block-miss-list">
+                {missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={block.missReasons.includes(reason)} onChange={() => toggleReason(index, reason)} />{reason}</label>)}
+              </div>
+            </details>
           </section>
         );
       })}

--- a/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
+++ b/cpa-boki2-trial-section-answer-manager/src/disposableStudy.css
@@ -193,6 +193,150 @@
 .block-review-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
 .block-miss-list { margin-top: 10px; }
 
+.first-use-steps {
+  display: grid;
+  gap: 12px;
+  border: 2px solid #f0c36d;
+  background: #fffaf0;
+}
+.first-use-steps div {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(160px, 1fr));
+  gap: 10px;
+}
+.first-use-steps span {
+  padding: 12px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #f2d49a;
+  font-weight: 900;
+}
+
+.question-practice-panel {
+  display: grid;
+  gap: 16px;
+}
+.question-practice-summary {
+  border: 2px solid #d7eadf;
+}
+.question-card {
+  display: grid;
+  gap: 14px;
+  border: 1px solid #d8e8e4;
+}
+.question-card.active-question-card {
+  border: 3px solid #0f5c68;
+  box-shadow: 0 8px 28px rgba(15, 92, 104, .16);
+}
+.question-card-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+}
+.question-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+.question-card-meta span {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef7f4;
+  border: 1px solid #d3e7e2;
+  font-weight: 800;
+  font-size: 12px;
+}
+.answer-input-label {
+  width: fit-content;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #0f5c68;
+  color: #fff;
+  font-weight: 900;
+}
+.question-card .answer-panel {
+  border: 1px solid #d8e8e4;
+  box-shadow: none;
+}
+.question-card .answer-heading h2 {
+  font-size: 16px;
+}
+.question-card .answer-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+.question-card .journal-table .col-memo,
+.question-card .answer-table .col-memo {
+  width: 14%;
+}
+.question-card .journal-table .col-account,
+.question-card .answer-table .col-account {
+  width: 14%;
+}
+.question-card .journal-table .col-amount,
+.question-card .answer-table .col-amount {
+  width: 12%;
+}
+.question-review-details {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #d8e8e4;
+  background: #fbfdfc;
+}
+.question-review-details > summary {
+  cursor: pointer;
+  font-weight: 900;
+}
+.question-score-grid {
+  margin-top: 10px;
+}
+
+.question-pdf-preview {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px solid #d8e8e4;
+  background: #f7fbf9;
+}
+.question-pdf-preview-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: center;
+}
+.question-pdf-preview-header strong {
+  font-size: 16px;
+}
+.question-pdf-preview-header span {
+  font-size: 12px;
+  color: #53676a;
+  font-weight: 800;
+}
+.question-pdf-crop-window {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid #d5e5e1;
+  background: #fff;
+}
+.question-pdf-canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  transform-origin: top left;
+}
+.empty-preview {
+  background: #fffaf0;
+  border-color: #f2d49a;
+}
+.compact-preview .question-pdf-crop-window {
+  max-height: 280px;
+}
+
 .progress-overview-panel { display: grid; grid-template-columns: minmax(0, 1fr) minmax(460px, auto); gap: 18px; align-items: center; }
 .progress-summary-grid { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 10px; }
 .progress-summary-grid div { display: grid; gap: 4px; padding: 14px; border-radius: 14px; background: #f2f8f6; border: 1px solid #d8e8e4; }
@@ -222,8 +366,11 @@
   .mobile-study-tabs button.active { background: #0f5c68; }
   .focused-study-layout.show-answer .study-pdf-column { display: none; }
   .focused-study-layout.show-pdf .answer-main-column { display: none; }
-  .progress-summary-grid { grid-template-columns: 1fr 1fr; }
+  .progress-summary-grid,
+  .first-use-steps div { grid-template-columns: 1fr; }
   .block-review-grid { grid-template-columns: 1fr; }
+  .question-card-header { grid-template-columns: 1fr; }
+  .question-card-meta { justify-content: flex-start; }
 }
 
 @media (max-width: 760px) {
@@ -239,4 +386,6 @@
   .mode-nav { grid-template-columns: 1fr; position: static; }
   .mobile-study-tabs { top: 0; }
   .progress-summary-grid { grid-template-columns: 1fr; }
+  .question-pdf-crop-window { min-height: 160px; }
+  .question-card .answer-table { min-width: 960px; }
 }

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -48,6 +48,8 @@ export interface ProblemBlock {
   description?: string;
   problemPageStart?: number;
   problemPageEnd?: number;
+  cropTopPercent?: number;
+  cropBottomPercent?: number;
   answerPageStart?: number;
   answerPageEnd?: number;
   explanationPageStart?: number;
@@ -63,6 +65,16 @@ export interface AnswerBlockState {
   id: string;
   title: string;
   description?: string;
+  problemPageStart?: number;
+  problemPageEnd?: number;
+  cropTopPercent?: number;
+  cropBottomPercent?: number;
+  answerPageStart?: number;
+  answerPageEnd?: number;
+  explanationPageStart?: number;
+  explanationPageEnd?: number;
+  estimatedMinutes?: number;
+  difficulty?: BlockDifficulty;
   templateId: TemplateId;
   templateName: string;
   columns: string[];


### PR DESCRIPTION
## 1. 修正目的

PR #238 までのPDF取込・PDF表示・問題文ブロック別答案テーブル・復習管理を維持したまま、学習時に迷わず使えるUIへ整理します。

今回の目的は新しい学習機能の追加ではなく、実際の学習者が自然に

1. PDFの設問を見る
2. 直下の答案欄に入力する
3. 次の設問へ進む
4. 最後に採点する

という流れで使える画面にすることです。

## 2. 主な変更

### 表示名を「問題文ブロック」から「設問」へ変更

学習画面の表示を以下のように変更しました。

- 問題文① → 設問1
- 問題文② → 設問2
- 問題文③ → 設問3
- 問題文ブロック別答案 → 設問別演習

内部互換性のため `ProblemBlock` 型名や一部CSSクラス名は残していますが、学習者に見える画面文言は「設問」中心に整理しています。

### 設問カード構成へ変更

今すぐ解く画面では、各設問を以下の順番で表示します。

- 設問名
- PDFの該当部分
- 答案入力
- 採点・メモを開く

採点・メモ・ミス原因・次回注意点は初期表示から外し、答案入力中の邪魔にならないよう `details` 内へ退避しました。

### PDF該当部分プレビューを追加

`PdfQuestionPreview.tsx` を追加しました。

PDF本文や問題文テキストを保存するのではなく、PDFページ画像の表示範囲だけを指定して、設問カード上にプレビュー表示します。

追加した範囲指定項目:

- `cropTopPercent`
- `cropBottomPercent`

これにより、1ページ内に複数設問がある場合でも、たとえば以下のように縦方向の表示範囲を分けられます。

- 設問1: 上0%〜30%
- 設問2: 上30%〜60%
- 設問3: 上60%〜90%

### 教材設定画面を設問単位に変更

教材設定画面の流れを以下へ整理しました。

1. PDF教材を選ぶ
2. 問題IDを選ぶ
3. PDFページを開く
4. 設問を追加
5. 設問名を入力
6. 該当ページを指定
7. PDF上で表示範囲を調整
8. 答案テンプレートを選ぶ
9. 保存する
10. 今すぐ解くで開く

教材設定画面には以下の説明を追加しています。

> PDF本文をアプリに保存するのではなく、購入済みPDFの該当ページ範囲だけを端末内で参照します。

### 設問ごとの行番号を1から開始

既存データや複数設問データでも、各設問カード内では答案テーブルの行番号が1から始まるように正規化しました。

### 初回利用時の3ステップ表示

教材未設定時は、今すぐ解く画面上部に以下だけを表示します。

1. 教材を設定する
2. 設問ごとにPDF範囲を登録する
3. 今すぐ解く

## 3. 維持したもの

- PDF取込
- PDF表示
- IndexedDB保存
- 問題IDごとのページ紐づけ
- 設問ごとの答案入力テーブル
- 3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリックでセル内編集
- Escで編集解除
- Enter / Shift+Enter移動
- 行追加
- 空行整理
- 行別採点
- 履歴保存
- JSONバックアップ
- 今日の学習キュー
- 90分セット演習
- 合格到達マップ

## 4. 著作権・保存方針

以下は行っていません。

- OCR
- AI解説
- 自動採点
- CPA教材本文のコード埋め込み
- 問題文・解答・解説の初期データ投入
- PDFをGitHubへ保存
- PDFをpublicフォルダへ配置
- PDFをsrc配下へ配置
- PDFを外部サーバーへ送信
- Supabase同期
- ログイン
- グラフ追加
- 大規模なデザイン装飾

PDFは利用者本人が端末内で選択し、IndexedDBにBlob保存する既存方針を維持しています。

## 5. 変更ファイル

- `src/App.tsx`
- `src/components/MaterialSetupWorkspace.tsx`
- `src/components/PdfQuestionPreview.tsx`
- `src/components/ProblemBlockAnswerPanel.tsx`
- `src/disposableStudy.css`
- `src/types/index.ts`

## 6. 動作確認結果

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 7. 実URLで確認すべき項目

- 「問題文①」という表示が初期画面から消えている
- 表示が「設問1」「設問2」「設問3」になっている
- 各設問カードの上にPDF該当部分が表示される
- 各設問カードの直下に答案入力テーブルが表示される
- 設問ごとに答案テーブルの行番号が1から始まる
- PDF表示範囲を教材設定画面で調整・保存できる
- 保存したPDF範囲が「今すぐ解く」画面に反映される
- 採点・メモ・ミス原因は答案入力中に邪魔にならない
- PCでは答案入力欄が十分広い
- スマホでは1設問ずつ縦に演習できる
- 既存の履歴保存、JSONバックアップ、今日の学習キュー、90分セット演習、合格到達マップが壊れていない
- 既存案件管理アプリのトップURLに影響がない
- `CPA Boki2 App Build Check` が成功している