### PR TITLE
Rebuild study app into usable question-card learning flow

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -32,6 +32,7 @@ import {
   getMaterialPdfs,
   getMistakeCards,
   getPracticeSessions,
+  getQuestionCards,
   getReviewStates,
   importAllData,
   recordBackupMade,
@@ -41,13 +42,15 @@ import {
   saveMaterialPdfMapping,
   saveMistakeCard,
   savePracticeSession,
+  saveQuestionCard,
   saveReviewState,
 } from './storage/indexedDb';
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, GradingStatus, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, ReviewState, StorageSafetyInfo, TemplateId, TimeMode } from './types';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, GradingStatus, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, QuestionCard, ReviewState, StorageSafetyInfo, TemplateId, TimeMode } from './types';
 import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, examSetCsvRows, historyCsvRows, masteryMapCsvRows, missReasonCsvRows, mistakeCardCsvRows, problemStatsCsvRows, recoveryPlanCsvRows, reviewTargetCsvRows, studyQueueCsvRows } from './utils/csv';
 import { chooseQuickStartProblem } from './utils/disposableStudy';
 import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
 import { buildMasteryMap } from './utils/mastery';
+import { fallbackQuestionCard, questionCardFromMapping } from './utils/questionCards';
 import { buildRecoveryPlan } from './utils/recovery';
 import { rankFromSelfGrading, updateReviewStateFromGrading } from './utils/reviewScheduler';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
