### PR TITLE
Simplify CPA Boki2 app to answer review tool

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createRows } from './components/AnswerTable';
+import { AnswerPracticePanel } from './components/AnswerPracticePanel';
 import { BackupSafetyPanel } from './components/BackupSafetyPanel';
 import { DashboardPanel } from './components/DashboardPanel';
 import { ExamSetPanel } from './components/ExamSetPanel';
 import { FocusedGradingPanel } from './components/FocusedGradingPanel';
-import { FocusedPracticePanel } from './components/FocusedPracticePanel';
 import { HistoryPanel } from './components/HistoryPanel';
 import { MasteryMapPanel } from './components/MasteryMapPanel';
 import { MaterialSetupWorkspace } from './components/MaterialSetupWorkspace';
@@ -50,7 +50,7 @@ import { currentAnswerCsvRows, dashboardCsvRows, downloadCsv, downloadText, exam
 import { chooseQuickStartProblem } from './utils/disposableStudy';
 import { isDueTodayOrEarlier, nowIso, reviewDateForRank } from './utils/dates';
 import { buildMasteryMap } from './utils/mastery';
-import { fallbackQuestionCard, questionCardFromMapping } from './utils/questionCards';
+import { questionCardFromMapping } from './utils/questionCards';
 import { buildRecoveryPlan } from './utils/recovery';
 import { rankFromSelfGrading, updateReviewStateFromGrading } from './utils/reviewScheduler';
 import { draftSummary, hasMeaningfulAnswer, sumRowPoints } from './utils/scoring';
@@ -59,7 +59,7 @@ import { buildStudyQueue } from './utils/studyQueue';
 import './styles.css';
 
 type HistoryFilter = 'all' | 'today' | 'overdue' | 'c' | 'b';
-type AppMode = 'study' | 'grading' | 'materials' | 'progress';
+type AppMode = 'solve' | 'review' | 'progress';
 
 function createAnswer(problemId: string, templateId: TemplateId): AnswerState {
   const template = getTemplateById(templateId);
@@ -155,13 +155,12 @@ export default function App() {
   const [safetyInfo, setSafetyInfo] = useState<StorageSafetyInfo | null>(null);
   const [message, setMessage] = useState('待機中');
   const [historyFilter, setHistoryFilter] = useState<HistoryFilter>('all');
-  const [mode, setMode] = useState<AppMode>('study');
+  const [mode, setMode] = useState<AppMode>('solve');
 
   const problem = useMemo(() => getProblemById(problemId), [problemId]);
   const template = useMemo(() => getTemplateById(answer.templateId), [answer.templateId]);
   const currentMapping = useMemo(() => pdfMappings.find((item) => item.problemId === problemId), [pdfMappings, problemId]);
-  const currentQuestionCard = useMemo(() => questionCards.find((card) => card.sourceProblemId === problemId || card.id === problemId) ?? (currentMapping ? questionCardFromMapping(currentMapping) : fallbackQuestionCard(problem)), [questionCards, currentMapping, problem, problemId]);
-  const currentPdf = useMemo(() => materialPdfs.find((item) => item.id === currentQuestionCard.sourceMaterialId || item.id === currentMapping?.materialPdfId), [materialPdfs, currentQuestionCard.sourceMaterialId, currentMapping?.materialPdfId]);
+  const currentPdf = useMemo(() => materialPdfs.find((item) => item.id === currentMapping?.materialPdfId), [materialPdfs, currentMapping?.materialPdfId]);
   const studyQueue = useMemo(() => buildStudyQueue(histories), [histories]);
   const masteryMap = useMemo(() => buildMasteryMap(histories), [histories]);
   const recoveryPlan = useMemo(() => buildRecoveryPlan(histories, examSets), [histories, examSets]);
@@ -269,7 +268,7 @@ export default function App() {
     const reviewState = updateReviewStateFromGrading({ problemId: problem.id, previous: currentReviewState, status: input.status, score: input.score, maxScore: input.maxScore });
     const scored = normalizeAnswer({ ...answer, score: input.score, maxScore: input.maxScore, scored: true, scoringStarted: true, scoredAt: submittedAt, rank, nextReviewDate: reviewState.nextReviewDate, reviewMemo: input.memo || answer.reviewMemo, updatedAt: submittedAt });
     const session = activeSession && activeSession.problemId === problem.id && !activeSession.completed ? activeSession : await startCurrentSession();
-    const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, openedExplanation: Boolean(currentMapping?.answerText || currentMapping?.explanationText), memo: input.memo, completed: true };
+    const completedSession: PracticeSession = { ...session, submittedAt, durationSeconds: secondsBetween(session.startedAt, submittedAt), answerSnapshot: scored, gradingResult: { status: input.status, score: input.score, maxScore: input.maxScore, scoreRate: input.maxScore > 0 ? Math.round((input.score / input.maxScore) * 1000) / 10 : 0, autoGraded: false, detailRows: [] }, reviewState, openedAnswer: true, openedExplanation: false, memo: input.memo, completed: true };
     await saveAnswer(scored);
     await addHistory(buildHistory(scored));
     await saveReviewState(reviewState);
@@ -281,7 +280,7 @@ export default function App() {
     await openNextProblem();
   }
 
-  const restoreHistory = async (entry: HistoryEntry) => { if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return; const restored = normalizeAnswer(entry.snapshot); await saveAnswer(restored); setProblemId(entry.problemId); setAnswer(restored); setMode('study'); await refreshAll(); setMessage('履歴を復元しました'); };
+  const restoreHistory = async (entry: HistoryEntry) => { if (!window.confirm('現在の画面を上書きして、この履歴を復元しますか？')) return; const restored = normalizeAnswer(entry.snapshot); await saveAnswer(restored); setProblemId(entry.problemId); setAnswer(restored); setMode('solve'); await refreshAll(); setMessage('履歴を復元しました'); };
   const deleteHistoryEntry = async (id: string) => { if (!window.confirm('この履歴を削除しますか？')) return; await deleteHistory(id); await refreshAll(); setMessage('履歴を削除しました'); };
   const clearAllHistories = async () => { if (!window.confirm('履歴を全削除しますか？答案データは消えません。')) return; await clearHistories(); await refreshAll(); setMessage('履歴を全削除しました'); };
   const saveCard = async (card: MistakeCard) => { await saveMistakeCard(card); await loadMistakeCards(); setMessage('白紙再現・解き直しカードを保存しました'); };
@@ -306,24 +305,21 @@ export default function App() {
   const importJson = async (file: File | undefined) => { if (!file) return; try { const payload = JSON.parse(await file.text()) as BackupPayload; await importAllData(payload); await loadProblem(problemId); await refreshAll(); setMessage('JSONバックアップを復元しました。PDF本体・抽出テキストは端末内データを維持する仕様です。'); } catch { setMessage('JSONの形式が不正です'); } };
 
   const saveExamSetRecord = async (record: ExamSetRecord) => { const relatedHistoryIds: string[] = []; for (const problemState of record.problemStates) { if (problemState.rank !== 'B' && problemState.rank !== 'C') continue; const problemDefinition = getProblemById(problemState.problemId); const base = createAnswer(problemState.problemId, problemDefinition.defaultTemplateId); const scored = normalizeAnswer({ ...base, score: Number(problemState.score) || 0, rowPointsTotal: Number(problemState.score) || 0, rank: problemState.rank, nextReviewDate: reviewDateForRank(problemState.rank), reviewMemo: `90分セット演習「${record.name}」から登録。${record.memo}`, scored: true, scoredAt: nowIso(), updatedAt: nowIso() }); const history = buildHistory(scored); relatedHistoryIds.push(history.id); await addHistory(history); } await saveExamSet({ ...record, relatedHistoryIds }); await refreshAll(); setMessage('90分セット演習履歴を保存しました。B/C判定の問題は復習キューにも反映しました。'); };
-  const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('study'); };
+  const openNextProblem = async () => { const next = studyQueue[0]?.problem.id ?? quickChoice.problemId; await loadProblem(next); setMode('solve'); };
 
   return (
-    <main className="app-shell redesigned-shell">
-      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>問題文を読む → 答案入力 → 採点 → 次回復習日へ回す、を最短で回すための学習画面です。</p></div><Timer /></header>
-      <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'study' ? 'active' : ''} onClick={() => setMode('study')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'materials' ? 'active' : ''} onClick={() => setMode('materials')}>教材を設定する</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>復習を見る</button></nav>
+    <main className="app-shell simplified-shell">
+      <header className="app-header compact-header"><div><h1>CPA日商簿記2級 試験対策編 解答・復習管理アプリ</h1><p>教材本文は本またはPDFで確認し、このアプリでは答案入力・自己採点・復習日管理に集中します。</p></div><Timer /></header>
+      <nav className="mode-nav" aria-label="学習モード切替"><button className={mode === 'solve' ? 'active' : ''} onClick={() => setMode('solve')}>解く</button><button className={mode === 'review' ? 'active' : ''} onClick={() => setMode('review')}>採点・復習</button><button className={mode === 'progress' ? 'active' : ''} onClick={() => setMode('progress')}>進捗・管理</button></nav>
       <div className="status-bar">{message}</div>
 
-      {mode === 'study' && <section className="mode-section study-mode-section">
-        {currentQuestionCard.needsReview && <section className="panel first-use-steps"><h2>問題カードの確認が必要です</h2><div><span>1. 教材を設定する</span><span>2. 抽出結果を整形する</span><span>3. 今すぐ解く</span></div><button className="accent" onClick={() => setMode('materials')}>教材を設定する</button></section>}
-        <FocusedPracticePanel problem={problem} questionCard={currentQuestionCard} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} totalToday={Math.max(1, studyQueue.length || 1)} progressIndex={progressIndex} onChange={updateAnswer} onSave={manualSave} onGoGrading={() => setMode('grading')} onNextProblem={openNextProblem} onApplyRowPoints={applyRowPoints} />
+      {mode === 'solve' && <section className="mode-section solve-mode-section">
+        <AnswerPracticePanel problem={problem} answer={answer} template={template} progressIndex={progressIndex} totalToday={Math.max(1, studyQueue.length || 1)} onSelectProblem={loadProblem} onSelectTemplate={(templateId) => updateAnswer({ ...answer, templateId, templateName: getTemplateById(templateId).name, columns: getTemplateById(templateId).columns, rows: createRows(getTemplateById(templateId).columns.length, getTemplateById(templateId).initialRows) })} onChange={updateAnswer} onSave={manualSave} onGoGrading={() => setMode('review')} onNextProblem={openNextProblem} onApplyRowPoints={applyRowPoints} />
       </section>}
 
-      {mode === 'grading' && <FocusedGradingPanel problem={problem} answer={answer} template={template} mapping={currentMapping} pdf={currentPdf} onChange={updateAnswer} onSave={manualSave} onApplyRowPoints={applyRowPoints} onSubmitSelfGrading={submitSelfGrading} onBackPractice={() => setMode('study')} />}
+      {mode === 'review' && <FocusedGradingPanel problem={problem} answer={answer} template={template} onChange={updateAnswer} onSave={manualSave} onApplyRowPoints={applyRowPoints} onSubmitSelfGrading={submitSelfGrading} onBackPractice={() => setMode('solve')} />}
 
-      {mode === 'materials' && <MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} />}
-
-      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">復習を見る</p><h2>今日やる問題だけ先に見る</h2><p>詳細な管理機能は下の折りたたみの中に退避しています。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やる問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div><div><strong>{progressSummary.last7Days}</strong><span>直近7日演習</span></div><div><strong>{progressSummary.last30Days}</strong><span>直近30日演習</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次に解く</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details></section>}
+      {mode === 'progress' && <section className="mode-section progress-mode-section"><section className="panel mode-card progress-overview-panel"><div><p className="eyebrow">進捗・管理</p><h2>今日やる問題だけ先に見る</h2><p>PDF関連機能は実験機能として下部に退避しています。通常演習では教材本文を本・PDFで確認してください。</p></div><div className="progress-summary-grid"><div><strong>{progressSummary.dueToday}</strong><span>今日やる問題</span></div><div><strong>{progressSummary.overdue}</strong><span>期限超過</span></div><div><strong>{progressSummary.cRank}</strong><span>C判定</span></div><div><strong>{progressSummary.untouched}</strong><span>未着手</span></div><div><strong>{progressSummary.last7Days}</strong><span>直近7日演習</span></div><div><strong>{progressSummary.last30Days}</strong><span>直近30日演習</span></div></div><button className="resume-button" onClick={() => { void openNextProblem(); }}>次に解く</button></section><details className="panel management-panel" open><summary>今日の復習・期限超過・C/B判定</summary><StudyQueuePanel items={studyQueue} onStart={loadProblem} onRestoreLatest={(item) => item.latestHistory && restoreHistory(item.latestHistory)} onExportCsv={exportStudyQueueCsv} /></details><details className="panel management-panel"><summary>合格到達マップ</summary><MasteryMapPanel histories={histories} onOpenProblem={loadProblem} onExportCsv={exportMasteryCsv} /></details><details className="panel management-panel"><summary>白紙再現カード</summary><MistakeCardPanel problem={problem} answer={answer} cards={mistakeCards} onSave={saveCard} onDelete={removeCard} onExportCsv={exportMistakeCardsCsv} /></details><details className="panel management-panel"><summary>70点リカバリー表・90分セット</summary><RecoveryPlanPanel histories={histories} examSets={examSets} onExportCsv={exportRecoveryCsv} /><ExamSetPanel histories={histories} examSets={examSets} onSave={saveExamSetRecord} onOpenProblem={loadProblem} onExportCsv={exportExamSetCsv} /></details><details className="panel management-panel"><summary>履歴一覧・復習管理</summary><ReviewPanel histories={histories} /><HistoryPanel histories={histories} filter={historyFilter} onFilter={setHistoryFilter} onRestore={restoreHistory} onDelete={deleteHistoryEntry} onClear={clearAllHistories} /></details><details className="panel management-panel"><summary>CSV出力・JSONバックアップ・保存状態</summary><div className="top-actions management-actions"><button className="danger" onClick={clearCurrentAnswer}>現在問題IDの答案を全消去</button><button onClick={bulkAddAllAnswers}>保存済み答案を一括履歴追加</button><button onClick={exportCurrentCsv}>現在問題IDの答案CSV</button><button onClick={exportHistoryCsv}>履歴一覧CSV</button><button onClick={exportReviewCsv}>復習対象CSV</button><button onClick={exportProblemStatsCsv}>問題ID別成績CSV</button><button onClick={exportMissReasonCsv}>ミス原因別集計CSV</button><button onClick={exportDashboardCsv}>ダッシュボードCSV</button><button onClick={exportExamSetCsv}>90分セットCSV</button><button onClick={exportMasteryCsv}>合格到達マップCSV</button><button onClick={exportRecoveryCsv}>70点リカバリーCSV</button><button onClick={exportJson}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(event) => importJson(event.target.files?.[0])} /></label><button onClick={() => window.print()}>印刷</button></div><BackupSafetyPanel info={safetyInfo} onBackup={exportJson} onRestoreFile={importJson} onRefresh={refreshSafety} onMessage={setMessage} /><DashboardPanel histories={histories} answerCount={answers.length} onExportCsv={exportDashboardCsv} /></details><details className="panel management-panel"><summary>実験機能：PDF教材設定・抽出</summary><p className="warning-text">PDF表示・PDF抽出は実験機能です。通常演習では使用せず、教材本文は本またはPDFで確認してください。</p><MaterialSetupWorkspace pdfs={materialPdfs} mappings={pdfMappings} selectedProblemId={problemId} onSavePdf={savePdf} onDeletePdf={removePdf} onSaveMapping={savePdfMapping} onDeleteMapping={removePdfMapping} onOpenProblem={loadProblem} onMessage={setMessage} /></details></section>}
     </main>
   );
 }

