### PR TITLE
Refine CPA Boki2 question-card study shell

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx
@@ -20,6 +20,12 @@ interface Props {
   onApplyRowPoints: () => void;
 }
 
+interface StructuredQuestionText {
+  instruction: string;
+  body: string;
+  notes: string[];
+}
+
 function pageLabel(card: QuestionCard, mapping?: MaterialPdfMapping): string {
   if (card.sourcePageStart && card.sourcePageEnd) return card.sourcePageStart === card.sourcePageEnd ? String(card.sourcePageStart) : `${card.sourcePageStart}-${card.sourcePageEnd}`;
   const pages = mapping?.sourcePages;
@@ -33,61 +39,95 @@ function hasBlankRequiredJournalCells(answer: AnswerState): boolean {
   return answer.rows.some((row) => importantIndexes.some((index) => (row.cells[index] ?? '').trim() === ''));
 }
 
+function formatMoneyInText(text: string): string {
+  return text.replace(/\b\d{4,}\b/g, (value) => Number(value).toLocaleString('ja-JP'));
+}
+
+function structureQuestionText(text: string): StructuredQuestionText {
+  const normalized = formatMoneyInText(text).replace(/\r\n?/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+  const lines = normalized.split('\n').map((line) => line.trim()).filter(Boolean);
+  const notes = lines.filter((line) => /^※|^注|^なお/.test(line));
+  const mainLines = lines.filter((line) => !notes.includes(line));
+  const joined = mainLines.join('\n\n');
+  const firstSentenceMatch = joined.match(/^(.{8,120}?(?:しなさい。|答えなさい。|選びなさい。|選択しなさい。|記入しなさい。))/);
+  if (firstSentenceMatch) {
+    return {
+      instruction: firstSentenceMatch[1],
+      body: joined.slice(firstSentenceMatch[1].length).trim(),
+      notes,
+    };
+  }
+  return {
+    instruction: '次の問題を解いてください。',
+    body: joined,
+    notes,
+  };
+}
+
 export function FocusedPracticePanel({ problem, questionCard, answer, template, mapping, pdf, totalToday, progressIndex, onChange, onSave, onGoGrading, onNextProblem, onApplyRowPoints }: Props) {
   const [showOriginal, setShowOriginal] = useState(false);
   const [page, setPage] = useState(questionCard.sourcePageStart || mapping?.problemPageStart || mapping?.sourcePages?.[0] || 1);
   const textReady = questionCard.questionText && !questionCard.questionText.includes('問題文未登録');
-  const bottomLabel = useMemo(() => hasBlankRequiredJournalCells(answer) ? '未入力があります。採点しますか？' : '採点する', [answer]);
+  const bottomLabel = useMemo(() => hasBlankRequiredJournalCells(answer) ? '未入力があります。採点しますか？' : '解答する', [answer]);
   const pageStart = questionCard.sourcePageStart || mapping?.problemPageStart || 1;
   const pageEnd = questionCard.sourcePageEnd || mapping?.problemPageEnd || pdf?.pageCount || 1;
+  const structuredText = useMemo(() => structureQuestionText(questionCard.questionText), [questionCard.questionText]);
 
   return (
-    <section className="question-card-learning-flow">
-      <div className="learning-top-bar">
-        <button className="secondary" onClick={onNextProblem}>戻る</button>
-        <div>
+    <section className="question-card-learning-flow study-app-shell">
+      <div className="learning-top-bar study-app-top-bar">
+        <button className="secondary" onClick={onNextProblem}>問題一覧へ</button>
+        <div className="study-position-block">
           <p className="eyebrow">今すぐ解く</p>
-          <strong>{questionCard.topic}</strong>
+          <strong>{questionCard.subject} / {questionCard.section}</strong>
+          <small>{questionCard.topic}</small>
         </div>
-        <span>{Math.max(1, progressIndex)} / {Math.max(1, totalToday)}</span>
+        <div className="study-progress-block" aria-label="進捗">
+          <span>{Math.max(1, progressIndex)} / {Math.max(1, totalToday)}</span>
+          <div className="study-progress-track"><i style={{ width: `${Math.min(100, Math.max(4, (Math.max(1, progressIndex) / Math.max(1, totalToday)) * 100))}%` }} /></div>
+        </div>
       </div>
 
-      <section className="panel focused-question-card question-card-main">
+      <section className="panel focused-question-card question-card-main study-question-card">
         <div className="focused-question-header">
           <div>
             <p className="question-label">問題</p>
-            <h2>{questionCard.title || `${problem.displayId}：${problem.topic}`}</h2>
+            <h2>{questionCard.questionNumber}：{questionCard.topic || problem.topic}</h2>
             <div className="focused-question-meta subtle-meta">
               <span>{questionCard.subject}</span>
               <span>{questionCard.section}</span>
               <span>想定{questionCard.estimatedMinutes}分</span>
               <span>難易度：{questionCard.difficulty}</span>
               <span>信頼度：{questionCard.extractionConfidence}%</span>
-              {questionCard.needsReview && <span className="needs-review-pill">要確認</span>}
+              {questionCard.needsReview && <span className="needs-review-pill">原本確認が必要</span>}
             </div>
           </div>
           <div className="button-row focused-main-actions desktop-only-actions">
             <button onClick={onSave}>一時保存</button>
-            <button className="accent" onClick={onGoGrading}>採点へ進む</button>
+            <button className="accent" onClick={onGoGrading}>解答する</button>
             <button className="secondary" onClick={onNextProblem}>次の問題へ</button>
           </div>
         </div>
 
-        <div className="problem-text-box app-like-problem-box">
+        <div className="problem-text-box app-like-problem-box structured-question-box">
           <div className="problem-text-toolbar">
             <strong>問題文</strong>
             <span>原本P{pageLabel(questionCard, mapping)}</span>
             {pdf && <button className="secondary" onClick={() => setShowOriginal((current) => !current)}>{showOriginal ? '原本を閉じる' : '原本を見る'}</button>}
           </div>
           {!textReady && <p className="warning-text">問題文が未登録または要確認です。教材を設定する画面で問題カードを確認してください。</p>}
-          <div className="problem-text-content app-like-problem-text">{questionCard.questionText}</div>
-          {questionCard.choices.length > 0 && <div className="choices-box"><strong>選択肢</strong>{questionCard.choices.map((choice) => <span key={choice}>{choice}</span>)}</div>}
+          <div className="structured-question-content">
+            <section className="question-part question-instruction"><h3>問題指示</h3><p>{structuredText.instruction}</p></section>
+            <section className="question-part question-body"><h3>取引・条件・資料</h3><div className="problem-text-content app-like-problem-text">{structuredText.body || questionCard.questionText}</div></section>
+            {questionCard.choices.length > 0 && <section className="question-part choices-box"><h3>選択肢</h3><div>{questionCard.choices.map((choice) => <span key={choice}>{choice}</span>)}</div></section>}
+            {structuredText.notes.length > 0 && <section className="question-part note-box"><h3>注意書き</h3>{structuredText.notes.map((note) => <p key={note}>{note}</p>)}</section>}
+          </div>
         </div>
 
         {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="原本確認" page={page} pageStart={pageStart} pageEnd={pageEnd} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
       </section>
 
-      <section className="focused-answer-area answer-input-main">
+      <section className="focused-answer-area answer-input-main study-answer-card">
         <div className="focused-answer-title">
           <div>
             <p className="eyebrow">答案入力</p>
@@ -99,7 +139,11 @@ export function FocusedPracticePanel({ problem, questionCard, answer, template, 
         <div className="pc-answer-only"><AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} /></div>
       </section>
 
-      <div className="mobile-bottom-action"><button className="accent" onClick={onGoGrading}>{bottomLabel}</button></div>
+      <div className="mobile-bottom-action three-button-footer">
+        <button className="secondary" onClick={onSave}>メモ/保存</button>
+        <button className="accent" onClick={onGoGrading}>{bottomLabel}</button>
+        <button className="secondary" onClick={onNextProblem}>次へ</button>
+      </div>
     </section>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
+++ b/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
@@ -6,9 +6,13 @@
   gap: 16px;
 }
 
-.focused-question-card {
-  border: 2px solid #b8dfc2;
+.study-app-shell {
+  width: min(100%, 980px);
+  margin: 0 auto;
+  padding-bottom: 24px;
 }
+
+.focused-question-card { border: 2px solid #b8dfc2; }
 
 .focused-question-header,
 .focused-answer-title {
@@ -25,7 +29,7 @@
   top: 70px;
   z-index: 12;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) minmax(140px, auto);
   gap: 12px;
   align-items: center;
   padding: 10px 12px;
@@ -34,10 +38,70 @@
   box-shadow: 0 6px 18px rgba(0,0,0,.08);
 }
 
-.learning-top-bar strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.study-app-top-bar {
+  border: 1px solid #cfe3df;
+}
+
+.study-position-block {
+  min-width: 0;
+}
+
+.learning-top-bar strong,
+.study-position-block small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.study-position-block small {
+  color: #55706c;
+  font-weight: 800;
+  margin-top: 2px;
+}
+
 .learning-top-bar span { font-weight: 900; color: #0f5c68; }
-.question-label { display: inline-flex; width: fit-content; margin: 0 0 8px; padding: 5px 12px; border-radius: 999px; background: #0f5c68; color: #fff; font-weight: 900; }
-.question-card-main { overflow: hidden; }
+
+.study-progress-block {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+  min-width: 130px;
+}
+
+.study-progress-track {
+  width: 100%;
+  height: 7px;
+  border-radius: 999px;
+  background: #dfecea;
+  overflow: hidden;
+}
+
+.study-progress-track i {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: #0f8ca0;
+}
+
+.question-label {
+  display: inline-flex;
+  width: fit-content;
+  margin: 0 0 8px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: #0f5c68;
+  color: #fff;
+  font-weight: 900;
+}
+
+.question-card-main,
+.study-question-card,
+.study-answer-card {
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 10px 28px rgba(27,55,50,.08);
+}
 
 .focused-question-meta {
   display: flex;
@@ -71,9 +135,38 @@
   padding: 14px;
 }
 
-.app-like-problem-box { background: #f8fbfa; }
+.app-like-problem-box,
+.structured-question-box { background: #f8fbfa; }
 .problem-text-toolbar { display: flex; flex-wrap: wrap; gap: 10px; justify-content: space-between; align-items: center; }
 .problem-text-toolbar span { color: #53676a; font-size: 12px; font-weight: 800; }
+
+.structured-question-content {
+  display: grid;
+  gap: 12px;
+}
+
+.question-part {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid #dfeae6;
+}
+
+.question-part h3 {
+  margin: 0;
+  color: #0f5c68;
+  font-size: 14px;
+}
+
+.question-instruction p,
+.note-box p {
+  margin: 0;
+  line-height: 1.85;
+  font-size: 16px;
+  font-weight: 800;
+}
 
 .problem-text-content {
   white-space: pre-wrap;
@@ -87,9 +180,16 @@
   border: 1px solid #dfeae6;
 }
 
+.question-body .problem-text-content {
+  padding: 0;
+  border: 0;
+  max-height: none;
+}
+
 .app-like-problem-text { font-size: 18px; line-height: 1.95; }
-.choices-box { display: grid; gap: 8px; padding: 12px; border-radius: 12px; background: #fff; border: 1px solid #dfeae6; }
-.choices-box span { display: block; padding: 7px 9px; border-radius: 8px; background: #f4f8f6; font-weight: 700; }
+.choices-box { background: #fff; }
+.choices-box div { display: flex; flex-wrap: wrap; gap: 8px; }
+.choices-box span { display: inline-flex; padding: 7px 11px; border-radius: 999px; background: #f4f8f6; font-weight: 800; border: 1px solid #dfeae6; }
 .explanation-text-content { max-height: 56vh; font-size: 15px; }
 
 .focused-answer-area { display: grid; gap: 10px; min-width: 0; }
@@ -129,6 +229,11 @@
 .mobile-bottom-action { display: none; }
 .pc-answer-only { display: block; }
 
+.three-button-footer {
+  grid-template-columns: 1fr 1.35fr 1fr;
+  gap: 8px;
+}
+
 .grading-text-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(360px, .85fr); gap: 16px; align-items: start; }
 .grading-control-box { display: grid; gap: 12px; border: 1px solid #d8e8e4; border-radius: 14px; padding: 14px; background: #fff; }
 .status-button-grid { display: grid; grid-template-columns: repeat(2, minmax(140px, 1fr)); gap: 8px; }
@@ -152,6 +257,12 @@
 .large-textarea { min-height: 160px; line-height: 1.65; }
 .compact-material-grid { grid-template-columns: minmax(0, 1fr); }
 
+@media (min-width: 1180px) {
+  .study-app-shell {
+    width: min(100%, 1040px);
+  }
+}
+
 @media (max-width: 1100px) {
   .focused-question-header,
   .focused-answer-title,
@@ -164,20 +275,26 @@
 
 @media (max-width: 760px) {
   .problem-text-content { font-size: 16px; max-height: none; }
-  .app-like-problem-text { font-size: 17px; line-height: 1.9; padding: 16px; }
+  .app-like-problem-text { font-size: 17px; line-height: 1.9; }
+  .question-part { padding: 13px; }
+  .question-instruction p { font-size: 15px; }
   .focused-answer-area .answer-table-wrap { max-height: none; }
   .focused-practice-panel .journal-table,
   .focused-grading-panel .journal-table,
   .question-card-learning-flow .journal-table { min-width: 720px; }
   .mode-nav { position: static; grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .learning-top-bar { top: 0; border-radius: 0; margin: -4px -8px 0; }
+  .learning-top-bar { top: 0; border-radius: 0; margin: -4px -8px 0; grid-template-columns: auto minmax(0, 1fr) 72px; }
+  .study-progress-block { min-width: 72px; }
+  .study-progress-track { display: none; }
   .desktop-only-actions { display: none; }
   .pc-answer-only { display: none; }
   .mobile-journal-input { display: grid; }
-  .mobile-bottom-action { display: block; position: sticky; bottom: 0; z-index: 18; padding: 10px 0 calc(10px + env(safe-area-inset-bottom)); background: linear-gradient(180deg, rgba(238,246,242,.1), #eef6f2 35%); }
-  .mobile-bottom-action button { width: 100%; min-height: 58px; font-size: 18px; font-weight: 900; border-radius: 14px; }
+  .mobile-bottom-action { display: grid; position: sticky; bottom: 0; z-index: 18; padding: 10px 0 calc(10px + env(safe-area-inset-bottom)); background: linear-gradient(180deg, rgba(238,246,242,.1), #eef6f2 35%); }
+  .mobile-bottom-action button { min-height: 54px; font-size: 14px; font-weight: 900; border-radius: 14px; padding: 10px 8px; }
+  .mobile-bottom-action .accent { font-size: 17px; }
   .question-card-main { padding: 14px; }
   .focused-question-meta.subtle-meta span { font-size: 11px; padding: 4px 7px; }
+  .study-app-shell { width: 100%; }
   .app-shell { width: min(100vw, 100%); margin: 0 auto 32px; padding: 0 8px; }
   .app-header,
   .panel { border-radius: 10px; }


### PR DESCRIPTION
## 1. 今回の目的

PR #241 でQuestionCard型とスマホ学習アプリ型の基礎導線は入りましたが、添付されたスタディング系の演習画面に近い「上部進捗・中央の白い問題カード・問題文直下の答案欄・スマホ下部固定ボタン」という学習体験としては、まだ詰めが不足していました。

今回の目的は機能追加ではなく、既存実装資産を壊さずに、学習画面をさらに1問集中型へ寄せるUI再設計です。

## 2. 変更内容

### 学習画面の上部ヘッダー改善

`FocusedPracticePanel` に、以下を表示する学習用トップバーを追加・整理しました。

- 問題一覧へ
- 今すぐ解く
- 科目 / 大問対策
- 論点名
- 現在何問目 / 全体何問
- 進捗バー

### 問題カードの構造化

PDF抽出テキストを単なる長文表示ではなく、画面上で以下の構造に分けて表示します。

- 問題指示
- 取引・条件・資料
- 選択肢
- 注意書き

また、4桁以上の数字は表示時に3桁カンマへ整形します。

### 学習アプリ型ボタン文言への整理

学習画面の主要ボタンを、より演習導線に合うように整理しました。

- `採点へ進む` だけでなく、学習中の主操作として `解答する` を表示
- スマホ下部固定フッターを3ボタン化
  - メモ/保存
  - 解答する
  - 次へ

### PC中央カラム化

PCでは、問題カードと答案入力が横に散らばらないよう、学習画面全体を中央カラム寄せにしました。

答案入力テーブルは従来通りPCで表示され、既存のExcel風操作を維持します。

### スマホUIの改善

スマホでは、以下を強化しました。

- 上部バーをコンパクト化
- 問題文を白いカード内で読みやすく表示
- 横長テーブルを強制せず、既存のスマホ用仕訳カード入力を維持
- 下部固定フッターを片手操作しやすい3ボタンに変更

## 3. 変更ファイル

- `cpa-boki2-trial-section-answer-manager/src/components/FocusedPracticePanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/focusedPractice.css`

## 4. 既存案件管理アプリへの影響

影響なしです。

以下は変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- `.github/workflows/pages.yml`

## 5. 著作権・保存方針

今回も以下は行っていません。

- 教材PDFをGitHubに保存
- 教材PDFをpublicフォルダへ配置
- 教材PDFをsrc配下へ配置
- 教材本文をコードへ埋め込み
- PDFや抽出テキストを外部サーバーへ送信
- Supabase同期
- OCR
- AI解説
- 自動採点

## 6. 維持した既存機能

- QuestionCard表示
- 原本を見るボタン
- PC用AnswerTable
- スマホ用JournalEntryCardInput
- 3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリック編集
- Esc解除
- 行追加
- 空行整理
- 履歴保存
- 復習管理
- JSONバックアップ
- 90分セット演習
- 合格到達マップ

## 7. 動作確認

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 8. 実URLで確認すべき項目

マージ後、以下を確認してください。

- 初期表示で「今すぐ解く」が開く
- 上部に現在位置・科目・論点・進捗が表示される
- 問題文が中央の白い問題カードに表示される
- 問題文が「問題指示」「取引・条件・資料」「選択肢」「注意書き」に分かれる
- 答案入力欄が問題文の直下にある
- PCでは答案入力テーブルが広く表示される
- スマホでは下部固定フッターに「メモ/保存」「解答する」「次へ」が表示される
- スマホで横長テーブルが強制表示されない
- 原本PDFは必要時だけ開ける
- 管理機能が学習画面に常時表示されていない

## 9. 未確認事項

この環境では、マージ後のGitHub Pages実URL表示とブラウザConsole確認までは実施していません。

Actions成功後、実URLでPC・スマホ表示を確認してください。