@@ -144,6 +147,7 @@ export default function App() {
   const [mistakeCards, setMistakeCards] = useState<MistakeCard[]>([]);
   const [materialPdfs, setMaterialPdfs] = useState<MaterialPdf[]>([]);
   const [pdfMappings, setPdfMappings] = useState<MaterialPdfMapping[]>([]);
+  const [questionCards, setQuestionCards] = useState<QuestionCard[]>([]);
   const [practiceSessions, setPracticeSessions] = useState<PracticeSession[]>([]);
   const [reviewStates, setReviewStates] = useState<ReviewState[]>([]);
   const [activeSessionId, setActiveSessionId] = useState('');
@@ -156,13 +160,15 @@ export default function App() {
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
   const currentMapping = useMemo(() => pdfMappings.find((item) => item.problemId === problemId), [pdfMappings, problemId]);
-  const currentPdf = useMemo(() => materialPdfs.find((item) => item.id === currentMapping?.materialPdfId), [materialPdfs, currentMapping?.materialPdfId]);
+  const currentQuestionCard = useMemo(() => questionCards.find((card) => card.sourceProblemId === problemId || card.id === problemId) ?? (currentMapping ? questionCardFromMapping(currentMapping) : fallbackQuestionCard(problem)), [questionCards, currentMapping, problem, problemId]);
+  const currentPdf = useMemo(() => materialPdfs.find((item) => item.id === currentQuestionCard.sourceMaterialId || item.id === currentMapping?.materialPdfId), [materialPdfs, currentQuestionCard.sourceMaterialId, currentMapping?.materialPdfId]);
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
   const activeSession = useMemo(() => practiceSessions.find((session) => session.id === activeSessionId) ?? null, [practiceSessions, activeSessionId]);
   const currentReviewState = useMemo(() => reviewStates.find((state) => state.problemId === problemId), [reviewStates, problemId]);
   const quickChoice = useMemo(() => chooseQuickStartProblem({ sessions: practiceSessions, studyQueue, masteryMap }), [practiceSessions, studyQueue, masteryMap]);
+  const progressIndex = useMemo(() => Math.max(1, studyQueue.findIndex((item) => item.problem.id === problemId) + 1 || 1), [studyQueue, problemId]);
   const progressSummary = useMemo(() => ({
     dueToday: studyQueue.filter((item) => item.statusLabels.includes('今日復習')).length,
     overdue: studyQueue.filter((item) => item.statusLabels.includes('期限超過')).length,
@@ -178,6 +184,7 @@ export default function App() {
   async function loadMistakeCards() { setMistakeCards(await getMistakeCards()); }
   async function loadMaterialPdfs() { setMaterialPdfs(await getMaterialPdfs()); }
   async function loadPdfMappings() { setPdfMappings(await getMaterialPdfMappings()); }
+  async function loadQuestionCards() { setQuestionCards(await getQuestionCards()); }
   async function loadPracticeSessions() { setPracticeSessions(await getPracticeSessions()); }
   async function loadReviewStates() { setReviewStates(await getReviewStates()); }
 
@@ -188,7 +195,7 @@ export default function App() {
   }
 
   async function refreshAll() {
-    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), loadMistakeCards(), loadMaterialPdfs(), loadPdfMappings(), loadPracticeSessions(), loadReviewStates(), refreshSafety()]);
+    await Promise.all([refreshAnswers(), loadHistories(), loadExamSets(), loadMistakeCards(), loadMaterialPdfs(), loadPdfMappings(), loadQuestionCards(), loadPracticeSessions(), loadReviewStates(), refreshSafety()]);
   }
 
   async function loadProblem(nextProblemId: string) {
@@ -280,9 +287,9 @@ export default function App() {
   const saveCard = async (card: MistakeCard) => { await saveMistakeCard(card); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを保存しました'); };
   const removeCard = async (id: string) => { if (!window.confirm('この解き直しカードを削除しますか？')) return; await deleteMistakeCard(id); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを削除しました'); };
   const savePdf = async (pdf: MaterialPdf) => { await saveMaterialPdf(pdf); await loadMaterialPdfs(); };
-  const removePdf = async (id: string) => { await deleteMaterialPdf(id); await Promise.all([loadMaterialPdfs(), loadPdfMappings()]); setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。'); };
-  const savePdfMapping = async (mapping: MaterialPdfMapping) => { await saveMaterialPdfMapping(mapping); await loadPdfMappings(); setMessage('PDF抽出テキスト紐づけを保存しました'); };
-  const removePdfMapping = async (id: string) => { if (!window.confirm('このPDF抽出テキスト紐づけを削除しますか？PDF教材データと答案履歴は削除されません。')) return; await deleteMaterialPdfMapping(id); await loadPdfMappings(); setMessage('PDF抽出テキスト紐づけを削除しました'); };
+  const removePdf = async (id: string) => { await deleteMaterialPdf(id); await Promise.all([loadMaterialPdfs(), loadPdfMappings(), loadQuestionCards()]); setMessage('PDF教材データと紐付けを削除しました。答案履歴・白紙再現カードは保持されています。'); };
+  const savePdfMapping = async (mapping: MaterialPdfMapping) => { await saveMaterialPdfMapping(mapping); await saveQuestionCard(questionCardFromMapping(mapping)); await Promise.all([loadPdfMappings(), loadQuestionCards()]); setMessage('問題カードを保存しました'); };
+  const removePdfMapping = async (id: string) => { if (!window.confirm('このPDF抽出テキスト紐づけを削除しますか？PDF教材データと答案履歴は削除されません。')) return; await deleteMaterialPdfMapping(id); await Promise.all([loadPdfMappings(), loadQuestionCards()]); setMessage('PDF抽出テキスト紐づけを削除しました'); };
 
   const exportCurrentCsv = () => downloadCsv('current-answer.csv', currentAnswerCsvRows(answer, problem));
   const exportHistoryCsv = () => downloadCsv('history.csv', historyCsvRows(histories));
@@ -304,19 +311,19 @@ export default function App() {
   return (
     <main className="app-shell redesigned-shell">
       <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>問題文を読む → 答案入力 → 採点 → 次回復習日へ回す、を最短で回すための学習画面です。</p></div><Timer /></header>
-      <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習・進捗を見る</button></nav>
+      <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習を見る</button></nav>
       <div className="status-bar">{message}</div>
 
       {mode === 'study' && <section className="mode-section study-mode-section">
-        {!currentMapping?.problemText && <section className="panel first-use-steps"><h2>最初にやること</h2><div><span>1. 教材を設定する</span><span>2. PDFから問題候補を抽出する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
-        <FocusedPracticePanel problem={problem} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} onChange={updateAnswer} onSave={manualSave} onGoGrading={() => setMode('grading')} onNextProblem={openNextProblem} onApplyRowPoints={applyRowPoints} />
+        {currentQuestionCard.needsReview && <section className="panel first-use-steps"><h2>問題カードの確認が必要です</h2><div><span>1. 教材を設定する</span><span>2. 抽出結果を整形する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
+        <FocusedPracticePanel problem={problem} questionCard={currentQuestionCard} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} totalToday={Math.max(1, studyQueue.length || 1)} progressIndex={progressIndex} onChange={updateAnswer} onSave={manualSave} onGoGrading={() => setMode('grading')} onNextProblem={openNextProblem} onApplyRowPoints={applyRowPoints} />
       </section>}
 
       {mode === 'grading' && <FocusedGradingPanel problem={problem} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} onChange={updateAnswer} onSave={manualSave} onApplyRowPoints={applyRowPoints} onSubmitSelfGrading={submitSelfGrading} onBackPractice={() => setMode('study')} />}
 
       {mode === 'materials' && <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />}
 
-      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習・進捗を見る</p><h2>管理機能はここに集約</h2><p>通常演習画面には出さず、必要な時だけここで確認します。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やる問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div><div><strong>{progressSummary.last7Days}</strong><span>直近7日演習</span></div><div><strong>{progressSummary.last30Days}</strong><span>直近30日演習</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次にやる問題へ</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
+      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習を見る</p><h2>今日やる問題だけ先に見る</h2><p>詳細な管理機能は下の折りたたみの中に退避しています。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やる問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div><div><strong>{progressSummary.last7Days}</strong><span>直近7日演習</span></div><div><strong>{progressSummary.last30Days}</strong><span>直近30日演習</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次に解く</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
     </main>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
@@ -1,14 +1,18 @@
 import { useMemo, useState } from 'react';
-import type { AnswerState, MaterialPdf, MaterialPdfMapping, ProblemDefinition, TemplateDefinition } from '../types';
+import type { AnswerState, MaterialPdf, MaterialPdfMapping, ProblemDefinition, QuestionCard, TemplateDefinition } from '../types';
 import { AnswerTable } from './AnswerTable';
+import { JournalEntryCardInput } from './JournalEntryCardInput';
 import { PdfViewerPanel } from './PdfViewerPanel';
 
 interface Props {
   problem: ProblemDefinition;
+  questionCard: QuestionCard;
   answer: AnswerState;
   template: TemplateDefinition;
   mapping?: MaterialPdfMapping;
   pdf?: MaterialPdf;
+  totalToday: number;
+  progressIndex: number;
   onChange: (answer: AnswerState) => void;
   onSave: () => void;
   onGoGrading: () => void;
@@ -16,72 +20,86 @@ interface Props {
   onApplyRowPoints: () => void;
 }
 
-function fallbackQuestion(problem: ProblemDefinition): string {
-  return '教材を設定すると、PDFから抽出した問題文テキストがここに表示されます。未設定の場合は、購入済みPDFや紙教材を見ながら下の答案欄へ入力してください。';
-}
-
-function joinBlockText(mapping?: MaterialPdfMapping): string {
-  const fromBlocks = mapping?.problemBlocks?.map((block) => block.questionText).filter(Boolean).join('\n\n');
-  return fromBlocks || mapping?.problemText || '';
-}
-
-function pageLabel(pages?: number[]): string {
+function pageLabel(card: QuestionCard, mapping?: MaterialPdfMapping): string {
+  if (card.sourcePageStart && card.sourcePageEnd) return card.sourcePageStart === card.sourcePageEnd ? String(card.sourcePageStart) : `${card.sourcePageStart}-${card.sourcePageEnd}`;
+  const pages = mapping?.sourcePages;
   if (!pages || pages.length === 0) return '未設定';
   return Array.from(new Set(pages)).sort((a, b) => a - b).join(', ');
 }
 
-export function FocusedPracticePanel({ problem, answer, template, mapping, pdf, onChange, onSave, onGoGrading, onNextProblem, onApplyRowPoints }: Props) {
+function hasBlankRequiredJournalCells(answer: AnswerState): boolean {
+  if (answer.templateId !== 'journal') return answer.rows.every((row) => row.cells.every((cell, index) => index === 0 || cell.trim() === ''));
+  const importantIndexes = answer.columns.map((column, index) => ({ column, index })).filter(({ column }) => column.includes('借方科目') || column.includes('借方金額') || column.includes('貸方科目') || column.includes('貸方金額')).map(({ index }) => index);
+  return answer.rows.some((row) => importantIndexes.some((index) => (row.cells[index] ?? '').trim() === ''));
+}
+
+export function FocusedPracticePanel({ problem, questionCard, answer, template, mapping, pdf, totalToday, progressIndex, onChange, onSave, onGoGrading, onNextProblem, onApplyRowPoints }: Props) {
   const [showOriginal, setShowOriginal] = useState(false);
-  const [page, setPage] = useState(mapping?.problemPageStart ?? mapping?.sourcePages?.[0] ?? 1);
-  const questionText = useMemo(() => joinBlockText(mapping) || fallbackQuestion(problem), [mapping, problem]);
-  const subjectLabel = problem.subject === 'commercial' ? '商業簿記' : '工業簿記';
-  const textReady = Boolean(joinBlockText(mapping));
+  const [page, setPage] = useState(questionCard.sourcePageStart || mapping?.problemPageStart || mapping?.sourcePages?.[0] || 1);
+  const textReady = questionCard.questionText && !questionCard.questionText.includes('問題文未登録');
+  const bottomLabel = useMemo(() => hasBlankRequiredJournalCells(answer) ? '未入力があります。採点しますか？' : '採点する', [answer]);
+  const pageStart = questionCard.sourcePageStart || mapping?.problemPageStart || 1;
+  const pageEnd = questionCard.sourcePageEnd || mapping?.problemPageEnd || pdf?.pageCount || 1;
 
   return (
-    <section className="focused-practice-panel">
-      <section className="panel focused-question-card">
+    <section className="question-card-learning-flow">
+      <div className="learning-top-bar">
+        <button className="secondary" onClick={onNextProblem}>戻る</button>
+        <div>
+          <p className="eyebrow">今すぐ解く</p>
+          <strong>{questionCard.topic}</strong>
+        </div>
+        <span>{Math.max(1, progressIndex)} / {Math.max(1, totalToday)}</span>
+      </div>
+
+      <section className="panel focused-question-card question-card-main">
         <div className="focused-question-header">
           <div>
-            <p className="eyebrow">今すぐ解く</p>
-            <h2>{problem.displayId}：{problem.topic}</h2>
-            <div className="focused-question-meta">
-              <span>{subjectLabel}</span>
-              <span>{problem.sectionLabel}</span>
-              <span>想定時間：{mapping?.estimatedMinutes ?? '未設定'}</span>
-              <span>難易度：{mapping?.difficulty ?? '未設定'}</span>
-              {mapping?.extractionConfidence !== undefined && <span>抽出信頼度：{mapping.extractionConfidence}%</span>}
+            <p className="question-label">問題</p>
+            <h2>{questionCard.title || `${problem.displayId}：${problem.topic}`}</h2>
+            <div className="focused-question-meta subtle-meta">
+              <span>{questionCard.subject}</span>
+              <span>{questionCard.section}</span>
+              <span>想定{questionCard.estimatedMinutes}分</span>
+              <span>難易度：{questionCard.difficulty}</span>
+              <span>信頼度：{questionCard.extractionConfidence}%</span>
+              {questionCard.needsReview && <span className="needs-review-pill">要確認</span>}
             </div>
           </div>
-          <div className="button-row focused-main-actions">
+          <div className="button-row focused-main-actions desktop-only-actions">
             <button onClick={onSave}>一時保存</button>
             <button className="accent" onClick={onGoGrading}>採点へ進む</button>
             <button className="secondary" onClick={onNextProblem}>次の問題へ</button>
           </div>
         </div>
 
-        <div className="problem-text-box">
+        <div className="problem-text-box app-like-problem-box">
           <div className="problem-text-toolbar">
-            <strong>問題文テキスト</strong>
-            <span>抽出元ページ：{pageLabel(mapping?.sourcePages)}</span>
+            <strong>問題文</strong>
+            <span>原本P{pageLabel(questionCard, mapping)}</span>
             {pdf && <button className="secondary" onClick={() => setShowOriginal((current) => !current)}>{showOriginal ? '原本を閉じる' : '原本を見る'}</button>}
           </div>
-          {!textReady && <p className="warning-text">PDF抽出テキストが未設定です。教材設定画面でPDFから問題候補を抽出してください。</p>}
-          <div className="problem-text-content">{questionText}</div>
+          {!textReady && <p className="warning-text">問題文が未登録または要確認です。教材を設定する画面で問題カードを確認してください。</p>}
+          <div className="problem-text-content app-like-problem-text">{questionCard.questionText}</div>
+          {questionCard.choices.length > 0 && <div className="choices-box"><strong>選択肢</strong>{questionCard.choices.map((choice) => <span key={choice}>{choice}</span>)}</div>}
         </div>
 
-        {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="原本" page={page} pageStart={mapping?.problemPageStart ?? 1} pageEnd={mapping?.problemPageEnd ?? pdf?.pageCount ?? 1} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
+        {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="原本確認" page={page} pageStart={pageStart} pageEnd={pageEnd} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
       </section>
 
-      <section className="focused-answer-area">
+      <section className="focused-answer-area answer-input-main">
         <div className="focused-answer-title">
           <div>
             <p className="eyebrow">答案入力</p>
-            <h2>{template.name}</h2>
+            <h2>{questionCard.answerTemplateType}</h2>
           </div>
-          <button className="secondary" onClick={onApplyRowPoints}>行別得点合計を反映</button>
+          <button className="secondary pc-answer-only" onClick={onApplyRowPoints}>行別得点合計を反映</button>
         </div>
-        <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} />
+        {questionCard.answerInputType === 'journalEntry' ? <JournalEntryCardInput answer={answer} template={template} onChange={onChange} /> : null}
+        <div className="pc-answer-only"><AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} /></div>
       </section>
+
+      <div className="mobile-bottom-action"><button className="accent" onClick={onGoGrading}>{bottomLabel}</button></div>
     </section>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/JournalEntryCardInput.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/JournalEntryCardInput.tsx
@@ -1,0 +1,107 @@
+import type { AnswerRow, AnswerState, TemplateDefinition } from '../types';
+import { formatAmount, normalizeNumericInput, toHalfWidthNumber } from '../utils/numberFormat';
+
+interface Props {
+  answer: AnswerState;
+  template: TemplateDefinition;
+  onChange: (answer: AnswerState) => void;
+}
+
+function makeRow(columnCount: number, index: number): AnswerRow {
+  const cells = Array.from({ length: columnCount }, (_, col) => (col === 0 ? String(index + 1) : ''));
+  return { id: crypto.randomUUID(), cells, grade: '未採点', points: 0 };
+}
+
+function findColumnIndex(columns: string[], patterns: string[], fallback: number): number {
+  const index = columns.findIndex((column) => patterns.some((pattern) => column.includes(pattern)));
+  return index >= 0 ? index : fallback;
+}
+
+export function JournalEntryCardInput({ answer, template, onChange }: Props) {
+  const columns = answer.columns;
+  const debitAccountIndex = findColumnIndex(columns, ['借方科目'], 2);
+  const debitAmountIndex = findColumnIndex(columns, ['借方金額'], 3);
+  const creditAccountIndex = findColumnIndex(columns, ['貸方科目'], 4);
+  const creditAmountIndex = findColumnIndex(columns, ['貸方金額'], 5);
+
+  const updateCell = (rowIndex: number, colIndex: number, value: string, amount = false) => {
+    const rows = answer.rows.map((row, index) => {
+      if (index !== rowIndex) return row;
+      const cells = [...row.cells];
+      cells[colIndex] = amount ? normalizeNumericInput(value) : value;
+      return { ...row, cells };
+    });
+    onChange({ ...answer, rows });
+  };
+
+  const addEntry = () => {
+    const rows = [...answer.rows, makeRow(answer.columns.length, answer.rows.length)];
+    onChange({ ...answer, rows });
+  };
+
+  const deleteEntry = (rowIndex: number) => {
+    const rows = answer.rows.filter((_, index) => index !== rowIndex);
+    onChange({ ...answer, rows: rows.length ? rows : [makeRow(answer.columns.length, 0)] });
+  };
+
+  const renderAccountInput = (row: AnswerRow, rowIndex: number, colIndex: number, label: string) => {
+    const value = row.cells[colIndex] ?? '';
+    const options = template.optionColumns?.[columns[colIndex] ?? ''];
+    return (
+      <label>{label}
+        {options ? (
+          <select value={value} onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)}>
+            <option value="">選択</option>
+            {options.map((option) => <option key={option} value={option}>{option}</option>)}
+          </select>
+        ) : (
+          <input value={value} onChange={(event) => updateCell(rowIndex, colIndex, event.target.value)} placeholder="例：仕掛品" lang="ja" autoComplete="off" />
+        )}
+      </label>
+    );
+  };
+
+  const renderAmountInput = (row: AnswerRow, rowIndex: number, colIndex: number, label: string) => {
+    const value = row.cells[colIndex] ?? '';
+    return (
+      <label>{label}
+        <input
+          value={formatAmount(value)}
+          onChange={(event) => updateCell(rowIndex, colIndex, toHalfWidthNumber(event.target.value), true)}
+          inputMode="numeric"
+          pattern="[0-9,\\-]*"
+          placeholder="例：10,000"
+          autoComplete="off"
+        />
+      </label>
+    );
+  };
+
+  return (
+    <section className="mobile-journal-input" aria-label="スマホ用仕訳入力">
+      <div className="mobile-journal-heading">
+        <p className="eyebrow">答案入力</p>
+        <h2>仕訳カード入力</h2>
+      </div>
+      {answer.rows.map((row, rowIndex) => (
+        <article className="journal-entry-card" key={row.id}>
+          <div className="journal-entry-card-header">
+            <strong>仕訳{rowIndex + 1}</strong>
+            <button className="secondary" onClick={() => deleteEntry(rowIndex)} disabled={answer.rows.length <= 1}>削除</button>
+          </div>
+          <div className="journal-entry-side">
+            <h3>借方</h3>
+            {renderAccountInput(row, rowIndex, debitAccountIndex, '科目')}
+            {renderAmountInput(row, rowIndex, debitAmountIndex, '金額')}
+          </div>
+          <div className="journal-entry-side">
+            <h3>貸方</h3>
+            {renderAccountInput(row, rowIndex, creditAccountIndex, '科目')}
+            {renderAmountInput(row, rowIndex, creditAmountIndex, '金額')}
+          </div>
+        </article>
+      ))}
+      <button className="accent add-journal-entry" onClick={addEntry}>＋ 仕訳を追加</button>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
+++ b/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
@@ -1,6 +1,7 @@
 .focused-practice-panel,
 .focused-grading-panel,
-.material-text-setup {
+.material-text-setup,
+.question-card-learning-flow {
   display: grid;
   gap: 16px;
 }
@@ -17,9 +18,26 @@
   align-items: start;
 }
 
-.focused-main-actions {
-  justify-content: flex-end;
+.focused-main-actions { justify-content: flex-end; }
+
+.learning-top-bar {
+  position: sticky;
+  top: 70px;
+  z-index: 12;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(255,255,255,.96);
+  box-shadow: 0 6px 18px rgba(0,0,0,.08);
 }
+
+.learning-top-bar strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.learning-top-bar span { font-weight: 900; color: #0f5c68; }
+.question-label { display: inline-flex; width: fit-content; margin: 0 0 8px; padding: 5px 12px; border-radius: 999px; background: #0f5c68; color: #fff; font-weight: 900; }
+.question-card-main { overflow: hidden; }
 
 .focused-question-meta {
   display: flex;
@@ -41,6 +59,8 @@
   border: 1px solid #d3e7e2;
 }
 
+.needs-review-pill { background: #fff7df !important; color: #865b00; border-color: #e9c56c !important; }
+
 .problem-text-box {
   display: grid;
   gap: 10px;
@@ -51,19 +71,9 @@
   padding: 14px;
 }
 
-.problem-text-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.problem-text-toolbar span {
-  color: #53676a;
-  font-size: 12px;
-  font-weight: 800;
-}
+.app-like-problem-box { background: #f8fbfa; }
+.problem-text-toolbar { display: flex; flex-wrap: wrap; gap: 10px; justify-content: space-between; align-items: center; }
+.problem-text-toolbar span { color: #53676a; font-size: 12px; font-weight: 800; }
 
 .problem-text-content {
   white-space: pre-wrap;
@@ -77,24 +87,14 @@
   border: 1px solid #dfeae6;
 }
 
-.explanation-text-content {
-  max-height: 56vh;
-  font-size: 15px;
-}
+.app-like-problem-text { font-size: 18px; line-height: 1.95; }
+.choices-box { display: grid; gap: 8px; padding: 12px; border-radius: 12px; background: #fff; border: 1px solid #dfeae6; }
+.choices-box span { display: block; padding: 7px 9px; border-radius: 8px; background: #f4f8f6; font-weight: 700; }
+.explanation-text-content { max-height: 56vh; font-size: 15px; }
 
-.focused-answer-area {
-  display: grid;
-  gap: 10px;
-  min-width: 0;
-}
-
-.focused-answer-area .answer-panel {
-  border: 2px solid #d7eadf;
-}
-
-.focused-answer-area .answer-table-wrap {
-  max-height: 68vh;
-}
+.focused-answer-area { display: grid; gap: 10px; min-width: 0; }
+.focused-answer-area .answer-panel { border: 2px solid #d7eadf; }
+.focused-answer-area .answer-table-wrap { max-height: 68vh; }
 
 .focused-practice-panel .col-memo,
 .focused-practice-panel .col-grade,
@@ -104,157 +104,81 @@
 .focused-practice-panel th.col-points,
 .focused-practice-panel td.col-memo,
 .focused-practice-panel td.col-grade,
-.focused-practice-panel td.col-points {
-  display: none;
-}
+.focused-practice-panel td.col-points,
+.question-card-learning-flow .col-memo,
+.question-card-learning-flow .col-grade,
+.question-card-learning-flow .col-points,
+.question-card-learning-flow th.col-memo,
+.question-card-learning-flow th.col-grade,
+.question-card-learning-flow th.col-points,
+.question-card-learning-flow td.col-memo,
+.question-card-learning-flow td.col-grade,
+.question-card-learning-flow td.col-points { display: none; }
 
-.focused-practice-panel .journal-table {
-  min-width: 760px;
-}
+.focused-practice-panel .journal-table,
+.question-card-learning-flow .journal-table { min-width: 760px; }
 
-.grading-text-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(360px, .85fr);
-  gap: 16px;
-  align-items: start;
-}
+.mobile-journal-input { display: none; gap: 12px; }
+.journal-entry-card { display: grid; gap: 12px; padding: 14px; border-radius: 16px; background: #fff; border: 1px solid #d8e8e4; box-shadow: 0 4px 14px rgba(28,62,54,.06); }
+.journal-entry-card-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.journal-entry-card-header strong { font-size: 18px; color: #0f5c68; }
+.journal-entry-side { display: grid; gap: 8px; padding: 12px; border-radius: 12px; background: #f7fbf9; border: 1px solid #dce9e4; }
+.journal-entry-side h3 { margin: 0; font-size: 15px; }
+.journal-entry-side label { display: grid; gap: 5px; font-weight: 800; }
+.add-journal-entry { width: 100%; min-height: 48px; }
+.mobile-bottom-action { display: none; }
+.pc-answer-only { display: block; }
 
-.grading-control-box {
-  display: grid;
-  gap: 12px;
-  border: 1px solid #d8e8e4;
-  border-radius: 14px;
-  padding: 14px;
-  background: #fff;
-}
+.grading-text-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(360px, .85fr); gap: 16px; align-items: start; }
+.grading-control-box { display: grid; gap: 12px; border: 1px solid #d8e8e4; border-radius: 14px; padding: 14px; background: #fff; }
+.status-button-grid { display: grid; grid-template-columns: repeat(2, minmax(140px, 1fr)); gap: 8px; }
+.compact-check-list { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 
-.status-button-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(140px, 1fr));
-  gap: 8px;
-}
-
-.compact-check-list {
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-}
-
-.material-setup-main {
-  border: 2px solid #d7eadf;
-}
-
-.setup-step-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(240px, 1fr));
-  gap: 12px;
-  align-items: start;
-}
-
+.material-setup-main { border: 2px solid #d7eadf; }
+.setup-step-grid { display: grid; grid-template-columns: repeat(3, minmax(240px, 1fr)); gap: 12px; align-items: start; }
 .setup-step-card,
-.extraction-summary-card {
-  display: grid;
-  gap: 10px;
-  padding: 14px;
-  border: 1px solid #d8e8e4;
-  border-radius: 14px;
-  background: #fbfdfc;
-}
-
-.extraction-counts {
-  grid-template-columns: repeat(4, minmax(110px, 1fr));
-}
-
-.candidate-review-panel {
-  border: 2px solid #d7eadf;
-}
-
-.candidate-review-layout {
-  display: grid;
-  grid-template-columns: minmax(240px, 330px) minmax(0, 1fr);
-  gap: 16px;
-  align-items: start;
-}
-
-.candidate-list {
-  display: grid;
-  gap: 8px;
-  max-height: 68vh;
-  overflow: auto;
-}
-
-.candidate-list-item {
-  display: grid;
-  gap: 4px;
-  text-align: left;
-  background: #eef7f4;
-  color: #173f35;
-  border: 1px solid #d8e8e4;
-}
-
-.candidate-list-item.active {
-  outline: 3px solid #0f5c68;
-  background: #fff;
-}
-
-.candidate-list-item small {
-  color: #53676a;
-}
-
+.extraction-summary-card { display: grid; gap: 10px; padding: 14px; border: 1px solid #d8e8e4; border-radius: 14px; background: #fbfdfc; }
+.extraction-counts { grid-template-columns: repeat(4, minmax(110px, 1fr)); }
+.candidate-review-panel { border: 2px solid #d7eadf; }
+.candidate-review-layout { display: grid; grid-template-columns: minmax(240px, 330px) minmax(0, 1fr); gap: 16px; align-items: start; }
+.candidate-list { display: grid; gap: 8px; max-height: 68vh; overflow: auto; }
+.candidate-list-item { display: grid; gap: 4px; text-align: left; background: #eef7f4; color: #173f35; border: 1px solid #d8e8e4; }
+.candidate-list-item.active { outline: 3px solid #0f5c68; background: #fff; }
+.candidate-list-item small { color: #53676a; }
 .status-pill.good { background: #e6f6ea; color: #17633b; border-color: #a8d8b3; }
 .status-pill.warn { background: #fff7df; color: #865b00; border-color: #e9c56c; }
 .status-pill.danger { background: #fff0ef; color: #9d2f2f; border-color: #e5aaa6; }
-
-.candidate-editor {
-  display: grid;
-  gap: 12px;
-  min-width: 0;
-}
-
-.large-textarea {
-  min-height: 160px;
-  line-height: 1.65;
-}
-
-.compact-material-grid {
-  grid-template-columns: minmax(0, 1fr);
-}
+.candidate-editor { display: grid; gap: 12px; min-width: 0; }
+.large-textarea { min-height: 160px; line-height: 1.65; }
+.compact-material-grid { grid-template-columns: minmax(0, 1fr); }
 
 @media (max-width: 1100px) {
   .focused-question-header,
   .focused-answer-title,
   .grading-text-grid,
   .setup-step-grid,
-  .candidate-review-layout {
-    grid-template-columns: 1fr;
-  }
-  .focused-main-actions {
-    justify-content: stretch;
-  }
-  .focused-main-actions button {
-    flex: 1 1 160px;
-  }
+  .candidate-review-layout { grid-template-columns: 1fr; }
+  .focused-main-actions { justify-content: stretch; }
+  .focused-main-actions button { flex: 1 1 160px; }
 }
 
 @media (max-width: 760px) {
-  .problem-text-content {
-    font-size: 16px;
-    max-height: none;
-  }
-  .focused-answer-area .answer-table-wrap {
-    max-height: none;
-  }
+  .problem-text-content { font-size: 16px; max-height: none; }
+  .app-like-problem-text { font-size: 17px; line-height: 1.9; padding: 16px; }
+  .focused-answer-area .answer-table-wrap { max-height: none; }
   .focused-practice-panel .journal-table,
-  .focused-grading-panel .journal-table {
-    min-width: 720px;
-  }
-  .mode-nav {
-    position: static;
-  }
-  .app-shell {
-    width: min(100vw, 100%);
-    margin: 0 auto 32px;
-  }
+  .focused-grading-panel .journal-table,
+  .question-card-learning-flow .journal-table { min-width: 720px; }
+  .mode-nav { position: static; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .learning-top-bar { top: 0; border-radius: 0; margin: -4px -8px 0; }
+  .desktop-only-actions { display: none; }
+  .pc-answer-only { display: none; }
+  .mobile-journal-input { display: grid; }
+  .mobile-bottom-action { display: block; position: sticky; bottom: 0; z-index: 18; padding: 10px 0 calc(10px + env(safe-area-inset-bottom)); background: linear-gradient(180deg, rgba(238,246,242,.1), #eef6f2 35%); }
+  .mobile-bottom-action button { width: 100%; min-height: 58px; font-size: 18px; font-weight: 900; border-radius: 14px; }
+  .question-card-main { padding: 14px; }
+  .focused-question-meta.subtle-meta span { font-size: 11px; padding: 4px 7px; }
+  .app-shell { width: min(100vw, 100%); margin: 0 auto 32px; padding: 0 8px; }
   .app-header,
-  .panel {
-    border-radius: 10px;
-  }
+  .panel { border-radius: 10px; }
 }

--- a/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/storage/indexedDb.ts
@@ -1,8 +1,8 @@
-import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, ReviewState } from '../types';
+import type { AnswerState, BackupMetadata, BackupPayload, ExamSetRecord, ExtractionCandidate, ExtractionJob, HistoryEntry, MaterialPdf, MaterialPdfMapping, MistakeCard, PracticeSession, QuestionCard, ReviewState } from '../types';
 
 const DB_NAME = 'cpa-boki2-trial-section-answer-manager';
-const DB_VERSION = 4;
-const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets', 'mistakeCards', 'materialPdfs', 'materialPdfMappings', 'practiceSessions', 'reviewStates'] as const;
+const DB_VERSION = 5;
+const STORES = ['answers', 'histories', 'settings', 'templates', 'backups', 'examSets', 'mistakeCards', 'materialPdfs', 'materialPdfMappings', 'questionCards', 'extractionJobs', 'extractionCandidates', 'practiceSessions', 'reviewStates'] as const;
 
 type StoreName = (typeof STORES)[number];
 
@@ -14,6 +14,14 @@ function stripExtractedTextFromMapping(mapping: MaterialPdfMapping): MaterialPdf
     explanationText: '',
     problemBlocks: mapping.problemBlocks?.map((block) => ({ ...block, questionText: '' })),
   };
+}
+
+function stripQuestionCardText(card: QuestionCard): QuestionCard {
+  return { ...card, questionText: '', choices: [] };
+}
+
+function stripExtractionCandidateText(candidate: ExtractionCandidate): ExtractionCandidate {
+  return { ...candidate, rawTextPreview: '', questionCardDraft: stripQuestionCardText(candidate.questionCardDraft) };
 }
 
 function openDb(): Promise<IDBDatabase> {
@@ -113,11 +121,23 @@ export async function getMaterialPdfs(): Promise<MaterialPdf[]> {
 export async function deleteMaterialPdf(id: string): Promise<void> {
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
-    const transaction = db.transaction(['materialPdfs', 'materialPdfMappings'], 'readwrite');
+    const transaction = db.transaction(['materialPdfs', 'materialPdfMappings', 'questionCards', 'extractionJobs', 'extractionCandidates'], 'readwrite');
     transaction.objectStore('materialPdfs').delete(id);
     const mappingsRequest = transaction.objectStore('materialPdfMappings').getAll();
     mappingsRequest.onsuccess = () => {
       (mappingsRequest.result as MaterialPdfMapping[]).filter((mapping) => mapping.materialPdfId === id).forEach((mapping) => transaction.objectStore('materialPdfMappings').delete(mapping.id));
+    };
+    const cardsRequest = transaction.objectStore('questionCards').getAll();
+    cardsRequest.onsuccess = () => {
+      (cardsRequest.result as QuestionCard[]).filter((card) => card.sourceMaterialId === id).forEach((card) => transaction.objectStore('questionCards').delete(card.id));
+    };
+    const jobsRequest = transaction.objectStore('extractionJobs').getAll();
+    jobsRequest.onsuccess = () => {
+      (jobsRequest.result as ExtractionJob[]).filter((job) => job.materialPdfId === id).forEach((job) => transaction.objectStore('extractionJobs').delete(job.id));
+    };
+    const candidatesRequest = transaction.objectStore('extractionCandidates').getAll();
+    candidatesRequest.onsuccess = () => {
+      (candidatesRequest.result as ExtractionCandidate[]).filter((candidate) => candidate.materialPdfId === id).forEach((candidate) => transaction.objectStore('extractionCandidates').delete(candidate.id));
     };
     transaction.oncomplete = () => {
       db.close();
@@ -141,6 +161,67 @@ export async function getMaterialPdfMappings(): Promise<MaterialPdfMapping[]> {
 
 export async function deleteMaterialPdfMapping(id: string): Promise<void> {
   await tx('materialPdfMappings', 'readwrite', (store) => store.delete(id));
+}
+
+export async function saveQuestionCard(card: QuestionCard): Promise<void> {
+  await tx('questionCards', 'readwrite', (store) => store.put(card));
+}
+
+export async function saveQuestionCards(cards: QuestionCard[]): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('questionCards', 'readwrite');
+    const store = transaction.objectStore('questionCards');
+    cards.forEach((card) => store.put(card));
+    transaction.oncomplete = () => { db.close(); resolve(); };
+    transaction.onerror = () => { db.close(); reject(transaction.error); };
+  });
+}
+
+export async function getQuestionCards(): Promise<QuestionCard[]> {
+  const rows = await tx<QuestionCard[]>('questionCards', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => a.questionNumber.localeCompare(b.questionNumber, 'ja'));
+}
+
+export async function deleteQuestionCard(id: string): Promise<void> {
+  await tx('questionCards', 'readwrite', (store) => store.delete(id));
+}
+
+export async function saveExtractionJob(job: ExtractionJob): Promise<void> {
+  await tx('extractionJobs', 'readwrite', (store) => store.put(job));
+}
+
+export async function getExtractionJobs(): Promise<ExtractionJob[]> {
+  const rows = await tx<ExtractionJob[]>('extractionJobs', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function saveExtractionCandidates(candidates: ExtractionCandidate[]): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('extractionCandidates', 'readwrite');
+    const store = transaction.objectStore('extractionCandidates');
+    candidates.forEach((candidate) => store.put(candidate));
+    transaction.oncomplete = () => { db.close(); resolve(); };
+    transaction.onerror = () => { db.close(); reject(transaction.error); };
+  });
+}
+
+export async function getExtractionCandidates(): Promise<ExtractionCandidate[]> {
+  const rows = await tx<ExtractionCandidate[]>('extractionCandidates', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function clearExtractionCandidatesForMaterial(materialPdfId: string): Promise<void> {
+  const candidates = await getExtractionCandidates();
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('extractionCandidates', 'readwrite');
+    const store = transaction.objectStore('extractionCandidates');
+    candidates.filter((candidate) => candidate.materialPdfId === materialPdfId).forEach((candidate) => store.delete(candidate.id));
+    transaction.oncomplete = () => { db.close(); resolve(); };
+    transaction.onerror = () => { db.close(); reject(transaction.error); };
+  });
 }
 
 export async function savePracticeSession(session: PracticeSession): Promise<void> {
@@ -201,10 +282,12 @@ export async function recordRestoreMade(): Promise<BackupMetadata> {
 export async function exportAllData(): Promise<BackupPayload> {
   const materialPdfs = await getMaterialPdfs();
   const mappings = await getMaterialPdfMappings();
+  const questionCards = await getQuestionCards();
+  const extractionCandidates = await getExtractionCandidates();
   return {
     exportedAt: new Date().toISOString(),
     appName: 'CPA日商簿記2級 試験対策編 解答・復習管理アプリ',
-    version: '1.4.0',
+    version: '1.5.0',
     answers: await getAllAnswers(),
     histories: await getHistories(),
     settings: await tx<Record<string, unknown>[]>('settings', 'readonly', (store) => store.getAll()),
@@ -214,6 +297,9 @@ export async function exportAllData(): Promise<BackupPayload> {
     mistakeCards: await getMistakeCards(),
     materialPdfMappings: mappings.map(stripExtractedTextFromMapping),
     materialPdfMetadata: materialPdfs.map(({ pdfBlob: _pdfBlob, ...metadata }) => metadata),
+    questionCards: questionCards.map(stripQuestionCardText),
+    extractionJobs: await getExtractionJobs(),
+    extractionCandidates: extractionCandidates.map(stripExtractionCandidateText),
     practiceSessions: await getPracticeSessions(),
     reviewStates: await getReviewStates(),
     backupMetadata: await getBackupMetadata(),
@@ -234,6 +320,9 @@ export async function importAllData(payload: BackupPayload): Promise<void> {
     payload.examSets?.forEach((item) => transaction.objectStore('examSets').put(item));
     payload.mistakeCards?.forEach((item) => transaction.objectStore('mistakeCards').put(item));
     payload.materialPdfMappings?.forEach((item) => transaction.objectStore('materialPdfMappings').put(item));
+    payload.questionCards?.forEach((item) => transaction.objectStore('questionCards').put(item));
+    payload.extractionJobs?.forEach((item) => transaction.objectStore('extractionJobs').put(item));
+    payload.extractionCandidates?.forEach((item) => transaction.objectStore('extractionCandidates').put(item));
     payload.practiceSessions?.forEach((item) => transaction.objectStore('practiceSessions').put(item));
     payload.reviewStates?.forEach((item) => transaction.objectStore('reviewStates').put(item));
     if (payload.backupMetadata) transaction.objectStore('backups').put(payload.backupMetadata);

--- a/cpa-boki2-trial-section-answer-manager/src/types/index.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/types/index.ts
@@ -1,7 +1,10 @@
-export type QualificationId = 'nissho_boki2';
+export type QualificationId = 'nissho_boki2' | (string & {});
+export type ExamType = '日商簿記2級' | (string & {});
 export type Subject = 'commercial' | 'industrial';
 export type SectionId = 'q1' | 'q2' | 'q3' | 'q4' | 'q5';
 export type ProblemKind = 'journal' | 'calculationTable' | 'fillBlank' | 'numericInput' | 'multipleChoice' | 'shortAnswer' | 'essay' | 'oral';
+export type AnswerInputType = 'journalEntry' | 'singleChoice' | 'multipleChoice' | 'shortText' | 'numeric' | 'memoOnly';
+export type AnswerTemplateType = '仕訳テーブル' | '選択式' | '短答式' | '金額計算' | '記述式' | 'メモのみ';
 export type TemplateId = 'journal' | 'genericNumber' | 'equityStatement' | 'consolidation' | 'ledger' | 'financialStatements' | 'processCosting' | 'departmentCosting' | 'standardCosting' | 'cvp' | 'variableFullCosting' | 'freeTable';
 export type GradeMark = '未採点' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
@@ -23,6 +26,65 @@ export interface ProblemDefinition {
   topic: string;
   problemKind?: ProblemKind;
   defaultTemplateId: TemplateId;
+}
+
+export interface QuestionCard {
+  id: string;
+  examType: ExamType;
+  subject: string;
+  section: string;
+  topic: string;
+  title: string;
+  questionNumber: string;
+  questionText: string;
+  choices: string[];
+  answerInputType: AnswerInputType;
+  answerTemplateType: AnswerTemplateType;
+  estimatedMinutes: number;
+  difficulty: '易' | '標準' | '難';
+  sourceMaterialId: string;
+  sourcePageStart: number;
+  sourcePageEnd: number;
+  answerPageStart?: number;
+  answerPageEnd?: number;
+  explanationPageStart?: number;
+  explanationPageEnd?: number;
+  extractionConfidence: number;
+  needsReview: boolean;
+  sourceProblemId?: string;
+  sourceMappingId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ExtractionJob {
+  id: string;
+  materialPdfId: string;
+  examType: ExamType;
+  status: 'created' | 'extracting' | 'ready' | 'failed';
+  totalPages: number;
+  extractedPages: number;
+  candidateCount: number;
+  autoLinkedCount: number;
+  needsReviewCount: number;
+  unmatchedCount: number;
+  errorMessage?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ExtractionCandidate {
+  id: string;
+  jobId: string;
+  materialPdfId: string;
+  suggestedProblemId: string;
+  questionCardDraft: QuestionCard;
+  rawTextPreview: string;
+  confidence: number;
+  needsReview: boolean;
+  reason: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface TemplateExampleGuide {
@@ -412,6 +474,9 @@ export interface BackupPayload {
   mistakeCards?: MistakeCard[];
   materialPdfMappings?: MaterialPdfMapping[];
   materialPdfMetadata?: MaterialPdfMetadata[];
+  questionCards?: QuestionCard[];
+  extractionJobs?: ExtractionJob[];
+  extractionCandidates?: ExtractionCandidate[];
   practiceSessions?: PracticeSession[];
   reviewStates?: ReviewState[];
   backupMetadata?: BackupMetadata | null;

--- a/cpa-boki2-trial-section-answer-manager/src/utils/questionCards.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/utils/questionCards.ts
@@ -1,0 +1,174 @@
+import { problemCatalog, subjectLabels } from '../data/problemCatalog';
+import type { AnswerInputType, AnswerTemplateType, MaterialPdfMapping, PdfProblemExtractionCandidate, ProblemDefinition, QuestionCard, TemplateId } from '../types';
+import { nowIso } from './dates';
+
+const NO_QUESTION_TEXT = 'この問題は問題文未登録です。原本を見るか、教材設定で問題文を登録してください。';
+const HEADER_PATTERNS = [
+  /試験対策編/g,
+  /いちばんわかる日商簿記2級/g,
+  /CPAラーニング/g,
+  /第\s*[1-5]\s*問対策(?:[-ー－]?\d+)?/g,
+  /商業簿記|工業簿記/g,
+  /解答・解説|解答解説/g,
+];
+
+function templateToInputType(templateId?: TemplateId): AnswerInputType {
+  if (templateId === 'journal') return 'journalEntry';
+  if (templateId === 'genericNumber') return 'numeric';
+  return 'memoOnly';
+}
+
+function templateToTemplateType(templateId?: TemplateId): AnswerTemplateType {
+  if (templateId === 'journal') return '仕訳テーブル';
+  if (templateId === 'genericNumber') return '金額計算';
+  return 'メモのみ';
+}
+
+function difficultyToMinutes(value?: MaterialPdfMapping['estimatedMinutes']): number {
+  const parsed = Number(String(value ?? '').replace(/[^0-9]/g, ''));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
+}
+
+function stripNoise(raw: string, displayId?: string): string {
+  let text = raw.replace(/\r\n?/g, '\n').replace(/[\t ]+/g, ' ');
+  HEADER_PATTERNS.forEach((pattern) => { text = text.replace(pattern, ' '); });
+  text = text.replace(/(^|\s)\d{1,4}(?=\s|$)/g, ' ');
+  if (displayId) {
+    const escaped = displayId.replace('-', '\\s*-\\s*');
+    text = text.replace(new RegExp(`問題?\s*${escaped}`, 'g'), ' ');
+    text = text.replace(new RegExp(`(^|\\s)${escaped}(?=\\s|$)`, 'g'), ' ');
+  }
+  text = text.replace(/\s*\(第\s*[1-5]\s*問対策[-ー－]?\d*\)\s*/g, ' ');
+  text = text.replace(/\s+/g, ' ').trim();
+  return text;
+}
+
+function splitChoices(text: string): { body: string; choices: string[] } {
+  const choicePattern = /([アイウエオカキクケコ])\s*[　 ]*([^アイウエオカキクケコ\n]{1,30})(?=\s+[アイウエオカキクケコ]\s|$)/g;
+  const choices: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = choicePattern.exec(text)) !== null) {
+    const label = match[1];
+    const value = match[2].trim();
+    if (value && !choices.includes(`${label}　${value}`)) choices.push(`${label}　${value}`);
+  }
+  if (choices.length === 0) return { body: text, choices };
+  const firstChoiceIndex = text.search(/アイウエオ|ア\s|ア　/);
+  return {
+    body: firstChoiceIndex > 0 ? text.slice(0, firstChoiceIndex).trim() : text.replace(choicePattern, '').trim(),
+    choices,
+  };
+}
+
+function paragraphize(text: string): string {
+  const normalized = text.replace(/。\s*/g, '。\n\n').replace(/(次の[^。]+。)/, '$1\n\n');
+  return normalized.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+export function cleanupQuestionText(raw: string, displayId?: string): { questionText: string; choices: string[]; needsReview: boolean } {
+  const stripped = stripNoise(raw, displayId);
+  if (!stripped || stripped.length < 20 || /�{2,}/.test(stripped)) return { questionText: NO_QUESTION_TEXT, choices: [], needsReview: true };
+  const answerStart = stripped.search(/解答|解説|正解|答案/);
+  const problemOnly = answerStart > 40 ? stripped.slice(0, answerStart).trim() : stripped;
+  const { body, choices } = splitChoices(problemOnly);
+  const questionText = paragraphize(body);
+  return { questionText: questionText || NO_QUESTION_TEXT, choices, needsReview: questionText.length < 20 };
+}
+
+export function questionCardFromMapping(mapping: MaterialPdfMapping): QuestionCard {
+  const problem = problemCatalog.find((item) => item.id === mapping.problemId) ?? problemCatalog[0];
+  const rawText = mapping.problemBlocks?.map((block) => block.questionText).filter(Boolean).join('\n\n') || mapping.problemText || '';
+  const cleaned = cleanupQuestionText(rawText, problem.displayId);
+  const now = mapping.updatedAt || nowIso();
+  return {
+    id: mapping.problemId,
+    examType: '日商簿記2級',
+    subject: subjectLabels[problem.subject],
+    section: problem.sectionLabel,
+    topic: problem.topic,
+    title: `${problem.displayId}：${problem.topic}`,
+    questionNumber: problem.displayId,
+    questionText: cleaned.questionText,
+    choices: cleaned.choices,
+    answerInputType: templateToInputType(problem.defaultTemplateId),
+    answerTemplateType: templateToTemplateType(problem.defaultTemplateId),
+    estimatedMinutes: difficultyToMinutes(mapping.estimatedMinutes),
+    difficulty: mapping.difficulty,
+    sourceMaterialId: mapping.materialPdfId,
+    sourcePageStart: mapping.problemPageStart,
+    sourcePageEnd: mapping.problemPageEnd,
+    answerPageStart: mapping.answerPageStart,
+    answerPageEnd: mapping.answerPageEnd,
+    explanationPageStart: mapping.explanationPageStart,
+    explanationPageEnd: mapping.explanationPageEnd,
+    extractionConfidence: mapping.extractionConfidence ?? 0,
+    needsReview: cleaned.needsReview || mapping.extractionStatus !== 'autoLinked',
+    sourceProblemId: mapping.problemId,
+    sourceMappingId: mapping.id,
+    createdAt: mapping.createdAt || now,
+    updatedAt: now,
+  };
+}
+
+export function fallbackQuestionCard(problem: ProblemDefinition): QuestionCard {
+  const now = nowIso();
+  return {
+    id: problem.id,
+    examType: '日商簿記2級',
+    subject: subjectLabels[problem.subject],
+    section: problem.sectionLabel,
+    topic: problem.topic,
+    title: `${problem.displayId}：${problem.topic}`,
+    questionNumber: problem.displayId,
+    questionText: NO_QUESTION_TEXT,
+    choices: [],
+    answerInputType: templateToInputType(problem.defaultTemplateId),
+    answerTemplateType: templateToTemplateType(problem.defaultTemplateId),
+    estimatedMinutes: 10,
+    difficulty: '標準',
+    sourceMaterialId: '',
+    sourcePageStart: 1,
+    sourcePageEnd: 1,
+    extractionConfidence: 0,
+    needsReview: true,
+    sourceProblemId: problem.id,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function questionCardFromCandidate(candidate: PdfProblemExtractionCandidate): QuestionCard {
+  const problem = problemCatalog.find((item) => item.id === candidate.suggestedProblemId) ?? problemCatalog[0];
+  const cleaned = cleanupQuestionText(candidate.problemText, problem.displayId);
+  const now = nowIso();
+  const pages = candidate.sourcePages.length ? [...candidate.sourcePages].sort((a, b) => a - b) : [1];
+  const answerPages = candidate.answerPages.length ? [...candidate.answerPages].sort((a, b) => a - b) : [];
+  const explanationPages = candidate.explanationPages.length ? [...candidate.explanationPages].sort((a, b) => a - b) : [];
+  return {
+    id: `${candidate.materialPdfId}-${problem.id}`,
+    examType: '日商簿記2級',
+    subject: subjectLabels[problem.subject],
+    section: problem.sectionLabel,
+    topic: problem.topic,
+    title: `${problem.displayId}：${problem.topic}`,
+    questionNumber: problem.displayId,
+    questionText: cleaned.questionText,
+    choices: cleaned.choices,
+    answerInputType: templateToInputType(candidate.templateId),
+    answerTemplateType: templateToTemplateType(candidate.templateId),
+    estimatedMinutes: 10,
+    difficulty: candidate.confidence >= 75 ? '標準' : '難',
+    sourceMaterialId: candidate.materialPdfId,
+    sourcePageStart: pages[0],
+    sourcePageEnd: pages[pages.length - 1],
+    answerPageStart: answerPages[0],
+    answerPageEnd: answerPages[answerPages.length - 1],
+    explanationPageStart: explanationPages[0],
+    explanationPageEnd: explanationPages[explanationPages.length - 1],
+    extractionConfidence: candidate.confidence,
+    needsReview: cleaned.needsReview || candidate.status !== 'autoLinked',
+    sourceProblemId: problem.id,
+    createdAt: now,
+    updatedAt: now,
+  };
+}


### PR DESCRIPTION
## 1. 今回の目的

現在のCPA日商簿記2級 試験対策編 解答・復習管理アプリは、PDF表示、PDF抽出、答案入力、採点、履歴、復習、教材設定、管理機能が混在し、学習時に何をすればよいか分かりにくくなっていました。

今回の目的は機能追加ではなく、実際に毎日使えるスマホ学習アプリ型UIへ再設計することです。

最優先の学習導線は以下です。

1. 問題を読む
2. 答案を入力する
3. 採点する
4. 復習に回す
5. 次の問題へ進む

## 2. なぜ機能追加ではなくUI再設計にしたか

前回までの実装では、PDF Vault、PDF抽出、答案入力、採点、履歴、復習、CSV、JSON、合格到達マップなどがアプリ内に増えました。

ただし、通常学習時に必要なのは、問題文、答案入力、採点導線だけです。

そのため今回のPRでは、新機能を前面に増やすのではなく、学習画面から管理機能を退避し、問題カードと答案入力を主役に戻しました。

## 3. 学習導線

初期表示は必ず `今すぐ解く` です。

`今すぐ解く` では以下を表示します。

- 上部の学習バー
- 論点名
- 進捗表示
- 問題カード
- 問題文
- 答案入力欄
- 一時保存
- 採点へ進む
- 次の問題へ
- 原本を見る

学習画面には以下を常時表示しません。

- 履歴一覧
- CSV
- JSON
- PDF Vault
- 教材設定
- 合格到達マップ詳細
- 白紙再現カード一覧
- 復習キュー詳細
- IndexedDBなどの内部技術名

## 4. 4モード構成

画面上部のモードは以下に整理しています。

1. 今すぐ解く
2. 採点する
3. 教材を設定する
4. 復習を見る

### 今すぐ解く

問題カードと答案入力だけに集中する画面です。

### 採点する

自分の答案、解答・解説確認、自己採点、ミス原因、次回復習日を扱う画面です。

### 教材を設定する

PDF登録、PDFテキスト抽出、問題候補確認、抽出テキスト修正、問題カード化を扱う管理画面です。

### 復習を見る

今日やる問題、期限超過、C判定、B判定、未着手をまず見せ、詳細管理は折りたたみに退避します。

## 5. PDFを主役にしない理由

PDF切り抜き表示は、スマホでは小さく、荒く、学習アプリとして読みづらいため、通常演習の主役にしていません。

今回の学習画面では、PDFは `原本を見る` ボタンから確認する補助機能にしています。

通常表示の主役は、PDFから抽出・整形した `QuestionCard.questionText` です。

## 6. PDF抽出の限界と候補確認方式

PDF抽出は、PDFのテキストレイヤーからページごとにテキストを取得する方式です。

OCRは今回実装していません。

そのため、スキャンPDFや保護PDFでは抽出できない場合があります。

今回の流れは以下です。

1. PDFを登録
2. PDFのテキストレイヤーから抽出
3. 問題候補を生成
4. 信頼度を付与
5. 低信頼候補は `needsReview=true`
6. ユーザーが確認・修正
7. 一括保存または個別保存で問題カード化

完全自動確定ではなく、候補生成と確認修正を分けています。

## 7. 問題文整形表示

`QuestionCard` 型を追加し、学習画面にはPDF抽出ログや教材ヘッダーをそのまま出さない設計にしました。

追加した主なデータ構造:

- `QuestionCard`
- `ExtractionJob`
- `ExtractionCandidate`
- `AnswerInputType`
- `AnswerTemplateType`

`utils/questionCards.ts` を追加し、抽出テキストから以下を可能な範囲で除去・整形します。

- 教材タイトル
- ページ番号
- 第1問対策などの重複見出し
- 解答・解説の混入
- 不要な空白
- 選択肢の本文混在

問題文が未登録または壊れている場合は、壊れた長文を表示せず、以下を表示します。

> この問題は問題文未登録です。原本を見るか、教材設定で問題文を登録してください。

## 8. スマホ・PCそれぞれの表示方針

### スマホ

スマホでは横長テーブルを強制表示しません。

仕訳入力は `JournalEntryCardInput` を追加し、以下のカード型にしました。

- 仕訳1
- 借方 科目
- 借方 金額
- 貸方 科目
- 貸方 金額
- 仕訳を追加
- 下部固定の採点ボタン

### PC・タブレット

PCでは従来の `AnswerTable` を維持します。

答案入力テーブル、行追加、列追加、空行整理、行別採点は引き続き使えます。

## 9. 既存機能への影響

維持しているもの:

- 3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリックでセル内編集
- Escで編集解除
- Enter / Shift+Enter移動
- 行追加
- 列追加
- 空行整理
- 行別採点
- 行別得点合計反映
- 答案保存
- 履歴保存
- 復習日設定
- JSONバックアップ
- 90分セット演習
- 合格到達マップ
- 白紙再現カード

追加したIndexedDBストア:

- `questionCards`
- `extractionJobs`
- `extractionCandidates`

既存ストアは維持しています。

既存の `materialPdfMappings` しかない場合も、そこから仮の `QuestionCard` を生成して学習画面に表示します。

## 10. 著作権・法令対応としてやっていないこと

以下は行っていません。

- CPA教材PDFをGitHubに保存
- CPA教材PDFをpublicフォルダに配置
- CPA教材PDFをsrc配下に配置
- CPA教材の問題文・解答・解説をコードに埋め込み
- CPAロゴ、教材画像をコードに埋め込み
- PDFや教材本文を外部サーバーへ送信
- Supabase保存
- クラウド同期
- AI解説
- 自動採点用の正解データ投入
- OCR
- ログイン
- 建設業経理士2級モード
- 弁理士モード

PDF・抽出テキスト・問題カード本文は、利用者本人の端末内IndexedDBで扱う設計です。

JSONバックアップにもPDF本体・抽出教材本文・問題文本文を含めません。

## 11. 変更ファイル

- `src/App.tsx`
- `src/components/FocusedPracticePanel.tsx`
- `src/components/JournalEntryCardInput.tsx`
- `src/focusedPractice.css`
- `src/storage/indexedDb.ts`
- `src/types/index.ts`
- `src/utils/questionCards.ts`

## 12. 検収項目

### PC表示

- トップURLでは既存案件管理アプリが壊れていない
- サブURLで簿記2級アプリが開く
- 初期表示は「今すぐ解く」
- 学習画面にCSV、JSON、PDF Vault、履歴一覧が常時表示されていない
- 問題文カードが見やすい
- 答案入力テーブルが十分な幅で表示される
- 採点へ進む導線が分かる
- 原本を見るは必要時だけ開く
- 管理機能は「教材を設定する」「復習を見る」へ退避している

### スマホ表示

- 1問1画面に近い表示
- 問題文が大きく読める
- 横長テーブルが強制表示されない
- 借方・貸方がカード型で入力できる
- 下部に大きな採点ボタンがある
- PDFと答案欄が同時に無理やり表示されない
- 次に何を押せばよいか分かる

### 教材設定

- PDFを選択できる
- PDFから問題候補を抽出できる
- 抽出候補を確認できる
- 信頼度が低いものだけ要確認になる
- 保存後、今すぐ解く画面に問題カードとして反映される
- PDF本文や抽出本文がGitHubに保存されない

### 既存機能

- 答案保存が壊れていない
- 履歴保存が壊れていない
- 復習日設定が壊れていない
- JSONバックアップが壊れていない
- 90分セット演習が完全に消えていない
- 既存の行追加・列追加・3桁カンマ・矢印移動が壊れていない

### ビルド

- `npm install` が通る
- `npm run build` が通る
- GitHub Actions の `CPA Boki2 App Build Check` が成功する
- Pages deploy が成功する
- Consoleに致命的なエラーが出ない

## 13. 実URLで確認すべき項目

対象URL:

`https://akashidaiki19910915-star.github.io/gyosei-app/cpa-boki2-trial-section-answer-manager/`

マージ後、PCとスマホで上記URLを開き、問題カード、スマホ仕訳カード入力、採点導線、教材設定、復習画面を確認してください。

## 14. Actions結果

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 15. 未確認事項

この環境では、マージ後のGitHub Pages実URL表示とブラウザConsole確認までは実施していません。

マージ後に実URLで以下を確認してください。

- GitHub Pages deploy が成功していること
- PC表示で問題カードと答案テーブルが崩れていないこと
- スマホ表示で仕訳カード入力が表示され、横長テーブルが強制表示されていないこと
- Consoleに致命的なエラーが出ていないこと