--- a/cpa-boki2-trial-section-answer-manager/src/components/AnswerPracticePanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AnswerPracticePanel.tsx
@@ -1,0 +1,75 @@
+import type { AnswerState, ProblemDefinition, TemplateDefinition, TemplateId } from '../types';
+import { AnswerTable } from './AnswerTable';
+import { ProblemSelector } from './ProblemSelector';
+
+interface Props {
+  problem: ProblemDefinition;
+  answer: AnswerState;
+  template: TemplateDefinition;
+  progressIndex: number;
+  totalToday: number;
+  onSelectProblem: (problemId: string) => void;
+  onSelectTemplate: (templateId: TemplateId) => void;
+  onChange: (answer: AnswerState) => void;
+  onSave: () => void;
+  onGoGrading: () => void;
+  onNextProblem: () => void;
+  onApplyRowPoints: () => void;
+}
+
+export function AnswerPracticePanel({ problem, answer, template, progressIndex, totalToday, onSelectProblem, onSelectTemplate, onChange, onSave, onGoGrading, onNextProblem, onApplyRowPoints }: Props) {
+  return (
+    <section className="answer-practice-shell">
+      <section className="panel practice-hero-card">
+        <div>
+          <p className="eyebrow">解く</p>
+          <h2>{problem.displayId}：{problem.topic}</h2>
+          <p className="practice-notice">問題文はお手元の教材・PDFで確認してください。この画面では答案入力と復習管理だけを行います。</p>
+        </div>
+        <div className="practice-progress-box">
+          <strong>{Math.max(1, progressIndex)} / {Math.max(1, totalToday)}</strong>
+          <span>今日の学習キュー</span>
+        </div>
+      </section>
+
+      <div className="answer-practice-layout">
+        <ProblemSelector selectedProblem={problem} selectedTemplateId={answer.templateId} onSelectProblem={onSelectProblem} onSelectTemplate={onSelectTemplate} />
+
+        <section className="answer-workspace">
+          <section className="panel answer-summary-card">
+            <div className="answer-summary-grid">
+              <div><span>科目</span><strong>{problem.subject}</strong></div>
+              <div><span>大問対策</span><strong>{problem.sectionLabel}</strong></div>
+              <div><span>問題ID</span><strong>{problem.displayId}</strong></div>
+              <div><span>論点名</span><strong>{problem.topic}</strong></div>
+              <div><span>想定時間</span><strong>教材側で確認</strong></div>
+              <div><span>テンプレート</span><strong>{template.name}</strong></div>
+            </div>
+            <div className="button-row answer-primary-actions">
+              <button onClick={onSave}>一時保存</button>
+              <button className="accent" onClick={onGoGrading}>採点へ進む</button>
+              <button className="secondary" onClick={onNextProblem}>次の問題へ</button>
+            </div>
+          </section>
+
+          <section className="focused-answer-area answer-input-main answer-only-main">
+            <div className="focused-answer-title">
+              <div>
+                <p className="eyebrow">答案入力</p>
+                <h2>{template.name}</h2>
+              </div>
+              <button className="secondary" onClick={onApplyRowPoints}>行別得点合計を反映</button>
+            </div>
+            <AnswerTable answer={answer} template={template} onChange={onChange} onApplyRowPoints={onApplyRowPoints} />
+          </section>
+
+          <section className="panel draft-memo-panel">
+            <label>下書きメモ・計算過程
+              <textarea value={answer.draftMemo} onChange={(event) => onChange({ ...answer, draftMemo: event.target.value })} placeholder="本・PDFを見ながら、仕訳メモ、計算過程、次に確認する点だけを残します。" />
+            </label>
+          </section>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx
@@ -1,15 +1,12 @@
 import { useState } from 'react';
-import type { AnswerState, GradingStatus, MaterialPdf, MaterialPdfMapping, MissReason, ProblemDefinition, ReviewRank, TemplateDefinition } from '../types';
+import type { AnswerState, GradingStatus, MissReason, ProblemDefinition, ReviewRank, TemplateDefinition } from '../types';
 import { reviewDateForRank } from '../utils/dates';
 import { AnswerTable } from './AnswerTable';
-import { PdfViewerPanel } from './PdfViewerPanel';
 
 interface Props {
   problem: ProblemDefinition;
   answer: AnswerState;
   template: TemplateDefinition;
-  mapping?: MaterialPdfMapping;
-  pdf?: MaterialPdf;
   onChange: (answer: AnswerState) => void;
   onSave: () => void;
   onApplyRowPoints: () => void;
@@ -20,21 +17,14 @@ interface Props {
 const gradingStatuses: GradingStatus[] = ['正解', '部分正解', '不正解', '迷いあり'];
 const missReasons: MissReason[] = ['論点理解不足', '仕訳ミス', '借方貸方逆', '金額ミス', '集計ミス', '転記ミス', '表の入力位置ミス', '下書き不足', '時間不足', '解答欄形式の誤認', '問題文読み落とし', 'その他'];
 
-function extractedAnswer(mapping?: MaterialPdfMapping): string {
-  return [mapping?.answerText, mapping?.explanationText].filter(Boolean).join('\n\n') || '教材設定画面でPDFから解答・解説テキストを抽出すると、ここに端末内データとして表示されます。未設定の場合は、原本PDFまたは教材を見ながら自己採点してください。';
-}
-
 function nextRankFromStatus(status: GradingStatus): ReviewRank {
   if (status === '正解') return 'A';
   if (status === '部分正解' || status === '迷いあり') return 'B';
   return 'C';
 }
 
-export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, onChange, onSave, onApplyRowPoints, onSubmitSelfGrading, onBackPractice }: Props) {
+export function FocusedGradingPanel({ problem, answer, template, onChange, onSave, onApplyRowPoints, onSubmitSelfGrading, onBackPractice }: Props) {
   const [status, setStatus] = useState<GradingStatus>('迷いあり');
-  const [showOriginal, setShowOriginal] = useState(false);
-  const [page, setPage] = useState(mapping?.answerPageStart ?? mapping?.answerPages?.[0] ?? mapping?.explanationPages?.[0] ?? 1);
-  const explanation = extractedAnswer(mapping);
 
   const setRank = (rank: ReviewRank) => onChange({ ...answer, rank, nextReviewDate: reviewDateForRank(rank) });
   const toggleReason = (reason: MissReason) => {
@@ -48,29 +38,25 @@ export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, o
   };
 
   return (
-    <section className="focused-grading-panel">
+    <section className="focused-grading-panel self-grading-only">
       <section className="panel focused-question-card">
         <div className="focused-question-header">
           <div>
-            <p className="eyebrow">採点する</p>
+            <p className="eyebrow">採点・復習</p>
             <h2>{problem.displayId}：{problem.topic}</h2>
-            <p>自分の回答を見ながら、端末内に抽出した解答・解説テキストで自己採点します。</p>
+            <p>解答・解説はお手元の教材・PDFで確認し、この画面では自己採点、ミス原因、次回復習日だけを保存します。</p>
           </div>
           <div className="button-row focused-main-actions">
             <button className="secondary" onClick={onBackPractice}>答案入力へ戻る</button>
-            {pdf && <button className="secondary" onClick={() => setShowOriginal((current) => !current)}>{showOriginal ? '原本を閉じる' : '原本を見る'}</button>}
             <button onClick={onSave}>一時保存</button>
             <button className="accent" onClick={() => { void onSubmitSelfGrading({ status, score: answer.score, maxScore: answer.maxScore, memo: answer.reviewMemo }); }}>保存して次へ進む</button>
           </div>
         </div>
 
-        <div className="grading-text-grid">
-          <div className="problem-text-box">
-            <div className="problem-text-toolbar"><strong>解答・解説テキスト</strong><span>端末内PDF抽出データ</span></div>
-            <div className="problem-text-content explanation-text-content">{explanation}</div>
-          </div>
-          <div className="grading-control-box">
+        <div className="grading-text-grid simplified-grading-grid">
+          <div className="grading-control-box self-score-box">
             <h3>自己採点</h3>
+            <p className="notice-small">自動採点は行いません。教材の解答・解説を見ながら、得点と判定を入力してください。</p>
             <div className="status-button-grid">
               {gradingStatuses.map((item) => <button key={item} className={status === item ? 'accent' : 'secondary'} onClick={() => applyStatus(item)}>{item}</button>)}
             </div>
@@ -87,8 +73,6 @@ export function FocusedGradingPanel({ problem, answer, template, mapping, pdf, o
             <label>復習メモ<textarea value={answer.reviewMemo} onChange={(event) => onChange({ ...answer, reviewMemo: event.target.value })} placeholder="次回解く前に見る注意点" /></label>
           </div>
         </div>
-
-        {showOriginal && <PdfViewerPanel pdf={pdf} title={pdf?.title ?? 'PDF原本'} label="解答・解説原本" page={page} pageStart={mapping?.answerPageStart ?? 1} pageEnd={mapping?.explanationPageEnd ?? pdf?.pageCount ?? 1} onPageChange={setPage} onClose={() => setShowOriginal(false)} />}
       </section>
 
       <section className="focused-answer-area">

--- a/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
+++ b/cpa-boki2-trial-section-answer-manager/src/focusedPractice.css
@@ -1,9 +1,139 @@
 .focused-practice-panel,
 .focused-grading-panel,
 .material-text-setup,
-.question-card-learning-flow {
+.question-card-learning-flow,
+.answer-practice-shell {
   display: grid;
   gap: 16px;
+}
+
+.simplified-shell {
+  width: min(1800px, 98vw);
+}
+
+.answer-practice-shell {
+  width: 100%;
+}
+
+.practice-hero-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  border: 2px solid #b8dfc2;
+  background: #fff;
+}
+
+.practice-notice {
+  margin: 8px 0 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #f2faf6;
+  border: 1px solid #cfe5dc;
+  line-height: 1.7;
+  font-weight: 800;
+  color: #1e4f43;
+}
+
+.practice-progress-box {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  min-width: 130px;
+  padding: 12px;
+  border-radius: 14px;
+  background: #eef7f4;
+  border: 1px solid #d3e7e2;
+}
+
+.practice-progress-box strong {
+  color: #0f5c68;
+  font-size: 26px;
+}
+
+.practice-progress-box span {
+  font-weight: 800;
+  color: #55706c;
+  font-size: 12px;
+}
+
+.answer-practice-layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.answer-workspace {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.answer-summary-card {
+  display: grid;
+  gap: 14px;
+}
+
+.answer-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.answer-summary-grid > div {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 12px;
+  background: #f7fbf9;
+  border: 1px solid #d9e9e3;
+}
+
+.answer-summary-grid span {
+  color: #5d6e68;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.answer-summary-grid strong {
+  color: #173f35;
+  font-size: 15px;
+  word-break: break-word;
+}
+
+.answer-primary-actions {
+  justify-content: flex-end;
+}
+
+.answer-primary-actions button {
+  min-height: 44px;
+  font-weight: 900;
+}
+
+.answer-only-main {
+  padding: 0;
+}
+
+.answer-only-main .answer-panel {
+  border: 2px solid #b8dfc2;
+}
+
+.draft-memo-panel textarea {
+  min-height: 92px;
+}
+
+.self-grading-only {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+}
+
+.simplified-grading-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.self-score-box {
+  max-width: 980px;
 }
 
 .study-app-shell {
@@ -268,9 +398,12 @@
   .focused-answer-title,
   .grading-text-grid,
   .setup-step-grid,
-  .candidate-review-layout { grid-template-columns: 1fr; }
+  .candidate-review-layout,
+  .answer-practice-layout,
+  .practice-hero-card { grid-template-columns: 1fr; }
   .focused-main-actions { justify-content: stretch; }
   .focused-main-actions button { flex: 1 1 160px; }
+  .practice-progress-box { justify-items: start; width: 100%; }
 }
 
 @media (max-width: 760px) {
@@ -282,7 +415,7 @@
   .focused-practice-panel .journal-table,
   .focused-grading-panel .journal-table,
   .question-card-learning-flow .journal-table { min-width: 720px; }
-  .mode-nav { position: static; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .mode-nav { position: static; grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .learning-top-bar { top: 0; border-radius: 0; margin: -4px -8px 0; grid-template-columns: auto minmax(0, 1fr) 72px; }
   .study-progress-block { min-width: 72px; }
   .study-progress-track { display: none; }
@@ -294,7 +427,10 @@
   .mobile-bottom-action .accent { font-size: 17px; }
   .question-card-main { padding: 14px; }
   .focused-question-meta.subtle-meta span { font-size: 11px; padding: 4px 7px; }
-  .study-app-shell { width: 100%; }
+  .study-app-shell,
+  .answer-practice-shell { width: 100%; }
+  .answer-summary-grid { grid-template-columns: 1fr; }
+  .answer-primary-actions button { flex: 1 1 140px; }
   .app-shell { width: min(100vw, 100%); margin: 0 auto 32px; padding: 0 8px; }
   .app-header,
   .panel { border-radius: 10px; }


### PR DESCRIPTION
## 1. 今回の目的

直近のPDF取込・PDF表示・PDFテキスト抽出・スタディング風UI化は、現時点では学習効率に対して開発コストが重く、実運用では使いづらい状態でした。

今回の目的は機能追加ではなく、損切り・整理です。

アプリをいったん「問題本文まで完結する学習アプリ」ではなく、6月末の簿記2級合格に向けた **答案入力・自己採点・復習日管理・進捗管理ツール** に戻しました。

## 2. 修正内容

### 学習画面を答案入力中心へ戻す

初期表示を `解く` にし、学習画面には以下だけを出す構成へ戻しました。

- 科目
- 大問対策
- 問題ID
- 論点名
- テンプレート
- 答案入力テーブル
- 下書きメモ
- 一時保存
- 採点へ進む
- 次の問題へ

問題本文は表示しません。

代わりに、以下の注意文を明示しています。

> 問題文はお手元の教材・PDFで確認してください。この画面では答案入力と復習管理だけを行います。

### 3モードへ整理

モードを以下の3つに整理しました。

1. 解く
2. 採点・復習
3. 進捗・管理

従来の `教材を設定する` は通常モードから外し、PDF関連機能は `進捗・管理` の中の実験機能として退避しました。

### PDF関連機能を学習画面から退避

以下は削除せず、実験機能として奥に退避しました。

- PDF教材設定
- PDF取込
- PDF抽出
- PDF紐づけ
- 問題カード化

通常演習では使わない前提にし、進捗・管理画面の下部に以下の注意付きで格納しています。

> PDF表示・PDF抽出は実験機能です。通常演習では使用せず、教材本文は本またはPDFで確認してください。

### 採点画面を自己採点専用へ整理

採点画面からPDF抽出テキスト表示を外しました。

表示するものは以下です。

- 自分の回答
- 得点
- 満点
- 正解 / 部分正解 / 不正解 / 迷いあり
- A/B/C判定
- ミス原因
- 次回復習日
- 復習メモ
- 保存して次へ進む

解答・解説は、手元の教材・PDFで確認する前提に戻しています。

## 3. 変更ファイル

- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/AnswerPracticePanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/FocusedGradingPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/focusedPractice.css`

## 4. 既存案件管理アプリへの影響

影響なしです。

以下は変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- `.github/workflows/pages.yml`

## 5. 維持した機能

以下は維持しています。

- 答案入力テーブル
- 3桁カンマ
- 全角数字から半角数字への正規化
- 矢印キー移動
- F2 / ダブルクリック編集
- Esc解除
- 行追加
- 列追加
- 空行整理
- 行別採点
- 行別得点合計反映
- 自動保存
- 手動保存
- 自己採点
- A/B/C判定
- 次回復習日
- 履歴保存
- 履歴復元
- 今日の学習キュー
- 合格到達マップ
- 白紙再現カード
- 70点リカバリー表
- 90分セット演習
- JSONバックアップ
- CSV出力

## 6. 著作権・保存方針

今回も以下は行っていません。

- 教材PDFをGitHubに保存
- 教材PDFをpublicフォルダへ配置
- 教材PDFをsrc配下へ配置
- 教材本文をコードへ埋め込み
- PDFや抽出テキストを外部サーバーへ送信
- Supabase同期
- OCR
- AI解説
- 自動採点

## 7. 動作確認

GitHub Actions の `CPA Boki2 App Build Check` が成功しました。

確認内容:

- `npm install`
- `npm run build`

## 8. 実URLで確認すべき項目

マージ後、以下を確認してください。

- 初期表示が `解く` になっている
- PDFや教材設定が学習画面に出てこない
- 問題文表示欄がない
- `問題文はお手元の教材・PDFで確認してください` の注意文が出る
- 問題ID選択ができる
- 答案入力テーブルが広く見える
- 一時保存ができる
- 採点・復習へ進める
- 得点、ミス原因、次回復習日を保存できる
- 今日の復習キューに反映される
- PDF関連機能は進捗・管理内の実験機能に退避されている
- 既存案件管理アプリに影響がない

## 9. 未確認事項

この環境では、マージ後のGitHub Pages実URL表示とブラウザConsole確認までは実施していません。

Actions成功後、実URLでPC表示とスマホ表示を確認してください。