### PR TITLE
Make CPA Boki2 practice text-first and one-question focused

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -2,18 +2,15 @@ import { useEffect, useMemo, useState } from 'react';
 import { createRows } from './components/AnswerTable';
 import { BackupSafetyPanel } from './components/BackupSafetyPanel';
 import { DashboardPanel } from './components/DashboardPanel';
-import { DisposableStudyPanel } from './components/DisposableStudyPanel';
 import { ExamSetPanel } from './components/ExamSetPanel';
-import { ExampleGuide } from './components/ExampleGuide';
+import { FocusedGradingPanel } from './components/FocusedGradingPanel';
+import { FocusedPracticePanel } from './components/FocusedPracticePanel';
 import { HistoryPanel } from './components/HistoryPanel';
 import { MasteryMapPanel } from './components/MasteryMapPanel';
 import { MaterialSetupWorkspace } from './components/MaterialSetupWorkspace';
 import { MistakeCardPanel } from './components/MistakeCardPanel';
-import { PdfStudyPanel } from './components/PdfStudyPanel';
-import { ProblemBlockAnswerPanel } from './components/ProblemBlockAnswerPanel';
 import { RecoveryPlanPanel } from './components/RecoveryPlanPanel';
 import { ReviewPanel } from './components/ReviewPanel';
-import { ScoringPanel } from './components/ScoringPanel';
 import { StudyQueuePanel } from './components/StudyQueuePanel';
 import { Timer } from './components/Timer';
 import { getProblemById, problemCatalog } from './data/problemCatalog';
@@ -48,7 +45,7 @@ import {
 } from './storage/indexedDb';
 import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, GradingStatus, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, ReviewState, StorageSafetyInfo, TemplateId, TimeMode } from './types';
 import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, masteryMapCsvRows, missReasonCsvRows, mistakeCardCsvRows, problemStatsCsvRows, recoveryPlanCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
-import { chooseProblemForTimeMode, chooseQuickStartProblem, latestUnfinishedSession } from './utils/disposableStudy';
+import { chooseQuickStartProblem } from './utils/disposableStudy';
 import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
 import { buildMasteryMap } from './utils/mastery';
 import { buildRecoveryPlan } from './utils/recovery';
@@ -60,7 +57,6 @@ import './styles.css';
 
 type HistoryFilter = 'all' | 'today' | 'overdue' | 'c' | 'b';
 type AppMode = 'study' | 'grading' | 'materials' | 'progress';
-type StudyView = 'problem' | 'answer' | 'grading';
 
 function createAnswer(problemId: string, templateId: TemplateId): AnswerState {
   const template = getTemplateById(templateId);
@@ -92,17 +88,14 @@ function createAnswer(problemId: string, templateId: TemplateId): AnswerState {
 function normalizeAnswer(answer: AnswerState): AnswerState {
   const template = getTemplateById(answer.templateId);
   if (answer.templateId !== 'journal') return answer;
-
   const legacyIndex = answer.columns.indexOf('会社名・立場');
   const columns = template.columns;
   if (legacyIndex === -1 && answer.columns.join('|') === columns.join('|')) return answer;
-
   const rows = answer.rows.map((row) => {
     const cells = [...row.cells];
     if (legacyIndex >= 0) cells.splice(legacyIndex, 1);
     return { ...row, cells: columns.map((_, index) => cells[index] ?? '') };
   });
-
   return { ...answer, columns, rows, templateName: template.name, updatedAt: nowIso() };
 }
 
@@ -159,7 +152,6 @@ export default function App() {
   const [message, setMessage] = useState('待機中');
   const [historyFilter, setHistoryFilter] = useState<HistoryFilter>('all');
   const [mode, setMode] = useState<AppMode>('study');
-  const [studyView, setStudyView] = useState<StudyView>('answer');
 
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
@@ -168,19 +160,17 @@ export default function App() {
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
-  const activeSession = useMemo(() => practiceSessions.find((session) => session.id === activeSessionId) ?? latestUnfinishedSession(practiceSessions) ?? null, [practiceSessions, activeSessionId]);
+  const activeSession = useMemo(() => practiceSessions.find((session) => session.id === activeSessionId) ?? null, [practiceSessions, activeSessionId]);
   const currentReviewState = useMemo(() => reviewStates.find((state) => state.problemId === problemId), [reviewStates, problemId]);
   const quickChoice = useMemo(() => chooseQuickStartProblem({ sessions: practiceSessions, studyQueue, masteryMap }), [practiceSessions, studyQueue, masteryMap]);
-  const quickHint = useMemo(() => {
-    const quickProblem = getProblemById(quickChoice.problemId);
-    return `推奨：${quickProblem.sectionLabel} ${quickProblem.displayId} ${quickProblem.topic}（${quickChoice.reason}）`;
-  }, [quickChoice]);
   const progressSummary = useMemo(() => ({
     dueToday: studyQueue.filter((item) => item.statusLabels.includes('今日復習')).length,
     overdue: studyQueue.filter((item) => item.statusLabels.includes('期限超過')).length,
     cRank: masteryMap.filter((item) => item.latestRank === 'C' || item.status === '危険問題').length,
     untouched: masteryMap.filter((item) => item.status === '未着手').length,
-  }), [studyQueue, masteryMap]);
+    last7Days: histories.filter((history) => Date.now() - new Date(history.savedAt).getTime() <= 7 * 24 * 60 * 60 * 1000).length,
+    last30Days: histories.filter((history) => Date.now() - new Date(history.savedAt).getTime() <= 30 * 24 * 60 * 60 * 1000).length,
+  }), [studyQueue, masteryMap, histories]);
 
   async function refreshAnswers() { setAnswers((await getAllAnswers()).map(normalizeAnswer)); }
   async function loadHistories() { setHistories(await getHistories()); }
@@ -230,48 +220,36 @@ export default function App() {
     const baseAnswer = normalizeAnswer(stored ?? createAnswer(problemIdForSession, problemDefinition.defaultTemplateId));
     const now = nowIso();
     return {
-      id: crypto.randomUUID(), examType: '日商簿記2級', problemId: problemIdForSession, startedAt: now, submittedAt: '', durationSeconds: 0,
-      selectedTimeMode, answerSnapshot: baseAnswer, gradingMode: 'self', gradingResult: { status: '', score: 0, maxScore: baseAnswer.maxScore, scoreRate: 0, autoGraded: false, detailRows: [] },
-      openedAnswer: false, openedExplanation: false, memo: '', completed: false,
+      id: crypto.randomUUID(),
+      examType: '日商簿記2級',
+      problemId: problemIdForSession,
+      startedAt: now,
+      submittedAt: '',
+      durationSeconds: 0,
+      selectedTimeMode,
+      answerSnapshot: baseAnswer,
+      gradingMode: 'self',
+      gradingResult: { status: '', score: 0, maxScore: baseAnswer.maxScore, scoreRate: 0, autoGraded: false, detailRows: [] },
+      openedAnswer: false,
+      openedExplanation: false,
+      memo: '',
+      completed: false,
     };
-  }
-
-  async function beginPractice(problemIdForSession: string, selectedTimeMode: TimeMode, reason: string): Promise<PracticeSession> {
-    const session = await createPracticeSession(problemIdForSession, selectedTimeMode);
-    await savePracticeSession(session);
-    setActiveSessionId(session.id);
-    await loadProblem(problemIdForSession);
-    await refreshAll();
-    setMode('study');
-    setStudyView('answer');
-    setMessage(`${selectedTimeMode}モードで演習開始：${getProblemById(problemIdForSession).displayId}（${reason}）`);
-    return session;
-  }
-
-  async function quickResume() {
-    const unfinished = latestUnfinishedSession(practiceSessions);
-    if (unfinished) {
-      setActiveSessionId(unfinished.id);
-      await loadProblem(unfinished.problemId);
-      setMode('study');
-      setStudyView('answer');
-      setMessage(`未完了セッションを再開しました：${getProblemById(unfinished.problemId).displayId}`);
-      return;
-    }
-    await beginPractice(quickChoice.problemId, quickChoice.mode, quickChoice.reason);
-  }
-
-  async function selectTimeMode(timeMode: TimeMode) {
-    const selectedProblemId = chooseProblemForTimeMode(timeMode, studyQueue, masteryMap, histories);
-    await beginPractice(selectedProblemId, timeMode, '空き時間から選択');
   }
 
   async function startCurrentSession(): Promise<PracticeSession> {
     if (activeSession && activeSession.problemId === problem.id && !activeSession.completed) return activeSession;
-    return beginPractice(problem.id, currentMapping?.estimatedMinutes ?? '10分', '現在の問題ID');
+    const session = await createPracticeSession(problem.id, currentMapping?.estimatedMinutes ?? '10分');
+    await savePracticeSession(session);
+    setActiveSessionId(session.id);
+    await loadPracticeSessions();
+    return session;
   }
 
-  async function updatePracticeSession(session: PracticeSession) { await savePracticeSession(session); setActiveSessionId(session.id); await loadPracticeSessions(); }
+  const applyRowPoints = () => {
+    const total = sumRowPoints(answer.rows);
+    updateAnswer({ ...answer, rowPointsTotal: total, score: total });
+  };
 
   const manualSave = async () => { await saveAnswer(normalizeAnswer({ ...answer, updatedAt: nowIso() })); await refreshAll(); setMessage('手動保存しました'); };
   const clearCurrentAnswer = async () => { if (!window.confirm('現在問題IDの答案を全消去しますか？履歴は消えません。')) return; const cleared = createAnswer(problemId, answer.templateId); await saveAnswer(cleared); setAnswer(cleared); await refreshAll(); setMessage('現在問題IDの答案を全消去しました'); };
@@ -284,19 +262,27 @@ export default function App() {
     const reviewState = updateReviewStateFromGrading({ problemId: problem.id, previous: currentReviewState, status: input.status, score: input.score, maxScore: input.maxScore });
     const scored = normalizeAnswer({ ...answer, score: input.score, maxScore: input.maxScore, scored: true, scoringStarted: true, scoredAt: submittedAt, rank, nextReviewDate: reviewState.nextReviewDate, reviewMemo: input.memo || answer.reviewMemo, updatedAt: submittedAt });
     const session = activeSession && activeSession.problemId === problem.id && !activeSession.completed ? activeSession : await startCurrentSession();
-    const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, memo: input.memo, completed: true };
-    await saveAnswer(scored); await addHistory(buildHistory(scored)); await saveReviewState(reviewState); await savePracticeSession(completedSession); setAnswer(scored); setActiveSessionId(''); setMode('progress'); await refreshAll(); setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
+    const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, openedExplanation: Boolean(currentMapping?.answerText || currentMapping?.explanationText), memo: input.memo, completed: true };
+    await saveAnswer(scored);
+    await addHistory(buildHistory(scored));
+    await saveReviewState(reviewState);
+    await savePracticeSession(completedSession);
+    setAnswer(scored);
+    setActiveSessionId('');
+    await refreshAll();
+    setMessage(`自己採点を保存しました。判定 ${rank}、次回復習日 ${reviewState.nextReviewDate}`);
+    await openNextProblem();
   }
 
-  const restoreHistory = async (entry: HistoryEntry) => { if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return; const restored = normalizeAnswer(entry.snapshot); await saveAnswer(restored); setProblemId(entry.problemId); setAnswer(restored); setMode('study'); setStudyView('answer'); await refreshAll(); setMessage('履歴を復元しました'); };
+  const restoreHistory = async (entry: HistoryEntry) => { if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return; const restored = normalizeAnswer(entry.snapshot); await saveAnswer(restored); setProblemId(entry.problemId); setAnswer(restored); setMode('study'); await refreshAll(); setMessage('履歴を復元しました'); };
   const deleteHistoryEntry = async (id: string) => { if (!window.confirm('この履歴を削除しますか？')) return; await deleteHistory(id); await refreshAll(); setMessage('履歴を削除しました'); };
   const clearAllHistories = async () => { if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return; await clearHistories(); await refreshAll(); setMessage('履歴を全削除しました'); };
   const saveCard = async (card: MistakeCard) => { await saveMistakeCard(card); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを保存しました'); };
   const removeCard = async (id: string) => { if (!window.confirm('この解き直しカードを削除しますか？')) return; await deleteMistakeCard(id); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを削除しました'); };
   const savePdf = async (pdf: MaterialPdf) => { await saveMaterialPdf(pdf); await loadMaterialPdfs(); };
   const removePdf = async (id: string) => { await deleteMaterialPdf(id); await Promise.all([loadMaterialPdfs(), loadPdfMappings()]); setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。'); };
-  const savePdfMapping = async (mapping: MaterialPdfMapping) => { await saveMaterialPdfMapping(mapping); await loadPdfMappings(); setMessage('PDFページ紐付けを保存しました'); };
-  const removePdfMapping = async (id: string) => { if (!window.confirm('このPDFページ紐付けを削除しますか？PDF教材データと答案履歴は削除されません。')) return; await deleteMaterialPdfMapping(id); await loadPdfMappings(); setMessage('PDFページ紐付けを削除しました'); };
+  const savePdfMapping = async (mapping: MaterialPdfMapping) => { await saveMaterialPdfMapping(mapping); await loadPdfMappings(); setMessage('PDF抽出テキスト紐づけを保存しました'); };
+  const removePdfMapping = async (id: string) => { if (!window.confirm('このPDF抽出テキスト紐づけを削除しますか？PDF教材データと答案履歴は削除されません。')) return; await deleteMaterialPdfMapping(id); await loadPdfMappings(); setMessage('PDF抽出テキスト紐づけを削除しました'); };
 
   const exportCurrentCsv = () => downloadCsv('current-answer.csv', currentAnswerCsvRows(answer, problem));
   const exportHistoryCsv = () => downloadCsv('history.csv', historyCsvRows(histories));
@@ -309,31 +295,28 @@ export default function App() {
   const exportMasteryCsv = () => downloadCsv('mastery-map.csv', masteryMapCsvRows(masteryMap));
   const exportMistakeCardsCsv = () => downloadCsv('mistake-cards.csv', mistakeCardCsvRows(mistakeCards, getProblemById));
   const exportRecoveryCsv = () => downloadCsv('recovery-plan.csv', recoveryPlanCsvRows(recoveryPlan));
-  const exportJson = async () => { const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]); const meta = await recordBackupMade(historyRows.length, answerRows.length); const payload = await exportAllData(); downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8'); setBackupMeta(meta); await refreshSafety(); setMessage('JSONバックアップを出力しました。PDF Blob本体はPR2対象のため含めていません。'); };
-  const importJson = async (file: File | undefined) => { if (!file) return; try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体は端末内Vaultに残る仕様です。'); } catch { setMessage('JSONの形式が不正です'); } };
+  const exportJson = async () => { const [historyRows, answerRows] = await Promise.all([getHistories(), getAllAnswers()]); const meta = await recordBackupMade(historyRows.length, answerRows.length); const payload = await exportAllData(); downloadText('cpa-boki2-backup.json', JSON.stringify({ ...payload, backupMetadata: meta }, null, 2), 'application/json;charset=utf-8'); setBackupMeta(meta); await refreshSafety(); setMessage('JSONバックアップを出力しました。PDF本体と抽出教材本文は含めていません。'); };
+  const importJson = async (file: File | undefined) => { if (!file) return; try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体・抽出テキストは端末内データを維持する仕様です。'); } catch { setMessage('JSONの形式が不正です'); } };
 
   const saveExamSetRecord = async (record: ExamSetRecord) => { const relatedHistoryIds: string[] = []; for (const problemState of record.problemStates) { if (problemState.rank !== 'B' && problemState.rank !== 'C') continue; const problemDefinition = getProblemById(problemState.problemId); const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId); const scored = normalizeAnswer({ ...base, score: Number(problemState.score) || 0, rowPointsTotal: Number(problemState.score) || 0, rank: problemState.rank, nextReviewDate: reviewDateForRank(problemState.rank), reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`, scored: true, scoredAt: nowIso(), updatedAt: nowIso() }); const history = buildHistory(scored); relatedHistoryIds.push(history.id); await addHistory(history); } await saveExamSet({ ...record, relatedHistoryIds }); await refreshAll(); setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。'); };
-  const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('study'); setStudyView('answer'); };
+  const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('study'); };
 
   return (
     <main className="app-shell redesigned-shell">
-      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>PDFの設問を見る → 直下の答案欄に入力する → 次の設問へ進む → 最後に採点する、の流れに集中する画面です。</p></div><Timer /></header>
+      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>問題文を読む → 答案入力 → 採点 → 次回復習日へ回す、を最短で回すための学習画面です。</p></div><Timer /></header>
       <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button></nav>
       <div className="status-bar">{message}</div>
 
       {mode === 'study' && <section className="mode-section study-mode-section">
-        {!currentMapping && <section className="panel first-use-steps"><h2>最初にやること</h2><div><span>1. 教材を設定する</span><span>2. 設問ごとにPDF範囲を登録する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
-        <DisposableStudyPanel activeSession={activeSession} quickHint={quickHint} onQuickResume={quickResume} onSelectMode={selectTimeMode} />
-        <section className="study-problem-strip panel mode-card"><div><p className="eyebrow">今解く問題</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>1. PDFの設問を読む　2. 直下の答案欄に入力する　3. 次の設問へ進む　4. 解答・解説を見る　5. 自己採点する　6. 次回復習日に回す</p><p>想定時間：{currentMapping?.estimatedMinutes ?? '未設定'} / 難易度：{currentMapping?.difficulty ?? '未設定'} / 設問数：{currentMapping?.problemBlocks?.length ?? answer.problemBlocks?.length ?? 1}</p></div><button className="secondary" onClick={() => setStudyView(studyView === 'problem' ? 'answer' : 'problem')}>{studyView === 'problem' ? '答案を大きく表示' : '問題PDFを開く'}</button></section>
-        <div className="mobile-study-tabs"><button className={studyView === 'problem' ? 'active' : ''} onClick={() => setStudyView('problem')}>問題を見る</button><button className={studyView === 'answer' ? 'active' : ''} onClick={() => setStudyView('answer')}>答案を書く</button><button onClick={() => { setMode('grading'); setStudyView('grading'); }}>採点する</button></div>
-        <div className={`focused-study-layout ${studyView === 'problem' ? 'show-pdf' : 'show-answer'}`}><div className="study-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="study" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} onRequestGrading={() => setMode('grading')} /></div><div className="answer-main-column"><ExampleGuide template={template} /><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} pdf={currentPdf} mode="practice" onChange={updateAnswer} /></div></div>
+        {!currentMapping?.problemText && <section className="panel first-use-steps"><h2>最初にやること</h2><div><span>1. 教材を設定する</span><span>2. PDFから問題候補を抽出する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
+        <FocusedPracticePanel problem={problem} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} onChange={updateAnswer} onSave={manualSave} onGoGrading={() => setMode('grading')} onNextProblem={openNextProblem} onApplyRowPoints={applyRowPoints} />
       </section>}
 
-      {mode === 'grading' && <section className="mode-section grading-mode-section"><section className="panel mode-card study-problem-strip"><div><p className="eyebrow">採点する</p><h2>{problem.sectionLabel} {problem.displayId}：{problem.topic}</h2><p>解答・解説PDFを確認し、必要な設問だけ「採点・メモを開く」から記録します。</p></div><button className="secondary" onClick={() => setMode('study')}>答案入力へ戻る</button></section><div className="grading-layout"><div className="grading-answer-column"><h2>自分の答案</h2><ProblemBlockAnswerPanel answer={answer} mapping={currentMapping} pdf={currentPdf} mode="grading" onChange={updateAnswer} /></div><div className="grading-pdf-column"><PdfStudyPanel problem={problem} answer={answer} pdfs={materialPdfs} mappings={pdfMappings} activeSession={activeSession} reviewState={currentReviewState} panelMode="grading" onStartCurrentSession={startCurrentSession} onSessionChange={updatePracticeSession} onSelfGrade={submitSelfGrading} /><ScoringPanel answer={answer} onChange={updateAnswer} onSave={manualSave} onConfirmScoring={confirmScoring} /></div></div></section>}
+      {mode === 'grading' && <FocusedGradingPanel problem={problem} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} onChange={updateAnswer} onSave={manualSave} onApplyRowPoints={applyRowPoints} onSubmitSelfGrading={submitSelfGrading} onBackPractice={() => setMode('study')} />}
 
       {mode === 'materials' && <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />}
 
-      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習・進捗を見る</p><h2>今日の判断だけを先に表示</h2><p>詳細な履歴、CSV、バックアップ、白紙再現、70点リカバリーは下のカードを開いた時だけ表示します。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やるべき問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定・危険問題</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
+      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習・進捗を見る</p><h2>管理機能はここに集約</h2><p>通常演習画面には出さず、必要な時だけここで確認します。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やる問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div><div><strong>{progressSummary.last7Days}</strong><span>直近7日演習</span></div><div><strong>{progressSummary.last30Days}</strong><span>直近30日演習</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
     </main>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import type { AnswerState, GradingStatus, MaterialPdf, MaterialPdfMapping, MissReason, ProblemDefinition, ReviewRank, TemplateDefinition } from '../types';
+import { reviewDateForRank } from '../utils/dates';
+import { AnswerTable } from './AnswerTable';
+import { PdfViewerPanel } from './PdfViewerPanel';
+
+interface Props {
+  problem: ProblemDefinition;
+  answer: AnswerState;
+  template: TemplateDefinition;
+  mapping?: MaterialPdfMapping;
+  pdf?: MaterialPdf;
+  onChange: (answer: AnswerState) => void;
+  onSave: () => void;
+  onSubmitSelfGrading: (input: { status: GradingStatus; score: number; maxScore: number; memo: string }) => void | Promise<void>;
+  onBackPractice: () => void;
+}
+
+const gradingStatuses: GradingStatus[] = ['正解', '部分正解', '不正解', '迷いあり'];
+const missReasons: MissReason[] = ['論点理解不足', '仕訳ミス', '借方貸方逆', '金額ミス', '集計ミス', '転記ミス', '表の入力位置ミス', '下書き不足', '時間不足', '解答欄形式の誤認', '問題文読み落とし', 'その他'];
+
+function extractedAnswer(mapping?: MaterialPdfMapping): string {
+  return [mapping?.answerText, mapping?.explanationText].filter(Boolean).join('\n\n') || '教材設定画面でPDFから解答・解説テキストを抽出すると、ここに端末内データとして表示されます。未設定の場合は、原本PDFまたは教材を見ながら自己採点してください。';
+}
+
+function nextRankFromStatus(status: GradingStatus): ReviewRank {
+  if (status === '正解') return 'A';
+  if (status === '部分正解' || status === '迷いあり') return 'B';
+  return 'C';
+}
+
+export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, onChange, onSave, onSubmitSelfGrading, onBackPractice }: Props) {
+  const [status, setStatus] = useState<GradingStatus>('迷いあり');
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [page, setPage] = useState(mapping?.answerPageStart ?? mapping?.answerPages?.[0] ?? mapping?.explanationPages?.[0] ?? 1);
+  const explanation = extractedAnswer(mapping);
+
+  const setRank = (rank: ReviewRank) => onChange({ ...answer, rank, nextReviewDate: reviewDateForRank(rank) });
+  const toggleReason = (reason: MissReason) => {
+    const exists = answer.missReasons.includes(reason);
+    onChange({ ...answer, missReasons: exists ? answer.missReasons.filter((item) => item !== reason) : [...answer.missReasons, reason] });
+  };
+  const applyStatus = (nextStatus: GradingStatus) => {
+    setStatus(nextStatus);
+    const nextRank = nextRankFromStatus(nextStatus);
+    setRank(nextRank);
+  };
+
+  return (
+    <section className="focused-grading-panel">
+      <section className="panel focused-question-card">
+        <div className="focused-question-header">
+          <div>
+            <p className="eyebrow">採点する</p>
+            <h2>{problem.displayId}：{problem.topic}</h2>
+            <p>自分の回答を見ながら、端末内に抽出した解答・解説テキストで自己採点します。</p>
+          </div>
+          <div className="button-row focused-main-actions">
+            <button className="secondary" onClick={onBackPractice}>答案入力へ戻る</button>
+            {pdf && <button className="secondary" onClick={() => setShowOriginal((current) => !current)}>{showOriginal ? '原本を閉じる' : '原本を見る'}</button>}
+            <button onClick={onSave}>一時保存</button>
+            <button className="accent" onClick={() => { void onSubmitSelfGrading({ status, score: answer.score, maxScore: answer.maxScore, memo: answer.reviewMemo }); }}>保存して次へ進む</button>
+          </div>
+        </div>
+
+        <div className="grading-text-grid">
+          <div className="problem-text-box">
+            <div className="problem-text-toolbar"><strong>解答・解説テキスト</strong><span>端末内PDF抽出データ</span></div>
+            <div className="problem-text-content explanation-text-content">{explanation}</div>
+          </div>
+          <div className="grading-control-box">
+            <h3>自己採点</h3>
+            <div className="status-button-grid">
+              {gradingStatuses.map((item) => <button key={item} className={status === item ? 'accent' : 'secondary'} onClick={() => applyStatus(item)}>{item}</button>)}
+            </div>
+            <div className="score-grid">
+              <label>得点<input type="number" value={answer.score} onChange={(event) => onChange({ ...answer, score: Number(event.target.value || 0) })} /></label>
+              <label>満点<input type="number" value={answer.maxScore} onChange={(event) => onChange({ ...answer, maxScore: Number(event.target.value || 0) })} /></label>
+              <label>A/B/C判定<select value={answer.rank} onChange={(event) => setRank(event.target.value as ReviewRank)}><option value="">未選択</option><option value="A">A：自力で解けた</option><option value="B">B：手順に不安</option><option value="C">C：再復習</option></select></label>
+              <label>次回復習日<input type="date" value={answer.nextReviewDate} onChange={(event) => onChange({ ...answer, nextReviewDate: event.target.value })} /></label>
+            </div>
+            <h3>ミス原因</h3>
+            <div className="check-list compact-check-list">
+              {missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={answer.missReasons.includes(reason)} onChange={() => toggleReason(reason)} />{reason}</label>)}
+            </div>
+            <label>復習メモ<textarea value={answer.reviewMemo} onChange={(event) => onChange({ ...answer, reviewMemo: event.target.value })} placeholder="次回解く前に見る注意点" /></label>
+          </div>
+        </div>
+
+        {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="解答・解説原本" page={page} pageStart={mapping?.answerPageStart ?? 1} pageEnd={mapping?.explanationPageEnd ?? pdf?.pageCount ?? 1} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
+      </section>
+
+      <section className="focused-answer-area">
+        <div className="focused-answer-title"><div><p className="eyebrow">自分の回答</p><h2>{template.name}</h2></div></div>
+        <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={() => onChange({ ...answer, rowPointsTotal: answer.rowPointsTotal })} />
+      </section>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
@@ -12,6 +12,7 @@ interface Props {
   pdf?: MaterialPdf;
   onChange: (answer: AnswerState) => void;
   onSave: () => void;
+  onApplyRowPoints: () => void;
   onSubmitSelfGrading: (input: { status: GradingStatus; score: number; maxScore: number; memo: string }) => void | Promise<void>;
   onBackPractice: () => void;
 }
@@ -29,7 +30,7 @@ function nextRankFromStatus(status: GradingStatus): ReviewRank {
   return 'C';
 }
 
-export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, onChange, onSave, onSubmitSelfGrading, onBackPractice }: Props) {
+export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, onChange, onSave, onApplyRowPoints, onSubmitSelfGrading, onBackPractice }: Props) {
   const [status, setStatus] = useState<GradingStatus>('迷いあり');
   const [showOriginal, setShowOriginal] = useState(false);
   const [page, setPage] = useState(mapping?.answerPageStart ?? mapping?.answerPages?.[0] ?? mapping?.explanationPages?.[0] ?? 1);
@@ -91,8 +92,8 @@ export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, o
       </section>
 
       <section className="focused-answer-area">
-        <div className="focused-answer-title"><div><p className="eyebrow">自分の回答</p><h2>{template.name}</h2></div></div>
-        <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={() => onChange({ ...answer, rowPointsTotal: answer.rowPointsTotal })} />
+        <div className="focused-answer-title"><div><p className="eyebrow">自分の回答</p><h2>{template.name}</h2></div><button className="secondary" onClick={onApplyRowPoints}>行別得点合計を反映</button></div>
+        <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} />
       </section>
     </section>
   );

--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import type { AnswerState, MaterialPdf, MaterialPdfMapping, ProblemDefinition, TemplateDefinition } from '../types';
+import { AnswerTable } from './AnswerTable';
+import { PdfViewerPanel } from './PdfViewerPanel';
+
+interface Props {
+  problem: ProblemDefinition;
+  answer: AnswerState;
+  template: TemplateDefinition;
+  mapping?: MaterialPdfMapping;
+  pdf?: MaterialPdf;
+  onChange: (answer: AnswerState) => void;
+  onSave: () => void;
+  onGoGrading: () => void;
+  onNextProblem: () => void;
+  onApplyRowPoints: () => void;
+}
+
+function fallbackQuestion(problem: ProblemDefinition): string {
+  return '教材を設定すると、PDFから抽出した問題文テキストがここに表示されます。未設定の場合は、購入済みPDFや紙教材を見ながら下の答案欄へ入力してください。';
+}
+
+function joinBlockText(mapping?: MaterialPdfMapping): string {
+  const fromBlocks = mapping?.problemBlocks?.map((block) => block.questionText).filter(Boolean).join('\n\n');
+  return fromBlocks || mapping?.problemText || '';
+}
+
+function pageLabel(pages?: number[]): string {
+  if (!pages || pages.length === 0) return '未設定';
+  return Array.from(new Set(pages)).sort((a, b) => a - b).join(', ');
+}
+
+export function FocusedPracticePanel({ problem, answer, template, mapping, pdf, onChange, onSave, onGoGrading, onNextProblem, onApplyRowPoints }: Props) {
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [page, setPage] = useState(mapping?.problemPageStart ?? mapping?.sourcePages?.[0] ?? 1);
+  const questionText = useMemo(() => joinBlockText(mapping) || fallbackQuestion(problem), [mapping, problem]);
+  const subjectLabel = problem.subject === 'commercial' ? '商業簿記' : '工業簿記';
+  const textReady = Boolean(joinBlockText(mapping));
+
+  return (
+    <section className="focused-practice-panel">
+      <section className="panel focused-question-card">
+        <div className="focused-question-header">
+          <div>
+            <p className="eyebrow">今すぐ解く</p>
+            <h2>{problem.displayId}：{problem.topic}</h2>
+            <div className="focused-question-meta">
+              <span>{subjectLabel}</span>
+              <span>{problem.sectionLabel}</span>
+              <span>想定時間：{mapping?.estimatedMinutes ?? '未設定'}</span>
+              <span>難易度：{mapping?.difficulty ?? '未設定'}</span>
+              {mapping?.extractionConfidence !== undefined && <span>抽出信頼度：{mapping.extractionConfidence}%</span>}
+            </div>
+          </div>
+          <div className="button-row focused-main-actions">
+            <button onClick={onSave}>一時保存</button>
+            <button className="accent" onClick={onGoGrading}>採点へ進む</button>
+            <button className="secondary" onClick={onNextProblem}>次の問題へ</button>
+          </div>
+        </div>
+
+        <div className="problem-text-box">
+          <div className="problem-text-toolbar">
+            <strong>問題文テキスト</strong>
+            <span>抽出元ページ：{pageLabel(mapping?.sourcePages)}</span>
+            {pdf && <button className="secondary" onClick={() => setShowOriginal((current) => !current)}>{showOriginal ? '原本を閉じる' : '原本を見る'}</button>}
+          </div>
+          {!textReady && <p className="warning-text">PDF抽出テキストが未設定です。教材設定画面でPDFから問題候補を抽出してください。</p>}
+          <div className="problem-text-content">{questionText}</div>
+        </div>
+
+        {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="原本" page={page} pageStart={mapping?.problemPageStart ?? 1} pageEnd={mapping?.problemPageEnd ?? pdf?.pageCount ?? 1} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
+      </section>
+
+      <section className="focused-answer-area">
+        <div className="focused-answer-title">
+          <div>
+            <p className="eyebrow">答案入力</p>
+            <h2>{template.name}</h2>
+          </div>
+          <button className="secondary" onClick={onApplyRowPoints}>行別得点合計を反映</button>
+        </div>
+        <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} />
+      </section>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/MaterialSetupWorkspace.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { problemCatalog } from '../data/problemCatalog';
-import { templateCatalog } from '../data/templateCatalog';
-import type { BlockDifficulty, MaterialPdf, MaterialPdfMapping, ProblemBlock, TemplateId, TimeMode } from '../types';
+import type { MaterialPdf, MaterialPdfMapping, PdfProblemExtractionCandidate, TemplateId } from '../types';
 import { nowIso } from '../utils/dates';
-import { timeModes } from '../utils/disposableStudy';
-import { suggestPdfLinkCandidates, type PdfAutoLinkCandidate } from '../utils/pdfAutoLink';
+import { extractProblemCandidatesFromPdf } from '../utils/pdfAutoLink';
 import { formatFileSize, getPdfPageCount } from '../utils/pdfRenderer';
-import { PdfQuestionPreview } from './PdfQuestionPreview';
 import { PdfViewerPanel } from './PdfViewerPanel';
 
 interface Props {
@@ -21,82 +18,100 @@ interface Props {
   onMessage: (message: string) => void;
 }
 
-type RangeKind = 'problem' | 'answer' | 'explanation';
-
-function blankBlock(index: number, templateId: TemplateId = 'journal'): ProblemBlock {
-  const start = Math.min(90, index * 30);
+function emptyCandidate(pdfId: string): PdfProblemExtractionCandidate {
+  const problem = problemCatalog[0];
   return {
     id: crypto.randomUUID(),
-    title: `設問${index + 1}`,
-    description: '',
-    problemPageStart: 1,
-    problemPageEnd: 1,
-    cropTopPercent: start,
-    cropBottomPercent: Math.min(100, start + 30),
-    estimatedMinutes: 3,
-    difficulty: '標準',
-    templateId,
-    memo: '',
+    materialPdfId: pdfId,
+    suggestedProblemId: problem.id,
+    displayId: problem.displayId,
+    subject: problem.subject,
+    sectionId: problem.sectionId,
+    sectionLabel: problem.sectionLabel,
+    topic: problem.topic,
+    templateId: problem.defaultTemplateId,
+    problemKind: problem.defaultTemplateId === 'journal' ? 'journal' : 'calculationTable',
+    problemText: '',
+    answerText: '',
+    explanationText: '',
+    sourcePages: [],
+    answerPages: [],
+    explanationPages: [],
+    confidence: 0,
+    status: 'needsReview',
+    reason: '手動で問題IDと抽出テキストを確認してください。',
   };
 }
 
-function blankMapping(problemId: string, pdfId = ''): MaterialPdfMapping {
-  const problem = problemCatalog.find((item) => item.id === problemId) ?? problemCatalog[0];
+function pagesToRange(pages: number[], fallback = 1): { start: number; end: number } {
+  if (pages.length === 0) return { start: fallback, end: fallback };
+  const sorted = [...pages].sort((a, b) => a - b);
+  return { start: sorted[0], end: sorted[sorted.length - 1] };
+}
+
+function candidateToMapping(candidate: PdfProblemExtractionCandidate): MaterialPdfMapping {
   const now = nowIso();
+  const problem = problemCatalog.find((item) => item.id === candidate.suggestedProblemId) ?? problemCatalog[0];
+  const problemRange = pagesToRange(candidate.sourcePages);
+  const answerRange = pagesToRange(candidate.answerPages, problemRange.end);
+  const explanationRange = pagesToRange(candidate.explanationPages, answerRange.end);
   return {
-    id: crypto.randomUUID(),
+    id: `${candidate.materialPdfId}-${problem.id}`,
+    qualificationId: 'nissho_boki2',
     problemId: problem.id,
     displayId: problem.displayId,
-    materialPdfId: pdfId,
-    problemPageStart: 1,
-    problemPageEnd: 1,
-    answerPageStart: undefined,
-    answerPageEnd: undefined,
-    explanationPageStart: undefined,
-    explanationPageEnd: undefined,
+    materialPdfId: candidate.materialPdfId,
+    subjectId: problem.subject,
+    topicId: problem.displayId,
+    problemKind: candidate.problemKind,
+    problemText: candidate.problemText,
+    answerText: candidate.answerText,
+    explanationText: candidate.explanationText,
+    sourcePages: candidate.sourcePages,
+    answerPages: candidate.answerPages,
+    explanationPages: candidate.explanationPages,
+    extractionConfidence: candidate.confidence,
+    extractionStatus: candidate.status,
+    extractedAt: now,
+    problemPageStart: problemRange.start,
+    problemPageEnd: problemRange.end,
+    answerPageStart: candidate.answerPages.length ? answerRange.start : undefined,
+    answerPageEnd: candidate.answerPages.length ? answerRange.end : undefined,
+    explanationPageStart: candidate.explanationPages.length ? explanationRange.start : undefined,
+    explanationPageEnd: candidate.explanationPages.length ? explanationRange.end : undefined,
     estimatedMinutes: '10分',
-    difficulty: '標準',
-    memo: '',
-    problemBlocks: [blankBlock(0, problem.defaultTemplateId)],
+    difficulty: candidate.confidence >= 75 ? '標準' : '難',
+    memo: candidate.reason,
+    problemBlocks: [
+      {
+        id: `${problem.id}-text-main`,
+        title: '設問1',
+        description: problem.topic,
+        questionText: candidate.problemText,
+        sourcePages: candidate.sourcePages,
+        problemPageStart: problemRange.start,
+        problemPageEnd: problemRange.end,
+        templateId: candidate.templateId,
+        estimatedMinutes: 10,
+        difficulty: '標準',
+        memo: '',
+      },
+    ],
     createdAt: now,
     updatedAt: now,
   };
 }
 
-function numberOrUndefined(value: string): number | undefined {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+function statusLabel(status: PdfProblemExtractionCandidate['status']): string {
+  if (status === 'autoLinked') return '自動紐づけ済み';
+  if (status === 'needsReview') return '確認が必要';
+  return '未分類';
 }
 
-function percentOrDefault(value: string, fallback: number): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return fallback;
-  return Math.max(0, Math.min(100, parsed));
-}
-
-function questionTitle(index: number, title?: string): string {
-  const trimmed = title?.trim();
-  if (!trimmed || trimmed.startsWith('問題文')) return `設問${index + 1}`;
-  return trimmed;
-}
-
-function ensureBlocks(mapping: MaterialPdfMapping): ProblemBlock[] {
-  if (mapping.problemBlocks && mapping.problemBlocks.length > 0) {
-    return mapping.problemBlocks.map((block, index) => ({
-      ...block,
-      title: questionTitle(index, block.title),
-      problemPageStart: block.problemPageStart ?? mapping.problemPageStart,
-      problemPageEnd: block.problemPageEnd ?? mapping.problemPageEnd,
-      cropTopPercent: block.cropTopPercent ?? 0,
-      cropBottomPercent: block.cropBottomPercent ?? 100,
-    }));
-  }
-  const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
-  return [blankBlock(0, problem.defaultTemplateId)];
-}
-
-function blockDifficultyLabel(value?: BlockDifficulty): string {
-  return value ?? '標準';
+function statusClass(status: PdfProblemExtractionCandidate['status']): string {
+  if (status === 'autoLinked') return 'good';
+  if (status === 'needsReview') return 'warn';
+  return 'danger';
 }
 
 export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSavePdf, onDeletePdf, onSaveMapping, onDeleteMapping, onOpenProblem, onMessage }: Props) {
@@ -104,57 +119,30 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
   const [sourceName, setSourceName] = useState('CPA問題集');
   const [bookType, setBookType] = useState<MaterialPdf['bookType']>('商業簿記');
   const [selectedPdfId, setSelectedPdfId] = useState(pdfs[0]?.id ?? '');
-  const [draft, setDraft] = useState<MaterialPdfMapping>(() => blankMapping(selectedProblemId, pdfs[0]?.id ?? ''));
-  const [previewKind, setPreviewKind] = useState<RangeKind>('problem');
-  const [page, setPage] = useState(1);
-  const [candidates, setCandidates] = useState<PdfAutoLinkCandidate[]>([]);
-  const [scanning, setScanning] = useState(false);
+  const [candidates, setCandidates] = useState<PdfProblemExtractionCandidate[]>([]);
+  const [selectedCandidateId, setSelectedCandidateId] = useState('');
+  const [extracting, setExtracting] = useState(false);
+  const [progress, setProgress] = useState('');
+  const [previewPage, setPreviewPage] = useState(1);
 
   const selectedPdf = useMemo(() => pdfs.find((pdf) => pdf.id === selectedPdfId) ?? pdfs[0], [pdfs, selectedPdfId]);
+  const selectedCandidate = candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0];
+  const counts = useMemo(() => ({
+    autoLinked: candidates.filter((candidate) => candidate.status === 'autoLinked').length,
+    needsReview: candidates.filter((candidate) => candidate.status === 'needsReview').length,
+    unmatched: candidates.filter((candidate) => candidate.status === 'unmatched').length,
+  }), [candidates]);
   const mappedProblemIds = useMemo(() => new Set(mappings.map((mapping) => mapping.problemId)), [mappings]);
-  const unmapped = problemCatalog.filter((problem) => !mappedProblemIds.has(problem.id));
-  const mapped = problemCatalog.filter((problem) => mappedProblemIds.has(problem.id));
-  const blocks = ensureBlocks(draft);
+  const unmappedCount = problemCatalog.filter((problem) => !mappedProblemIds.has(problem.id)).length;
 
   useEffect(() => {
     if (!selectedPdfId && pdfs[0]) setSelectedPdfId(pdfs[0].id);
   }, [pdfs, selectedPdfId]);
 
   useEffect(() => {
-    const existing = mappings.find((mapping) => mapping.problemId === selectedProblemId) ?? blankMapping(selectedProblemId, selectedPdf?.id ?? '');
-    const next = { ...existing, materialPdfId: existing.materialPdfId || selectedPdf?.id || '', problemBlocks: ensureBlocks(existing) };
-    setDraft(next);
-    setSelectedPdfId(next.materialPdfId || selectedPdf?.id || '');
-  }, [selectedProblemId, mappings, selectedPdf?.id]);
-
-  const activeRange = (() => {
-    if (previewKind === 'answer' && draft.answerPageStart) return { start: draft.answerPageStart, end: draft.answerPageEnd ?? draft.answerPageStart };
-    if (previewKind === 'explanation' && draft.explanationPageStart) return { start: draft.explanationPageStart, end: draft.explanationPageEnd ?? draft.explanationPageStart };
-    return { start: draft.problemPageStart, end: draft.problemPageEnd };
-  })();
-
-  useEffect(() => {
-    setPage(activeRange.start || 1);
-  }, [previewKind, draft.problemPageStart, draft.answerPageStart, draft.explanationPageStart]);
-
-  function update(patch: Partial<MaterialPdfMapping>) {
-    const nextProblemId = patch.problemId ?? draft.problemId;
-    const problem = problemCatalog.find((item) => item.id === nextProblemId) ?? problemCatalog[0];
-    setDraft((current) => ({ ...current, ...patch, problemId: nextProblemId, displayId: problem.displayId, problemBlocks: patch.problemBlocks ?? ensureBlocks(current), updatedAt: nowIso() }));
-  }
-
-  function updateBlock(index: number, patch: Partial<ProblemBlock>) {
-    update({ problemBlocks: blocks.map((block, blockIndex) => blockIndex === index ? { ...block, ...patch } : block) });
-  }
-
-  function addBlock() {
-    update({ problemBlocks: [...blocks, blankBlock(blocks.length, blocks[blocks.length - 1]?.templateId ?? 'journal')] });
-  }
-
-  function deleteBlock(index: number) {
-    const next = blocks.filter((_, blockIndex) => blockIndex !== index);
-    update({ problemBlocks: next.length > 0 ? next : [blankBlock(0)] });
-  }
+    const mapping = mappings.find((item) => item.problemId === selectedProblemId);
+    if (mapping?.sourcePages?.[0]) setPreviewPage(mapping.sourcePages[0]);
+  }, [mappings, selectedProblemId]);
 
   async function importPdf(file: File | undefined) {
     if (!file) return;
@@ -181,90 +169,158 @@ export function MaterialSetupWorkspace({ pdfs, mappings, selectedProblemId, onSa
       };
       await onSavePdf(pdf);
       setSelectedPdfId(pdf.id);
-      setDraft((current) => ({ ...current, materialPdfId: pdf.id }));
       setTitle('');
       setCandidates([]);
-      onMessage('PDFを端末内IndexedDBへ保存しました。続けて問題IDと設問ごとの表示範囲を登録してください。');
+      setSelectedCandidateId('');
+      onMessage('PDFを端末内IndexedDBへ保存しました。次に「PDFから問題候補を抽出」を押してください。');
     } catch {
       onMessage('PDFの読み込みに失敗しました。破損ファイル、保護PDF、ブラウザ非対応の可能性があります。');
     }
   }
 
-  async function scanCandidates() {
-    if (!selectedPdf) return;
-    setScanning(true);
-    try {
-      const rows = await suggestPdfLinkCandidates(selectedPdf);
-      setCandidates(rows);
-      onMessage(rows.length ? `候補ページを${rows.length}件検出しました。必ずPDFを確認してから保存してください。` : '候補ページは検出できませんでした。PDFを見ながら手動で指定してください。');
-    } finally {
-      setScanning(false);
-    }
-  }
-
-  async function saveMapping() {
-    if (!draft.materialPdfId) {
-      onMessage('先に対象PDFを選択してください');
+  async function extractCandidates() {
+    if (!selectedPdf) {
+      onMessage('先にPDFを選択してください');
       return;
     }
-    await onSaveMapping({ ...draft, problemBlocks: blocks, updatedAt: nowIso() });
+    setExtracting(true);
+    setProgress('抽出準備中');
+    try {
+      const rows = await extractProblemCandidatesFromPdf(selectedPdf, (page, pageCount) => setProgress(`PDFテキスト抽出中 ${page} / ${pageCount}ページ`));
+      setCandidates(rows);
+      setSelectedCandidateId(rows[0]?.id ?? '');
+      setProgress('');
+      onMessage(`問題候補を抽出しました。自動紐づけ済み：${rows.filter((row) => row.status === 'autoLinked').length}件、確認が必要：${rows.filter((row) => row.status === 'needsReview').length}件、未分類：${rows.filter((row) => row.status === 'unmatched').length}件`);
+    } catch {
+      onMessage('PDFテキスト抽出に失敗しました。テキストPDFでない場合、OCRは今回実装していないため抽出できません。');
+    } finally {
+      setExtracting(false);
+      setProgress('');
+    }
   }
 
-  function jumpToRange(kind: RangeKind) {
-    setPreviewKind(kind);
-    if (kind === 'answer' && draft.answerPageStart) setPage(draft.answerPageStart);
-    else if (kind === 'explanation' && draft.explanationPageStart) setPage(draft.explanationPageStart);
-    else setPage(draft.problemPageStart);
+  function updateCandidate(id: string, patch: Partial<PdfProblemExtractionCandidate>) {
+    setCandidates((current) => current.map((candidate) => {
+      if (candidate.id !== id) return candidate;
+      const nextProblemId = patch.suggestedProblemId ?? candidate.suggestedProblemId;
+      const problem = problemCatalog.find((item) => item.id === nextProblemId) ?? problemCatalog[0];
+      return {
+        ...candidate,
+        ...patch,
+        suggestedProblemId: nextProblemId,
+        displayId: problem.displayId,
+        subject: problem.subject,
+        sectionId: problem.sectionId,
+        sectionLabel: problem.sectionLabel,
+        topic: problem.topic,
+        templateId: (patch.templateId ?? problem.defaultTemplateId) as TemplateId,
+        problemKind: problem.defaultTemplateId === 'journal' ? 'journal' : 'calculationTable',
+      };
+    }));
   }
 
-  function applyCandidate(pageNumber: number, target: RangeKind) {
-    if (target === 'problem') update({ problemPageStart: pageNumber, problemPageEnd: Math.max(pageNumber, draft.problemPageEnd) });
-    if (target === 'answer') update({ answerPageStart: pageNumber, answerPageEnd: pageNumber });
-    if (target === 'explanation') update({ explanationPageStart: pageNumber, explanationPageEnd: pageNumber });
-    setPage(pageNumber);
+  async function saveCandidate(candidate: PdfProblemExtractionCandidate) {
+    await onSaveMapping(candidateToMapping({ ...candidate, status: candidate.confidence >= 75 ? 'autoLinked' : candidate.status }));
+    onMessage(`${candidate.displayId} の抽出テキスト紐づけを保存しました`);
+  }
+
+  async function saveAutoLinkedCandidates() {
+    const targets = candidates.filter((candidate) => candidate.status === 'autoLinked');
+    if (targets.length === 0) {
+      onMessage('自動保存できる高信頼度候補がありません。確認が必要な候補を手動保存してください。');
+      return;
+    }
+    for (const candidate of targets) await onSaveMapping(candidateToMapping(candidate));
+    onMessage(`自動紐づけ済み ${targets.length}件を保存しました。確認が必要な候補だけ手動修正してください。`);
+  }
+
+  function addManualCandidate() {
+    if (!selectedPdf) return;
+    const next = emptyCandidate(selectedPdf.id);
+    setCandidates((current) => [next, ...current]);
+    setSelectedCandidateId(next.id);
   }
 
   return (
-    <section className="material-setup-grid wizard-setup-grid">
-      <div className="panel setup-control-panel mode-card wizard-control-panel">
-        <p className="eyebrow">教材を設定する</p>
-        <h2>PDF教材を選ぶ → 問題IDを選ぶ → 設問ごとの表示範囲を登録</h2>
-        <p className="notice-small">PDF本文をアプリに保存するのではなく、購入済みPDFの該当ページ範囲だけを端末内で参照します。</p>
-        <p className="notice-small">PDFの作りによっては自動候補が出ない場合があります。その場合はPDFを見ながら手動でページ範囲を指定してください。</p>
-
-        <details open className="wizard-step-card"><summary>1. PDF教材を選ぶ</summary>
-          <div className="form-grid three-columns">
-            <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
-            <label>教材区分<select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}><option value="商業簿記">商業簿記</option><option value="工業簿記">工業簿記</option><option value="その他">その他</option></select></label>
-            <label>出所メモ<input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" /></label>
+    <section className="material-text-setup">
+      <section className="panel material-setup-main">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">教材を設定する</p>
+            <h2>PDF取込・テキスト抽出・問題ID自動紐づけ</h2>
+            <p>通常演習画面へ出す問題文は、PDF画像ではなく端末内で抽出したテキストを使います。PDF本体・抽出テキストはGitHubへ保存しません。</p>
           </div>
-          <label className="import-label pdf-import-label">PDFを選択してプレビュー<input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} /></label>
-        </details>
+          <button className="secondary" onClick={() => { void onOpenProblem(selectedProblemId); }}>今すぐ解くへ戻る</button>
+        </div>
 
-        <details open className="wizard-step-card"><summary>2. 問題IDとページを選ぶ</summary>
-          <div className="form-grid two-columns"><label>対象PDF<select value={draft.materialPdfId || selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); update({ materialPdfId: event.target.value }); }}><option value="">PDFを選択</option>{pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P）</option>)}</select></label><label>問題ID<select value={draft.problemId} onChange={(event) => { const existing = mappings.find((mapping) => mapping.problemId === event.target.value); setDraft(existing ? { ...existing, problemBlocks: ensureBlocks(existing) } : blankMapping(event.target.value, draft.materialPdfId || selectedPdfId)); }}>
-            {problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.sectionLabel} {problem.displayId} {problem.topic}</option>)}</select></label></div>
-          <div className="form-grid six-columns"><label>問題開始P<input type="number" min="1" value={draft.problemPageStart} onChange={(event) => update({ problemPageStart: Number(event.target.value) || 1 })} /></label><label>問題終了P<input type="number" min="1" value={draft.problemPageEnd} onChange={(event) => update({ problemPageEnd: Number(event.target.value) || draft.problemPageStart })} /></label><label>解答開始P<input type="number" min="1" value={draft.answerPageStart ?? ''} onChange={(event) => update({ answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解答終了P<input type="number" min="1" value={draft.answerPageEnd ?? ''} onChange={(event) => update({ answerPageEnd: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" min="1" value={draft.explanationPageStart ?? ''} onChange={(event) => update({ explanationPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説終了P<input type="number" min="1" value={draft.explanationPageEnd ?? ''} onChange={(event) => update({ explanationPageEnd: numberOrUndefined(event.target.value) })} /></label></div>
-          <div className="form-grid three-columns"><label>想定時間<select value={draft.estimatedMinutes} onChange={(event) => update({ estimatedMinutes: event.target.value as TimeMode })}>{timeModes.map((mode) => <option key={mode} value={mode}>{mode}</option>)}</select></label><label>難易度<select value={draft.difficulty} onChange={(event) => update({ difficulty: event.target.value as MaterialPdfMapping['difficulty'] })}><option value="易">易</option><option value="標準">標準</option><option value="難">難</option></select></label><label>メモ<input value={draft.memo} onChange={(event) => update({ memo: event.target.value })} placeholder="教材本文は入れない" /></label></div>
-          <div className="button-row"><button onClick={() => { void scanCandidates(); }} disabled={!selectedPdf || scanning}>{scanning ? '候補抽出中...' : '候補ページを提案'}</button><button className={previewKind === 'problem' ? 'accent' : 'secondary'} onClick={() => jumpToRange('problem')}>問題</button><button className={previewKind === 'answer' ? 'accent' : 'secondary'} disabled={!draft.answerPageStart} onClick={() => jumpToRange('answer')}>解答</button><button className={previewKind === 'explanation' ? 'accent' : 'secondary'} disabled={!draft.explanationPageStart} onClick={() => jumpToRange('explanation')}>解説</button></div>
-          {candidates.length > 0 && <div className="auto-link-candidates"><h3>候補ページ</h3>{candidates.map((candidate) => <div key={candidate.page} className="candidate-row"><strong>P{candidate.page}</strong><span>{candidate.labels.join(' / ')}</span><small>{candidate.preview}</small><button onClick={() => setPage(candidate.page)}>このページへ移動</button><button onClick={() => applyCandidate(candidate.page, 'problem')}>問題開始</button><button onClick={() => applyCandidate(candidate.page, 'answer')}>解答開始</button><button onClick={() => applyCandidate(candidate.page, 'explanation')}>解説開始</button></div>)}</div>}
-        </details>
+        <div className="setup-step-grid">
+          <section className="setup-step-card">
+            <h3>1. PDFを選択する</h3>
+            <div className="form-grid three-columns">
+              <label>表示名<input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例：商業簿記 試験対策編" /></label>
+              <label>教材区分<select value={bookType} onChange={(event) => setBookType(event.target.value as MaterialPdf['bookType'])}><option value="商業簿記">商業簿記</option><option value="工業簿記">工業簿記</option><option value="その他">その他</option></select></label>
+              <label>出所メモ<input value={sourceName} onChange={(event) => setSourceName(event.target.value)} placeholder="例：正規取得PDF" /></label>
+            </div>
+            <label className="import-label pdf-import-label">PDFを選択<input type="file" accept="application/pdf" onChange={(event) => { void importPdf(event.target.files?.[0]); }} /></label>
+            <label>対象PDF<select value={selectedPdfId} onChange={(event) => { setSelectedPdfId(event.target.value); setCandidates([]); setSelectedCandidateId(''); }}><option value="">PDFを選択</option>{pdfs.map((pdf) => <option key={pdf.id} value={pdf.id}>{pdf.title}（{pdf.pageCount}P / {formatFileSize(pdf.size)}）</option>)}</select></label>
+          </section>
 
-        <details open className="wizard-step-card"><summary>3. 設問ごとのPDF表示範囲と答案欄を作る</summary>
-          <div className="button-row"><button className="accent" onClick={addBlock}>設問を追加</button><span>現在 {blocks.length} 設問</span></div>
-          <div className="block-editor-list">
-            {blocks.map((block, index) => <div key={block.id} className="block-editor-card"><div className="section-heading"><div><p className="eyebrow">設問{index + 1}</p><h3>{questionTitle(index, block.title)}</h3></div><button className="danger" onClick={() => deleteBlock(index)}>削除</button></div><div className="form-grid three-columns"><label>設問名<input value={questionTitle(index, block.title)} onChange={(event) => updateBlock(index, { title: event.target.value })} /></label><label>答案テンプレート<select value={block.templateId} onChange={(event) => updateBlock(index, { templateId: event.target.value as TemplateId })}>{templateCatalog.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}</select></label><label>想定分<input type="number" value={block.estimatedMinutes ?? ''} onChange={(event) => updateBlock(index, { estimatedMinutes: numberOrUndefined(event.target.value) })} /></label></div><div className="form-grid six-columns"><label>問題P<input type="number" value={block.problemPageStart ?? draft.problemPageStart} onChange={(event) => updateBlock(index, { problemPageStart: numberOrUndefined(event.target.value) })} /></label><label>問題終了P<input type="number" value={block.problemPageEnd ?? block.problemPageStart ?? draft.problemPageEnd} onChange={(event) => updateBlock(index, { problemPageEnd: numberOrUndefined(event.target.value) })} /></label><label>上から％<input type="number" min="0" max="100" value={block.cropTopPercent ?? 0} onChange={(event) => updateBlock(index, { cropTopPercent: percentOrDefault(event.target.value, 0) })} /></label><label>下まで％<input type="number" min="0" max="100" value={block.cropBottomPercent ?? 100} onChange={(event) => updateBlock(index, { cropBottomPercent: percentOrDefault(event.target.value, 100) })} /></label><label>解答開始P<input type="number" value={block.answerPageStart ?? ''} onChange={(event) => updateBlock(index, { answerPageStart: numberOrUndefined(event.target.value) })} /></label><label>解説開始P<input type="number" value={block.explanationPageStart ?? ''} onChange={(event) => updateBlock(index, { explanationPageStart: numberOrUndefined(event.target.value) })} /></label></div><PdfQuestionPreview pdf={selectedPdf} page={block.problemPageStart ?? draft.problemPageStart} cropTopPercent={block.cropTopPercent} cropBottomPercent={block.cropBottomPercent} title="この設問で表示されるPDF範囲" compact /><div className="form-grid three-columns"><label>難易度<select value={blockDifficultyLabel(block.difficulty)} onChange={(event) => updateBlock(index, { difficulty: event.target.value as BlockDifficulty })}><option value="易しい">易しい</option><option value="標準">標準</option><option value="やや難">やや難</option><option value="難しい">難しい</option></select></label><label>補足<input value={block.description ?? ''} onChange={(event) => updateBlock(index, { description: event.target.value })} placeholder="例：商品、収益認識、現金預金" /></label><label>メモ<input value={block.memo ?? ''} onChange={(event) => updateBlock(index, { memo: event.target.value })} placeholder="教材本文は入れない" /></label></div></div>)}
+          <section className="setup-step-card">
+            <h3>2. PDFから問題候補を一括抽出する</h3>
+            <p>「第1問対策」「1-1」「解答・解説」などの見出し・問題ID・論点語から候補を作ります。信頼度が低いものだけ手動確認します。</p>
+            <div className="button-row">
+              <button className="accent" disabled={!selectedPdf || extracting} onClick={() => { void extractCandidates(); }}>{extracting ? '抽出中...' : 'PDFから問題候補を抽出'}</button>
+              <button className="secondary" disabled={!selectedPdf} onClick={addManualCandidate}>手動候補を追加</button>
+            </div>
+            {progress && <p className="notice-small">{progress}</p>}
+          </section>
+
+          <section className="setup-step-card extraction-summary-card">
+            <h3>3. 自動紐づけ結果</h3>
+            <div className="progress-summary-grid extraction-counts">
+              <div><strong>{counts.autoLinked}</strong><span>自動紐づけ済み</span></div>
+              <div><strong>{counts.needsReview}</strong><span>確認が必要</span></div>
+              <div><strong>{counts.unmatched}</strong><span>未分類</span></div>
+              <div><strong>{unmappedCount}</strong><span>未設定問題ID</span></div>
+            </div>
+            <button className="accent" disabled={counts.autoLinked === 0} onClick={() => { void saveAutoLinkedCandidates(); }}>高信頼度候補を一括保存</button>
+          </section>
+        </div>
+      </section>
+
+      {candidates.length > 0 && <section className="panel candidate-review-panel">
+        <div className="section-heading">
+          <div><p className="eyebrow">候補確認</p><h2>確認が必要な問題だけ手動修正する</h2></div>
+          {selectedCandidate && <button className="accent" onClick={() => { void saveCandidate(selectedCandidate); }}>この候補を保存</button>}
+        </div>
+        <div className="candidate-review-layout">
+          <div className="candidate-list">
+            {candidates.map((candidate) => <button key={candidate.id} className={`candidate-list-item ${selectedCandidate?.id === candidate.id ? 'active' : ''}`} onClick={() => { setSelectedCandidateId(candidate.id); setPreviewPage(candidate.sourcePages[0] ?? 1); }}><strong>{candidate.displayId}</strong><span className={`status-pill ${statusClass(candidate.status)}`}>{statusLabel(candidate.status)}</span><span>信頼度 {candidate.confidence}%</span><small>{candidate.topic}</small></button>)}
           </div>
-        </details>
 
-        <div className="button-row sticky-actions"><button className="accent" onClick={() => { void saveMapping(); }}>保存する</button><button className="secondary" onClick={() => { void onOpenProblem(draft.problemId); }}>今すぐ解くで開く</button></div>
-      </div>
+          {selectedCandidate && <div className="candidate-editor">
+            <div className="form-grid three-columns">
+              <label>問題ID<select value={selectedCandidate.suggestedProblemId} onChange={(event) => updateCandidate(selectedCandidate.id, { suggestedProblemId: event.target.value })}>{problemCatalog.map((problem) => <option key={problem.id} value={problem.id}>{problem.displayId} {problem.topic}</option>)}</select></label>
+              <label>状態<select value={selectedCandidate.status} onChange={(event) => updateCandidate(selectedCandidate.id, { status: event.target.value as PdfProblemExtractionCandidate['status'] })}><option value="autoLinked">自動紐づけ済み</option><option value="needsReview">確認が必要</option><option value="unmatched">未分類</option></select></label>
+              <label>信頼度<input type="number" min="0" max="100" value={selectedCandidate.confidence} onChange={(event) => updateCandidate(selectedCandidate.id, { confidence: Number(event.target.value) || 0 })} /></label>
+            </div>
+            <div className="form-grid three-columns">
+              <label>問題ページ<input value={selectedCandidate.sourcePages.join(',')} onChange={(event) => updateCandidate(selectedCandidate.id, { sourcePages: event.target.value.split(',').map((item) => Number(item.trim())).filter(Boolean) })} /></label>
+              <label>解答ページ<input value={selectedCandidate.answerPages.join(',')} onChange={(event) => updateCandidate(selectedCandidate.id, { answerPages: event.target.value.split(',').map((item) => Number(item.trim())).filter(Boolean) })} /></label>
+              <label>解説ページ<input value={selectedCandidate.explanationPages.join(',')} onChange={(event) => updateCandidate(selectedCandidate.id, { explanationPages: event.target.value.split(',').map((item) => Number(item.trim())).filter(Boolean) })} /></label>
+            </div>
+            <label>問題文テキスト<textarea className="large-textarea" value={selectedCandidate.problemText} onChange={(event) => updateCandidate(selectedCandidate.id, { problemText: event.target.value })} /></label>
+            <label>解答テキスト<textarea className="large-textarea" value={selectedCandidate.answerText} onChange={(event) => updateCandidate(selectedCandidate.id, { answerText: event.target.value })} /></label>
+            <label>解説テキスト<textarea className="large-textarea" value={selectedCandidate.explanationText} onChange={(event) => updateCandidate(selectedCandidate.id, { explanationText: event.target.value })} /></label>
+          </div>}
+        </div>
+      </section>}
 
-      <div className="setup-preview-panel"><PdfViewerPanel pdf={selectedPdf} title={selectedPdf ? selectedPdf.title : 'PDF未選択'} label={previewKind === 'answer' ? '解答' : previewKind === 'explanation' ? '解説' : '問題'} page={page} pageStart={1} pageEnd={selectedPdf?.pageCount ?? 1} onPageChange={setPage} large /></div>
-
-      <details className="panel mapping-list-panel" open><summary>保存済み設定 / 設問数</summary><div className="panel-body"><div className="progress-summary-grid"><div><strong>{mappings.length}</strong><span>保存済み紐付け</span></div><div><strong>{mapped.length}</strong><span>設定済み問題ID</span></div><div><strong>{unmapped.length}</strong><span>未設定問題ID</span></div></div><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>問題</th><th>解答</th><th>解説</th><th>設問</th><th>操作</th></tr></thead><tbody>{mappings.map((mapping) => { const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0]; const pdf = pdfs.find((item) => item.id === mapping.materialPdfId); return <tr key={mapping.id}><td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td><td>{mapping.problemPageStart}-{mapping.problemPageEnd}</td><td>{mapping.answerPageStart ? `${mapping.answerPageStart}-${mapping.answerPageEnd ?? mapping.answerPageStart}` : '-'}</td><td>{mapping.explanationPageStart ? `${mapping.explanationPageStart}-${mapping.explanationPageEnd ?? mapping.explanationPageStart}` : '-'}</td><td>{mapping.problemBlocks?.length ?? 1}</td><td><button onClick={() => { setDraft({ ...mapping, problemBlocks: ensureBlocks(mapping) }); setSelectedPdfId(mapping.materialPdfId); void onOpenProblem(mapping.problemId); }}>確認</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td></tr>; })}{mappings.length === 0 && <tr><td colSpan={8}>まだページ紐付けがありません。</td></tr>}</tbody></table></div>{unmapped.length > 0 && <p className="notice-small">未設定問題ID例：{unmapped.slice(0, 16).map((problem) => `${problem.displayId} ${problem.topic}`).join(' / ')}{unmapped.length > 16 ? ' ...' : ''}</p>}</div></details>
-
-      <details className="panel mapping-list-panel"><summary>PDF教材データの削除</summary><div className="panel-body"><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead><tbody>{pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}{pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}</tbody></table></div></div></details>
+      <section className="material-setup-grid compact-material-grid">
+        <div className="setup-preview-panel"><PdfViewerPanel pdf={selectedPdf} title={selectedPdf ? selectedPdf.title : 'PDF未選択'} label="原本確認" page={previewPage} pageStart={1} pageEnd={selectedPdf?.pageCount ?? 1} onPageChange={setPreviewPage} large /></div>
+        <details className="panel mapping-list-panel" open><summary>保存済み設定</summary><div className="panel-body"><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>問題ID</th><th>論点</th><th>PDF</th><th>抽出</th><th>信頼度</th><th>操作</th></tr></thead><tbody>{mappings.map((mapping) => { const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0]; const pdf = pdfs.find((item) => item.id === mapping.materialPdfId); return <tr key={mapping.id}><td>{problem.displayId}</td><td>{problem.topic}</td><td>{pdf?.title ?? 'PDF未登録'}</td><td>{mapping.problemText ? 'テキストあり' : '未抽出'}</td><td>{mapping.extractionConfidence ?? '-'}</td><td><button onClick={() => { void onOpenProblem(mapping.problemId); }}>開く</button> <button className="danger" onClick={() => { void onDeleteMapping(mapping.id); }}>削除</button></td></tr>; })}{mappings.length === 0 && <tr><td colSpan={6}>まだ保存済み設定がありません。</td></tr>}</tbody></table></div></div></details>
+        <details className="panel mapping-list-panel"><summary>PDF教材データの削除</summary><div className="panel-body"><div className="table-wrap short-wrap"><table className="compact-table"><thead><tr><th>教材名</th><th>ファイル</th><th>ページ数</th><th>サイズ</th><th>操作</th></tr></thead><tbody>{pdfs.map((pdf) => <tr key={pdf.id}><td>{pdf.title}</td><td>{pdf.fileName}</td><td>{pdf.pageCount}</td><td>{formatFileSize(pdf.size)}</td><td><button className="danger" onClick={() => { if (window.confirm('このPDF教材データと問題IDへの紐付けを削除します。答案履歴・白紙再現カードは削除されません。本当に削除しますか？')) void onDeletePdf(pdf.id); }}>削除</button></td></tr>)}{pdfs.length === 0 && <tr><td colSpan={5}>PDF教材は未登録です。</td></tr>}</tbody></table></div></div></details>
+      </section>
     </section>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/data/problemCatalog.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/problemCatalog.ts
@@ -1,4 +1,4 @@
-import type { ProblemDefinition, SectionId, Subject, TemplateId } from '../types';
+import type { ProblemDefinition, ProblemKind, SectionId, Subject, TemplateId } from '../types';
 
 type Row = [Subject, SectionId, string, string, string, TemplateId];
 
@@ -26,13 +26,23 @@ const rows: Row[] = [
   ['industrial', 'q5', '第5問対策', '5-3', '全部原価計算と直接原価計算', 'variableFullCosting'],
 ];
 
+function problemKindFromTemplate(templateId: TemplateId): ProblemKind {
+  if (templateId === 'journal') return 'journal';
+  if (templateId === 'genericNumber') return 'numericInput';
+  return 'calculationTable';
+}
+
 export const problemCatalog: ProblemDefinition[] = rows.map(([subject, sectionId, sectionLabel, displayId, topic, defaultTemplateId]) => ({
   id: `${subject}-${displayId}`,
+  qualificationId: 'nissho_boki2',
   subject,
+  subjectId: subject,
   sectionId,
   sectionLabel,
   displayId,
   topic,
+  topicId: displayId,
+  problemKind: problemKindFromTemplate(defaultTemplateId),
   defaultTemplateId,
 }));
 

--- a/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
+++ b/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
@@ -1,0 +1,260 @@
+.focused-practice-panel,
+.focused-grading-panel,
+.material-text-setup {
+  display: grid;
+  gap: 16px;
+}
+
+.focused-question-card {
+  border: 2px solid #b8dfc2;
+}
+
+.focused-question-header,
+.focused-answer-title {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: start;
+}
+
+.focused-main-actions {
+  justify-content: flex-end;
+}
+
+.focused-question-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.focused-question-meta span,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 5px 9px;
+  font-size: 12px;
+  font-weight: 800;
+  background: #eef7f4;
+  border: 1px solid #d3e7e2;
+}
+
+.problem-text-box {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  border: 1px solid #d8e8e4;
+  border-radius: 14px;
+  background: #fbfdfc;
+  padding: 14px;
+}
+
+.problem-text-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.problem-text-toolbar span {
+  color: #53676a;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.problem-text-content {
+  white-space: pre-wrap;
+  line-height: 1.85;
+  font-size: 17px;
+  max-height: 46vh;
+  overflow: auto;
+  padding: 14px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #dfeae6;
+}
+
+.explanation-text-content {
+  max-height: 56vh;
+  font-size: 15px;
+}
+
+.focused-answer-area {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.focused-answer-area .answer-panel {
+  border: 2px solid #d7eadf;
+}
+
+.focused-answer-area .answer-table-wrap {
+  max-height: 68vh;
+}
+
+.focused-practice-panel .col-memo,
+.focused-practice-panel .col-grade,
+.focused-practice-panel .col-points,
+.focused-practice-panel th.col-memo,
+.focused-practice-panel th.col-grade,
+.focused-practice-panel th.col-points,
+.focused-practice-panel td.col-memo,
+.focused-practice-panel td.col-grade,
+.focused-practice-panel td.col-points {
+  display: none;
+}
+
+.focused-practice-panel .journal-table {
+  min-width: 760px;
+}
+
+.grading-text-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(360px, .85fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.grading-control-box {
+  display: grid;
+  gap: 12px;
+  border: 1px solid #d8e8e4;
+  border-radius: 14px;
+  padding: 14px;
+  background: #fff;
+}
+
+.status-button-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.compact-check-list {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.material-setup-main {
+  border: 2px solid #d7eadf;
+}
+
+.setup-step-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(240px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.setup-step-card,
+.extraction-summary-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid #d8e8e4;
+  border-radius: 14px;
+  background: #fbfdfc;
+}
+
+.extraction-counts {
+  grid-template-columns: repeat(4, minmax(110px, 1fr));
+}
+
+.candidate-review-panel {
+  border: 2px solid #d7eadf;
+}
+
+.candidate-review-layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 330px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.candidate-list {
+  display: grid;
+  gap: 8px;
+  max-height: 68vh;
+  overflow: auto;
+}
+
+.candidate-list-item {
+  display: grid;
+  gap: 4px;
+  text-align: left;
+  background: #eef7f4;
+  color: #173f35;
+  border: 1px solid #d8e8e4;
+}
+
+.candidate-list-item.active {
+  outline: 3px solid #0f5c68;
+  background: #fff;
+}
+
+.candidate-list-item small {
+  color: #53676a;
+}
+
+.status-pill.good { background: #e6f6ea; color: #17633b; border-color: #a8d8b3; }
+.status-pill.warn { background: #fff7df; color: #865b00; border-color: #e9c56c; }
+.status-pill.danger { background: #fff0ef; color: #9d2f2f; border-color: #e5aaa6; }
+
+.candidate-editor {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.large-textarea {
+  min-height: 160px;
+  line-height: 1.65;
+}
+
+.compact-material-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (max-width: 1100px) {
+  .focused-question-header,
+  .focused-answer-title,
+  .grading-text-grid,
+  .setup-step-grid,
+  .candidate-review-layout {
+    grid-template-columns: 1fr;
+  }
+  .focused-main-actions {
+    justify-content: stretch;
+  }
+  .focused-main-actions button {
+    flex: 1 1 160px;
+  }
+}
+
+@media (max-width: 760px) {
+  .problem-text-content {
+    font-size: 16px;
+    max-height: none;
+  }
+  .focused-answer-area .answer-table-wrap {
+    max-height: none;
+  }
+  .focused-practice-panel .journal-table,
+  .focused-grading-panel .journal-table {
+    min-width: 720px;
+  }
+  .mode-nav {
+    position: static;
+  }
+  .app-shell {
+    width: min(100vw, 100%);
+    margin: 0 auto 32px;
+  }
+  .app-header,
+  .panel {
+    border-radius: 10px;
+  }
+}

--- a/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
@@ -6,6 +6,16 @@ const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'exa
 
 type StoreName = (typeof STORES)[number];
 
+function stripExtractedTextFromMapping(mapping: MaterialPdfMapping): MaterialPdfMapping {
+  return {
+    ...mapping,
+    problemText: '',
+    answerText: '',
+    explanationText: '',
+    problemBlocks: mapping.problemBlocks?.map((block) => ({ ...block, questionText: '' })),
+  };
+}
+
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
@@ -190,10 +200,11 @@ export async function recordRestoreMade(): Promise<BackupMetadata> {
 
 export async function exportAllData(): Promise<BackupPayload> {
   const materialPdfs = await getMaterialPdfs();
+  const mappings = await getMaterialPdfMappings();
   return {
     exportedAt: new Date().toISOString(),
     appName: 'CPA日商簿記2級 試験対策編 解答・復習管理アプリ',
-    version: '1.3.0',
+    version: '1.4.0',
     answers: await getAllAnswers(),
     histories: await getHistories(),
     settings: await tx<Record<string, unknown>[]>('settings', 'readonly', (store) => store.getAll()),
@@ -201,7 +212,7 @@ export async function exportAllData(): Promise<BackupPayload> {
     backups: await tx<Record<string, unknown>[]>('backups', 'readonly', (store) => store.getAll()),
     examSets: await getExamSets(),
     mistakeCards: await getMistakeCards(),
-    materialPdfMappings: await getMaterialPdfMappings(),
+    materialPdfMappings: mappings.map(stripExtractedTextFromMapping),
     materialPdfMetadata: materialPdfs.map(({ pdfBlob: _pdfBlob, ...metadata }) => metadata),
     practiceSessions: await getPracticeSessions(),
     reviewStates: await getReviewStates(),

--- a/cpa-boki2-trial-section-answer-manager/src/styles.css
+++ b/cpa-boki2-trial-section-answer-manager/src/styles.css
@@ -1,3 +1,5 @@
+@import './focusedPractice.css';
+
 :root {
   color-scheme: light;
   font-family: 'Yu Gothic', 'Meiryo', system-ui, sans-serif;

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -1,5 +1,7 @@
+export type QualificationId = 'nissho_boki2';
 export type Subject = 'commercial' | 'industrial';
 export type SectionId = 'q1' | 'q2' | 'q3' | 'q4' | 'q5';
+export type ProblemKind = 'journal' | 'calculationTable' | 'fillBlank' | 'numericInput' | 'multipleChoice' | 'shortAnswer' | 'essay' | 'oral';
 export type TemplateId = 'journal' | 'genericNumber' | 'equityStatement' | 'consolidation' | 'ledger' | 'financialStatements' | 'processCosting' | 'departmentCosting' | 'standardCosting' | 'cvp' | 'variableFullCosting' | 'freeTable';
 export type GradeMark = '未採点' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
@@ -7,14 +9,19 @@ export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方�
 export type TimeMode = '1分' | '3分' | '5分' | '10分' | '30分' | '90分';
 export type GradingStatus = '正解' | '部分正解' | '不正解' | '迷いあり';
 export type BlockDifficulty = '易しい' | '標準' | 'やや難' | '難しい';
+export type ExtractionStatus = 'autoLinked' | 'needsReview' | 'unmatched';
 
 export interface ProblemDefinition {
   id: string;
+  qualificationId?: QualificationId;
   subject: Subject;
+  subjectId?: string;
   sectionId: SectionId;
   sectionLabel: string;
+  topicId?: string;
   displayId: string;
   topic: string;
+  problemKind?: ProblemKind;
   defaultTemplateId: TemplateId;
 }
 
@@ -28,6 +35,7 @@ export interface TemplateExampleGuide {
 
 export interface TemplateDefinition {
   id: TemplateId;
+  answerTemplateKind?: ProblemKind;
   name: string;
   initialRows: number;
   columns: string[];
@@ -46,6 +54,8 @@ export interface ProblemBlock {
   id: string;
   title: string;
   description?: string;
+  questionText?: string;
+  sourcePages?: number[];
   problemPageStart?: number;
   problemPageEnd?: number;
   cropTopPercent?: number;
@@ -65,6 +75,8 @@ export interface AnswerBlockState {
   id: string;
   title: string;
   description?: string;
+  questionText?: string;
+  sourcePages?: number[];
   problemPageStart?: number;
   problemPageEnd?: number;
   cropTopPercent?: number;
@@ -286,11 +298,53 @@ export interface MaterialPdf {
 
 export type MaterialPdfMetadata = Omit<MaterialPdf, 'pdfBlob'>;
 
+export interface ExtractedPdfPage {
+  page: number;
+  text: string;
+  normalizedText: string;
+  extractedAt: string;
+}
+
+export interface PdfProblemExtractionCandidate {
+  id: string;
+  materialPdfId: string;
+  suggestedProblemId: string;
+  displayId: string;
+  subject: Subject;
+  sectionId: SectionId;
+  sectionLabel: string;
+  topic: string;
+  templateId: TemplateId;
+  problemKind: ProblemKind;
+  problemText: string;
+  answerText: string;
+  explanationText: string;
+  sourcePages: number[];
+  answerPages: number[];
+  explanationPages: number[];
+  confidence: number;
+  status: ExtractionStatus;
+  reason: string;
+}
+
 export interface MaterialPdfMapping {
   id: string;
+  qualificationId?: QualificationId;
   problemId: string;
   displayId: string;
   materialPdfId: string;
+  subjectId?: string;
+  topicId?: string;
+  problemKind?: ProblemKind;
+  problemText?: string;
+  answerText?: string;
+  explanationText?: string;
+  sourcePages?: number[];
+  answerPages?: number[];
+  explanationPages?: number[];
+  extractionConfidence?: number;
+  extractionStatus?: ExtractionStatus;
+  extractedAt?: string;
   problemPageStart: number;
   problemPageEnd: number;
   answerPageStart?: number;

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfAutoLink.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfAutoLink.ts
@@ -1,5 +1,6 @@
-import type { MaterialPdf } from '../types';
-import { extractPdfPageText } from './pdfRenderer';
+import { problemCatalog } from '../data/problemCatalog';
+import type { ExtractedPdfPage, MaterialPdf, PdfProblemExtractionCandidate, ProblemDefinition, SectionId, Subject, TemplateId } from '../types';
+import { extractAllPdfPageTexts, extractPdfPageText } from './pdfRenderer';
 
 export interface PdfAutoLinkCandidate {
   page: number;
@@ -8,6 +9,110 @@ export interface PdfAutoLinkCandidate {
 }
 
 const KEYWORDS = ['第1問対策', '第2問対策', '第3問対策', '第4問対策', '第5問対策', '問題', '解答', '解説', '仕訳', '連結', 'CVP', '標準原価', '直接原価計算', '工業簿記', '商業簿記'];
+
+const SECTION_PATTERNS: Record<SectionId, RegExp[]> = {
+  q1: [/第\s*1\s*問/, /1\s*-\s*\d+/],
+  q2: [/第\s*2\s*問/, /2\s*-\s*\d+/],
+  q3: [/第\s*3\s*問/, /3\s*-\s*\d+/],
+  q4: [/第\s*4\s*問/, /4\s*-\s*\d+/],
+  q5: [/第\s*5\s*問/, /5\s*-\s*\d+/],
+};
+
+function compact(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsProblemId(text: string, displayId: string): boolean {
+  const escaped = escapeRegExp(displayId).replace('\\-', '\\s*-\\s*');
+  return new RegExp(`(^|[^0-9])${escaped}([^0-9]|$)`).test(text);
+}
+
+function subjectFromText(text: string): Subject | '' {
+  if (/工業簿記|原価計算|標準原価|CVP|直接原価|部門別|工程別/.test(text)) return 'industrial';
+  if (/商業簿記|連結|株主資本|有価証券|本支店|決算/.test(text)) return 'commercial';
+  return '';
+}
+
+function scorePageForProblem(page: ExtractedPdfPage, problem: ProblemDefinition): number {
+  const text = page.text;
+  let score = 0;
+  if (containsProblemId(text, problem.displayId)) score += 55;
+  if (text.includes(problem.sectionLabel)) score += 18;
+  if (problem.topic.split(/[、・\s]+/).filter(Boolean).some((word) => text.includes(word))) score += 12;
+  if (SECTION_PATTERNS[problem.sectionId].some((pattern) => pattern.test(text))) score += 10;
+  const subject = subjectFromText(text);
+  if (subject && subject === problem.subject) score += 5;
+  if (/解答|解説|解答・解説/.test(text) && !/問題|問\d|資料|次の/.test(text)) score -= 25;
+  return score;
+}
+
+function buildAnswerText(pages: ExtractedPdfPage[], startPage: number): { answerText: string; answerPages: number[]; explanationText: string; explanationPages: number[] } {
+  const nearby = pages.filter((page) => page.page > startPage && page.page <= startPage + 8);
+  const answerPages = nearby.filter((page) => /解答|答案|正解/.test(page.text)).slice(0, 3);
+  const explanationPages = nearby.filter((page) => /解説|ポイント|考え方|仕訳/.test(page.text)).slice(0, 3);
+  return {
+    answerText: compact(answerPages.map((page) => `P${page.page} ${page.text}`).join('\n\n')).slice(0, 12000),
+    answerPages: answerPages.map((page) => page.page),
+    explanationText: compact(explanationPages.map((page) => `P${page.page} ${page.text}`).join('\n\n')).slice(0, 12000),
+    explanationPages: explanationPages.map((page) => page.page),
+  };
+}
+
+function confidenceToStatus(confidence: number): PdfProblemExtractionCandidate['status'] {
+  if (confidence >= 75) return 'autoLinked';
+  if (confidence >= 35) return 'needsReview';
+  return 'unmatched';
+}
+
+function templateKind(templateId: TemplateId): PdfProblemExtractionCandidate['problemKind'] {
+  if (templateId === 'journal') return 'journal';
+  if (templateId === 'genericNumber') return 'numericInput';
+  return 'calculationTable';
+}
+
+export async function extractProblemCandidatesFromPdf(pdf: MaterialPdf, onProgress?: (page: number, pageCount: number) => void): Promise<PdfProblemExtractionCandidate[]> {
+  const pages = await extractAllPdfPageTexts(pdf.pdfBlob, onProgress);
+  const usedPages = new Set<number>();
+  return problemCatalog.map((problem) => {
+    const ranked = pages
+      .filter((page) => page.text.trim().length > 20)
+      .map((page) => ({ page, score: scorePageForProblem(page, problem) }))
+      .sort((a, b) => b.score - a.score);
+    const best = ranked[0];
+    const fallback = pages.find((page) => !usedPages.has(page.page) && page.text.trim().length > 60) ?? pages[0];
+    const page = best && best.score > 0 ? best.page : fallback;
+    const confidence = Math.max(0, Math.min(100, best?.score ?? 0));
+    if (page) usedPages.add(page.page);
+    const answer = page ? buildAnswerText(pages, page.page) : { answerText: '', answerPages: [], explanationText: '', explanationPages: [] };
+    const problemText = page ? compact(page.text).slice(0, 16000) : '';
+    const status = confidenceToStatus(confidence);
+    return {
+      id: crypto.randomUUID(),
+      materialPdfId: pdf.id,
+      suggestedProblemId: problem.id,
+      displayId: problem.displayId,
+      subject: problem.subject,
+      sectionId: problem.sectionId,
+      sectionLabel: problem.sectionLabel,
+      topic: problem.topic,
+      templateId: problem.defaultTemplateId,
+      problemKind: templateKind(problem.defaultTemplateId),
+      problemText,
+      answerText: answer.answerText,
+      explanationText: answer.explanationText,
+      sourcePages: page ? [page.page] : [],
+      answerPages: answer.answerPages,
+      explanationPages: answer.explanationPages,
+      confidence,
+      status,
+      reason: status === 'autoLinked' ? '問題ID・見出し・論点語の一致度が高い候補です。' : status === 'needsReview' ? '候補はありますが、手動確認を推奨します。' : '自動紐づけできませんでした。手動確認してください。',
+    };
+  });
+}
 
 export async function suggestPdfLinkCandidates(pdf: MaterialPdf, maxPages = 80): Promise<PdfAutoLinkCandidate[]> {
   const limit = Math.min(pdf.pageCount, maxPages);

--- a/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/pdfRenderer.ts
@@ -1,7 +1,12 @@
 import * as pdfjsLib from 'pdfjs-dist';
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
+import type { ExtractedPdfPage } from '../types';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+function normalizePdfText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
 
 export async function getPdfPageCount(blob: Blob): Promise<number> {
   const data = new Uint8Array(await blob.arrayBuffer());
@@ -33,7 +38,23 @@ export async function extractPdfPageText(blob: Blob, pageNumber: number): Promis
   const safePage = Math.max(1, Math.min(pageNumber, pdf.numPages));
   const page = await pdf.getPage(safePage);
   const textContent = await page.getTextContent();
-  return textContent.items.map((item) => ('str' in item ? item.str : '')).join(' ');
+  return normalizePdfText(textContent.items.map((item) => ('str' in item ? item.str : '')).join(' '));
+}
+
+export async function extractAllPdfPageTexts(blob: Blob, onProgress?: (page: number, pageCount: number) => void): Promise<ExtractedPdfPage[]> {
+  const data = new Uint8Array(await blob.arrayBuffer());
+  const task = pdfjsLib.getDocument({ data });
+  const pdf = await task.promise;
+  const extractedAt = new Date().toISOString();
+  const pages: ExtractedPdfPage[] = [];
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+    const page = await pdf.getPage(pageNumber);
+    const textContent = await page.getTextContent();
+    const text = normalizePdfText(textContent.items.map((item) => ('str' in item ? item.str : '')).join(' '));
+    pages.push({ page: pageNumber, text, normalizedText: text.toLowerCase(), extractedAt });
+    onProgress?.(pageNumber, pdf.numPages);
+  }
+  return pages;
 }
 
 export function formatFileSize(size: number): string {


### PR DESCRIPTION
## 1. 修正目的

今回の目的は機能追加ではなく、現在のCPA日商簿記2級 試験対策編 解答・復習管理アプリを、毎日使える実用的な学習UIへ整理することです。

PR #238/#239 まででPDF表示・問題文ブロック・教材設定・復習管理が増えた一方、通常演習時に画面が複雑化していたため、通常演習画面を「問題文を読む → 答案入力 → 採点 → 次回復習日へ回す → 次の問題へ進む」の最短導線へ戻します。

## 2. 今回の最重要方針

大規模な共通基盤化はしていません。

以下は作っていません。

- StudyCore / ExamPack の大規模ディレクトリ再編
- 建設業経理士2級モード
- 弁理士モード
- 他資格選択画面
- AI解説
- OCR
- 自動採点
- ログイン
- Supabase同期
- クラウド保存
- 教材本文のコード埋め込み
- PDF全文のGitHub保存
- 新資格用の問題データ投入

画面上の実運用対象は、引き続き日商簿記2級のみです。

## 3. 通常演習画面を1問集中UIへ整理

`今すぐ解く` 画面を、スマホ学習アプリに近い1問集中UIへ変更しました。

通常演習画面に表示するものを以下に絞っています。

- 現在の問題ID
- 科目
- 論点名
- 想定時間
- 難易度
- PDFから抽出した問題文テキスト
- 答案入力欄
- 一時保存ボタン
- 採点へ進むボタン
- 次の問題へボタン

通常演習画面から退避したもの:

- 履歴一覧
- CSV出力
- JSONバックアップ
- PDF管理
- PDF取込
- 合格到達マップ詳細
- 白紙再現カード一覧
- 70点リカバリー表
- 大量の管理ボタン

## 4. PDF画像表示中心ではなく、抽出テキスト中心に変更

通常演習画面では、PDF画像の切り取り表示を主役にしていません。

主表示は、ユーザー本人が端末上で選択したPDFから抽出した問題文テキストです。

PDF原本は `原本を見る` ボタンで必要な時だけ開ける補助機能にしました。

## 5. PDFから問題候補を一括抽出し、自動紐づけ候補を出すように変更

`教材を設定する` 画面を、1問ずつPDF範囲を手動保存する方式から、PDF全体を読み込んで問題候補を一括抽出する方式へ変更しました。

処理の流れ:

1. PDFを選択する
2. PDF全体からページごとのテキストを抽出する
3. 「第1問対策」「1-1」「解答・解説」などの見出し・問題ID・論点語を検出する
4. 問題IDへの自動紐づけ候補を作る
5. 信頼度を表示する
6. 高信頼度候補を一括保存する
7. 確認が必要な候補だけ手動修正する

表示する集計:

- 自動紐づけ済み
- 確認が必要
- 未分類
- 未設定問題ID

手動修正は、自動紐づけできない問題・信頼度が低い候補に限定しています。

## 6. 答案入力テーブルを主役に戻したこと

`FocusedPracticePanel` を追加し、通常演習時は問題文テキストと答案入力欄を主役にしました。

通常演習中は、答案入力を圧迫しやすい以下を初期表示から外しています。

- メモ列
- 採点列
- 行別得点列

採点時には `FocusedGradingPanel` 側で、自分の回答・解答解説テキスト・自己採点欄を表示します。

## 7. 採点画面の整理

`採点する` 画面では、以下だけを中心に表示します。

- 自分の回答
- 端末内に抽出した解答・解説テキスト
- 得点
- 満点
- 正解 / 部分正解 / 不正解 / 迷いあり
- A/B/C判定
- ミス原因
- 復習メモ
- 次回復習日
- 保存して次へ進むボタン

自動採点はしていません。あくまで自己採点です。

## 8. 復習・進捗画面へ管理機能を集約

管理系機能は `復習・進捗を見る` に集約しました。

この画面で確認できるもの:

- 今日やる問題数
- 期限超過問題数
- C判定問題数
- 未着手問題数
- 直近7日演習数
- 直近30日演習数
- 合格到達マップ
- 白紙再現カード
- 70点リカバリー表
- 履歴一覧
- CSV出力
- JSONバックアップ

## 9. 将来の他資格転用を妨げないデータ構造

今回、他資格モードは実装していません。

ただし、将来の建設業経理士2級・弁理士などへの転用を邪魔しないよう、型とデータ項目だけ以下の方向へ寄せています。

- `qualificationId`
- `subjectId`
- `topicId`
- `problemKind`
- `answerTemplateKind`
- `ExtractionStatus`
- `PdfProblemExtractionCandidate`
- `ExtractedPdfPage`

画面上には日商簿記2級以外を出していません。

## 10. 著作権・保存方針

以下は行っていません。

- 教材PDFをGitHubへ保存
- 教材PDFをpublicへ配置
- 教材PDFをsrcへ配置
- 教材本文をソースコードへ埋め込み
- PDFや抽出テキストを外部サーバーへ送信
- PDFや抽出テキストをSupabaseへ保存
- 共有URLから第三者が教材本文を見られる状態にする
- DRMや技術的保護手段を回避する処理

保存方針:

- PDF Blobはユーザー端末内IndexedDBに保存
- PDFから抽出した問題文・解答・解説テキストも端末内IndexedDBに保存
- GitHub Pages上のアプリ本体には教材本文を含めない
- GitHubコミットには教材本文を含めない
- JSONバックアップにもPDF本体・抽出教材本文は含めない

## 11. 既存機能の維持

以下は維持しています。

- 金額3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリックでセル内編集
- Escで編集解除
- 履歴保存
- 履歴復元
- JSONバックアップ
- 今日の学習キュー
- 90分セット演習
- 合格到達マップ
- 白紙再現カード
- 70点リカバリー表
- 復習スケジューラー
- 問題ブロック別答案のデータ構造

## 12. 既存案件管理アプリへの影響

変更対象は `cpa-boki2-trial-section-answer-manager/` 配下です。

既存案件管理アプリ本体、トップURL、既存Pages workflowは変更していません。

## 13. 変更ファイル

- `src/App.tsx`
- `src/components/FocusedPracticePanel.tsx`
- `src/components/FocusedGradingPanel.tsx`
- `src/components/MaterialSetupWorkspace.tsx`
- `src/data/problemCatalog.ts`
- `src/focusedPractice.css`
- `src/storage/indexedDb.ts`
- `src/styles.css`
- `src/types/index.ts`
- `src/utils/pdfAutoLink.ts`
- `src/utils/pdfRenderer.ts`

## 14. 動作確認結果

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 15. 実URLで確認すべき項目

- サブURLで簿記2級アプリが開く
- 初期表示が「今すぐ解く」になっている
- 通常演習画面で問題文テキストが大きく表示される
- PDF画像が通常演習画面の主役になっていない
- 答案入力欄が小さくなりすぎていない
- スマホで、問題文 → 入力欄 → 採点ボタンの流れで使える
- PCで、答案入力テーブルが広く使える
- 教材設定画面でPDF取込と問題候補抽出ができる
- 問題IDへの自動紐づけ候補が表示される
- 自動紐づけできない問題だけ手動修正できる
- 採点画面で得点・判定・ミス原因・次回復習日を保存できる
- 復習・進捗画面で管理機能を確認できる
- 既存の履歴保存、履歴復元、JSONバックアップが壊れていない
- 建設業経理士2級・弁理士の画面は表示されていない
- 既存案件管理アプリ本体に影響がない
- `npm install` が成功する
- `npm run build` が成功する
- GitHub Actions の簿記2級チェックが成功する
- GitHub Pages build が成功する
- consoleに致命的なエラーが出ない