### PR TITLE
Add Boki2 dual study modes for trial section practice

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/App.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/App.tsx
@@ -1,307 +1,82 @@
 import { useEffect, useMemo, useState } from 'react';
-import { originalQuestions } from './data/originalQuestions';
-import type { AnswerAttempt, AnswerLine, AnswerTemplateId, MissReason, QuestionItem, ReviewRank, ReviewSchedule, SourceType, StudyBackupPayload } from './originalStudyTypes';
-import { exportStudyData, getAttempts, getReviewSchedules, getStoredQuestions, importStudyData, saveAttempt, saveQuestion, saveReviewSchedule, storageSummary } from './originalStudyStorage';
+import { externalProblemRefs } from './data/cpaTrialSections';
+import { approvedOriginalQuestions, draftOriginalQuestions, originalQuestions } from './data/originalQuestions';
+import type { AnswerAttempt, AnswerLine, AnswerTemplateId, ExternalProblemRef, MissReason, PracticeItem, QuestionItem, ReviewRank, ReviewSchedule, StudyBackupPayload, StudyMode } from './originalStudyTypes';
+import { exportStudyData, getAttempts, getReviewSchedules, getStoredExternalProblemRefs, getStoredQuestions, importStudyData, saveAttempt, saveExternalProblemRef, saveQuestion, saveReviewSchedule, storageSummary } from './originalStudyStorage';
 import './styles.css';
 
 type AppMode = 'solve' | 'grading' | 'review' | 'management';
-
-type QuestionForm = Omit<QuestionItem, 'conditions' | 'modelAnswer'> & {
-  conditionsText: string;
-  modelAnswerJson: string;
-};
+type ActiveStudyChoice = 'external_material' | 'built_in_question';
 
 const missReasons: MissReason[] = ['論点理解不足', '仕訳ミス', '借方貸方逆', '金額ミス', '集計ミス', '転記ミス', '表の入力位置ミス', '下書き不足', '時間不足', '解答形式の誤認', '問題文読み落とし', 'その他'];
-const templateLabels: Record<AnswerTemplateId, string> = { journal: '仕訳テンプレート', numeric: '数値入力テンプレート', statementTable: '表形式テンプレート', free: '自由テンプレート' };
-const sourceTypes: SourceType[] = ['original', 'public_domain', 'licensed', 'user_created'];
-
-function todayString(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function addDays(days: number): string {
-  const date = new Date();
-  date.setDate(date.getDate() + days);
-  return date.toISOString().slice(0, 10);
-}
-
-function newLine(itemName = ''): AnswerLine {
-  return { id: crypto.randomUUID(), itemName, debitAccount: '', debitAmount: '', creditAccount: '', creditAmount: '', value: '', value1: '', value2: '', value3: '', value4: '', memo: '', grade: '未採点', points: 0 };
-}
-
-function emptyRows(question: QuestionItem): AnswerLine[] {
-  const modelRows = question.modelAnswer?.length ? question.modelAnswer : [newLine('')];
-  return modelRows.map((row) => ({ ...newLine(row.itemName ?? ''), id: crypto.randomUUID() }));
-}
-
-function normalizeNumberText(value: string): string {
-  return value.replace(/[０-９]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xFEE0)).replace(/,/g, '').replace(/[^0-9.-]/g, '');
-}
-
-function formatAmount(value = ''): string {
-  const normalized = normalizeNumberText(value);
-  if (!normalized || normalized === '-' || normalized === '.') return normalized;
-  const numeric = Number(normalized);
-  if (!Number.isFinite(numeric)) return normalized;
-  return numeric.toLocaleString('ja-JP');
-}
-
-function rowPointsTotal(rows: AnswerLine[]): number {
-  return rows.reduce((sum, row) => sum + (Number(row.points) || 0), 0);
-}
-
-function questionToForm(question?: QuestionItem): QuestionForm {
-  const base: QuestionItem = question ?? {
-    id: `ユーザー-${Date.now()}`,
-    examType: 'boki2',
-    subject: '商業簿記',
-    section: '第1問対策',
-    topic: '',
-    title: '',
-    questionText: '',
-    conditions: [],
-    answerTemplateId: 'journal',
-    maxScore: 4,
-    estimatedMinutes: 3,
-    difficulty: '標準',
-    explanation: '',
-    sourceType: 'user_created',
-    isVerified: false,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    modelAnswer: [newLine('')],
-    modelAnswerText: '',
-  };
-  return { ...base, conditionsText: base.conditions.join('\n'), modelAnswerJson: JSON.stringify(base.modelAnswer ?? [], null, 2) };
-}
-
-function formToQuestion(form: QuestionForm): QuestionItem {
-  let parsed: AnswerLine[] = [];
-  try {
-    parsed = JSON.parse(form.modelAnswerJson || '[]') as AnswerLine[];
-  } catch {
-    parsed = [];
-  }
-  const sourceType = form.sourceType === 'original' ? 'user_created' : form.sourceType;
-  return {
-    id: form.id.trim(),
-    examType: 'boki2',
-    subject: form.subject,
-    section: form.section,
-    topic: form.topic.trim(),
-    title: form.title.trim(),
-    questionText: form.questionText.trim(),
-    conditions: form.conditionsText.split('\n').map((line) => line.trim()).filter(Boolean),
-    answerTemplateId: form.answerTemplateId,
-    maxScore: Number(form.maxScore) || 0,
-    estimatedMinutes: Number(form.estimatedMinutes) || undefined,
-    difficulty: form.difficulty,
-    explanation: form.explanation,
-    sourceType,
-    isVerified: form.isVerified,
-    createdAt: form.createdAt || new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    modelAnswer: parsed.map((row) => ({ ...newLine(row.itemName ?? ''), ...row, id: row.id || crypto.randomUUID() })),
-    modelAnswerText: form.modelAnswerText,
-  };
-}
-
-function buildReviewSchedule(question: QuestionItem, rank: ReviewRank, score: number, previous?: ReviewSchedule): ReviewSchedule {
-  const aStreak = rank === 'A' ? (previous?.aStreak ?? 0) + 1 : 0;
-  const cStreak = rank === 'C' ? (previous?.cStreak ?? 0) + 1 : 0;
-  const days = rank === 'A' ? (aStreak >= 3 ? 30 : aStreak >= 2 ? 14 : 7) : rank === 'B' ? 3 : 1;
-  return {
-    id: question.id,
-    questionId: question.id,
-    nextReviewDate: addDays(days),
-    latestRank: rank,
-    latestScore: score,
-    maxScore: question.maxScore,
-    aStreak,
-    cStreak,
-    attempts: (previous?.attempts ?? 0) + 1,
-    isWeak: cStreak >= 2,
-    updatedAt: new Date().toISOString(),
-  };
-}
-
-function problemLabel(question: QuestionItem): string {
-  return `${question.id}　${question.title || question.topic}`;
-}
+const templateLabels: Record<AnswerTemplateId, string> = { journal: '仕訳テンプレート', numeric: '数値入力テンプレート', statementTable: '表形式テンプレート', accountLedger: '勘定記入テンプレート', free: '自由テンプレート' };
+function todayString(): string { return new Date().toISOString().slice(0, 10); }
+function addDays(days: number): string { const d = new Date(); d.setDate(d.getDate() + days); return d.toISOString().slice(0, 10); }
+function normalizeNumberText(value: string): string { return value.replace(/[０-９]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0xfee0)).replace(/,/g, '').replace(/[^0-9.-]/g, ''); }
+function formatAmount(value = ''): string { const n = normalizeNumberText(value); if (!n || n === '-' || n === '.') return n; const num = Number(n); return Number.isFinite(num) ? num.toLocaleString('ja-JP') : n; }
+function isBuiltIn(item: PracticeItem): item is QuestionItem { return item.studyMode === 'built_in_question'; }
+function newLine(itemName = ''): AnswerLine { return { id: crypto.randomUUID(), itemName, debitDate: '', debitSummary: '', debitAccount: '', debitAmount: '', creditDate: '', creditSummary: '', creditAccount: '', creditAmount: '', value: '', value1: '', value2: '', value3: '', value4: '', memo: '', grade: '未採点', points: 0 }; }
+function lineCountForTemplate(t: AnswerTemplateId): number { return t === 'journal' ? 4 : t === 'accountLedger' ? 6 : t === 'statementTable' ? 8 : 4; }
+function emptyRows(item: PracticeItem): AnswerLine[] { const source = isBuiltIn(item) && item.modelAnswer.length ? item.modelAnswer : Array.from({ length: lineCountForTemplate(item.answerTemplateId) }, () => newLine('')); return source.map((row) => ({ ...newLine(row.itemName ?? ''), id: crypto.randomUUID() })); }
+function rowPointsTotal(rows: AnswerLine[]): number { return rows.reduce((sum, row) => sum + (Number(row.points) || 0), 0); }
+function labelOf(item: PracticeItem): string { return `${item.id}　${item.topic || item.title}`; }
+function itemKey(item: PracticeItem): string { return `${item.studyMode}:${item.id}`; }
+function nextReviewDateFor(rank: ReviewRank, prev?: ReviewSchedule): string { const a = rank === 'A' ? (prev?.aStreak ?? 0) + 1 : 0; return addDays(rank === 'A' ? (a >= 3 ? 30 : a >= 2 ? 14 : 7) : rank === 'B' ? 3 : 1); }
+function buildReviewSchedule(item: PracticeItem, rank: ReviewRank, score: number, prev?: ReviewSchedule, manualDate?: string): ReviewSchedule { const aStreak = rank === 'A' ? (prev?.aStreak ?? 0) + 1 : 0; const cStreak = rank === 'C' ? (prev?.cStreak ?? 0) + 1 : 0; return { id: itemKey(item), examType: 'boki2', studyMode: item.studyMode, questionId: item.id, cpaTrialSectionRef: item.cpaTrialSectionRef, nextReviewDate: manualDate || nextReviewDateFor(rank, prev), latestRank: rank, latestScore: score, maxScore: item.maxScore, aStreak, cStreak, attempts: (prev?.attempts ?? 0) + 1, isWeak: cStreak >= 2 || prev?.isWeak === true, updatedAt: new Date().toISOString() }; }
+function modelAnswerText(item: PracticeItem): string { if (!isBuiltIn(item)) return ''; return item.modelAnswer.map((r, i) => item.answerTemplateId === 'journal' ? `${i + 1}. 借方 ${r.debitAccount || '-'} ${formatAmount(r.debitAmount)} / 貸方 ${r.creditAccount || '-'} ${formatAmount(r.creditAmount)}` : `${i + 1}. ${r.itemName || '項目'}：${formatAmount(r.value ?? r.value1)}${r.value2 ? ` / ${formatAmount(r.value2)}` : ''}`).join('\n'); }
 
 export default function App() {
   const [mode, setMode] = useState<AppMode>('solve');
+  const [choice, setChoice] = useState<ActiveStudyChoice>('external_material');
+  const [externalRefs, setExternalRefs] = useState<ExternalProblemRef[]>(externalProblemRefs);
   const [questions, setQuestions] = useState<QuestionItem[]>(originalQuestions);
   const [attempts, setAttempts] = useState<AnswerAttempt[]>([]);
   const [reviews, setReviews] = useState<ReviewSchedule[]>([]);
-  const [selectedId, setSelectedId] = useState(originalQuestions[0].id);
-  const [rows, setRows] = useState<AnswerLine[]>(() => emptyRows(originalQuestions[0]));
+  const [selectedExternalId, setSelectedExternalId] = useState(externalProblemRefs[0].id);
+  const [selectedQuestionId, setSelectedQuestionId] = useState(approvedOriginalQuestions[0]?.id ?? originalQuestions[0].id);
+  const [rows, setRows] = useState<AnswerLine[]>(() => emptyRows(externalProblemRefs[0]));
   const [score, setScore] = useState(0);
   const [rank, setRank] = useState<ReviewRank>('B');
+  const [manualReviewDate, setManualReviewDate] = useState('');
   const [selectedReasons, setSelectedReasons] = useState<MissReason[]>([]);
   const [reviewMemo, setReviewMemo] = useState('');
   const [message, setMessage] = useState('待機中');
-  const [form, setForm] = useState<QuestionForm>(() => questionToForm());
-  const [summary, setSummary] = useState<{ questionCount: number; attemptCount: number; reviewCount: number; usage: number | null; quota: number | null } | null>(null);
-
-  const selected = useMemo(() => questions.find((question) => question.id === selectedId) ?? questions[0], [questions, selectedId]);
-  const latestReview = useMemo(() => reviews.find((review) => review.questionId === selected.id), [reviews, selected.id]);
+  const [questionJson, setQuestionJson] = useState('');
+  const [externalJson, setExternalJson] = useState('');
+  const [summary, setSummary] = useState<{ questionCount: number; externalRefCount: number; attemptCount: number; reviewCount: number; usage: number | null; quota: number | null } | null>(null);
+  const approvedQuestions = useMemo(() => questions.filter((q) => q.verificationStatus === 'approved'), [questions]);
+  const selectedItem: PracticeItem = useMemo(() => choice === 'external_material' ? (externalRefs.find((i) => i.id === selectedExternalId) ?? externalRefs[0]) : (approvedQuestions.find((i) => i.id === selectedQuestionId) ?? approvedQuestions[0] ?? questions[0]), [approvedQuestions, choice, externalRefs, questions, selectedExternalId, selectedQuestionId]);
+  const latestReview = useMemo(() => reviews.find((r) => r.id === itemKey(selectedItem)), [reviews, selectedItem]);
   const dueCards = useMemo(() => {
-    const today = todayString();
-    return reviews
-      .map((review) => ({ review, question: questions.find((question) => question.id === review.questionId) }))
-      .filter((item): item is { review: ReviewSchedule; question: QuestionItem } => Boolean(item.question))
-      .sort((a, b) => a.review.nextReviewDate.localeCompare(b.review.nextReviewDate))
-      .filter((item) => item.review.nextReviewDate <= today || item.review.latestRank === 'C' || item.review.latestRank === 'B' || item.review.isWeak);
-  }, [questions, reviews]);
-
-  const untouchedQuestions = useMemo(() => questions.filter((question) => !attempts.some((attempt) => attempt.questionId === question.id)), [questions, attempts]);
+    const today = todayString(); const items: PracticeItem[] = [...externalRefs, ...approvedQuestions];
+    return reviews.map((review) => ({ review, item: items.find((candidate) => itemKey(candidate) === review.id) })).filter((x): x is { review: ReviewSchedule; item: PracticeItem } => Boolean(x.item)).sort((a, b) => (a.review.nextReviewDate < today ? 0 : 1) - (b.review.nextReviewDate < today ? 0 : 1) || (a.review.isWeak === b.review.isWeak ? 0 : a.review.isWeak ? -1 : 1) || a.review.nextReviewDate.localeCompare(b.review.nextReviewDate));
+  }, [approvedQuestions, externalRefs, reviews]);
+  const untouchedItems = useMemo(() => [...externalRefs, ...approvedQuestions].filter((item) => !attempts.some((a) => a.studyMode === item.studyMode && a.questionId === item.id)), [approvedQuestions, attempts, externalRefs]);
 
   async function refreshAll() {
-    const [stored, attemptRows, reviewRows, storage] = await Promise.all([getStoredQuestions(), getAttempts(), getReviewSchedules(), storageSummary()]);
-    const merged = new Map<string, QuestionItem>();
-    originalQuestions.forEach((question) => merged.set(question.id, question));
-    stored.forEach((question) => merged.set(question.id, question));
-    const nextQuestions = Array.from(merged.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja'));
-    setQuestions(nextQuestions);
-    setAttempts(attemptRows);
-    setReviews(reviewRows);
-    setSummary(storage);
+    const [storedQuestions, storedRefs, attemptRows, reviewRows, storage] = await Promise.all([getStoredQuestions(), getStoredExternalProblemRefs(), getAttempts(), getReviewSchedules(), storageSummary()]);
+    const qMap = new Map<string, QuestionItem>(); originalQuestions.forEach((q) => qMap.set(q.id, q)); storedQuestions.forEach((q) => qMap.set(q.id, q));
+    const rMap = new Map<string, ExternalProblemRef>(); externalProblemRefs.forEach((r) => rMap.set(r.id, r)); storedRefs.forEach((r) => rMap.set(r.id, r));
+    setQuestions(Array.from(qMap.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja'))); setExternalRefs(Array.from(rMap.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja'))); setAttempts(attemptRows); setReviews(reviewRows); setSummary(storage);
   }
-
   useEffect(() => { void refreshAll(); }, []);
+  useEffect(() => { setRows(emptyRows(selectedItem)); setScore(0); setRank('B'); setManualReviewDate(''); setSelectedReasons([]); setReviewMemo(''); }, [selectedItem.id, selectedItem.studyMode]);
+  function updateRow(i: number, patch: Partial<AnswerLine>) { setRows((cur) => cur.map((row, idx) => idx === i ? { ...row, ...patch } : row)); }
+  function addRow() { setRows((cur) => [...cur, newLine('')]); }
+  function applyRowPoints() { setScore(rowPointsTotal(rows)); }
+  function toggleReason(reason: MissReason) { setSelectedReasons((cur) => cur.includes(reason) ? cur.filter((x) => x !== reason) : [...cur, reason]); }
+  function selectPracticeItem(item: PracticeItem) { setChoice(item.studyMode); if (item.studyMode === 'external_material') setSelectedExternalId(item.id); else setSelectedQuestionId(item.id); setMode('solve'); }
+  async function saveCurrentAttempt() { const finalScore = score || rowPointsTotal(rows); const review = buildReviewSchedule(selectedItem, rank, finalScore, latestReview, manualReviewDate); const attempt: AnswerAttempt = { id: crypto.randomUUID(), examType: 'boki2', studyMode: selectedItem.studyMode, questionId: selectedItem.id, questionTitle: selectedItem.title, subject: selectedItem.subject, section: selectedItem.section, topic: selectedItem.topic, cpaTrialSectionRef: selectedItem.cpaTrialSectionRef, answeredAt: new Date().toISOString(), answerTemplateId: selectedItem.answerTemplateId, rows, score: finalScore, maxScore: selectedItem.maxScore, rank, missReasons: selectedReasons, reviewMemo, nextReviewDate: review.nextReviewDate }; await saveAttempt(attempt); await saveReviewSchedule(review); await refreshAll(); setMessage(`保存しました。次回復習日：${review.nextReviewDate}${review.isWeak ? '（苦手固定）' : ''}`); const list = selectedItem.studyMode === 'external_material' ? externalRefs : approvedQuestions; const next = list[(list.findIndex((i) => i.id === selectedItem.id) + 1) % list.length]; selectPracticeItem(next); }
+  async function saveQuestionJson() { try { const parsed = JSON.parse(questionJson) as QuestionItem; if (parsed.studyMode !== 'built_in_question') throw new Error('studyMode'); await saveQuestion({ ...parsed, sourceType: parsed.sourceType === 'initial_original' ? 'user_created' : parsed.sourceType, updatedAt: new Date().toISOString() }); await refreshAll(); setMessage('オリジナル問題を保存しました'); } catch { setMessage('オリジナル問題JSONの保存に失敗しました'); } }
+  async function saveExternalJson() { try { const parsed = JSON.parse(externalJson) as ExternalProblemRef; if (parsed.studyMode !== 'external_material') throw new Error('studyMode'); await saveExternalProblemRef({ ...parsed, updatedAt: new Date().toISOString() }); await refreshAll(); setMessage('外部教材モード用問題IDを保存しました'); } catch { setMessage('外部教材モード用JSONの保存に失敗しました'); } }
+  async function handleExport() { const payload = await exportStudyData(originalQuestions, externalProblemRefs); const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json;charset=utf-8' }); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'cross-qualification-study-backup.json'; a.click(); URL.revokeObjectURL(url); setMessage('JSONバックアップを作成しました'); }
+  async function handleImport(file?: File) { if (!file) return; try { await importStudyData(JSON.parse(await file.text()) as StudyBackupPayload); await refreshAll(); setMessage('JSON復元が完了しました'); } catch { setMessage('JSON復元に失敗しました'); } }
 
-  useEffect(() => {
-    setRows(emptyRows(selected));
-    setScore(0);
-    setRank('B');
-    setSelectedReasons([]);
-    setReviewMemo('');
-  }, [selected.id]);
+  function renderStudyChoice() { return <section className="study-choice-grid"><button className={choice === 'external_material' ? 'study-choice active' : 'study-choice'} onClick={() => setChoice('external_material')}><strong>CPA教材を見ながら解く</strong><span>手元の問題集・PDFを見ながら答案を入力し、自己採点と復習管理を行います。</span></button><button className={choice === 'built_in_question' ? 'study-choice active' : 'study-choice'} onClick={() => setChoice('built_in_question')}><strong>教材なしで解く</strong><span>検証済みのオリジナル短問を解き、解答解説を見て復習できます。</span></button></section>; }
+  function renderProblemSelector() { const options = choice === 'external_material' ? externalRefs : approvedQuestions; const value = choice === 'external_material' ? selectedExternalId : selectedQuestionId; return <section className="panel answer-summary-card"><label>{choice === 'external_material' ? '外部教材の問題ID' : 'approved オリジナル短問'}<select value={value} onChange={(e) => choice === 'external_material' ? setSelectedExternalId(e.target.value) : setSelectedQuestionId(e.target.value)}>{options.map((item) => <option key={item.id} value={item.id}>{labelOf(item)}</option>)}</select></label><div className="button-row"><button onClick={() => setRows(emptyRows(selectedItem))}>一時保存</button><button className="accent" onClick={() => { applyRowPoints(); setMode('grading'); }}>採点へ進む</button></div></section>; }
+  function renderQuestionCard() { return <section className="panel question-reference-card original-question-card"><p className="eyebrow">{choice === 'external_material' ? '外部教材モード' : '教材なしモード'}</p><h2>{labelOf(selectedItem)}</h2>{choice === 'external_material' ? <p className="readable-question-text">問題文・解答・解説はお手元のCPAラーニング問題集・PDF・紙教材で確認してください。この画面では、問題ID、答案入力、自己採点、復習管理だけを行います。</p> : <p className="readable-question-text">{isBuiltIn(selectedItem) ? selectedItem.questionText : ''}</p>}{isBuiltIn(selectedItem) && selectedItem.conditions.length > 0 && <div className="condition-list"><strong>条件</strong>{selectedItem.conditions.map((c) => <span key={c}>{c}</span>)}</div>}<div className="answer-summary-grid compact-meta-grid"><div><span>資格</span><strong>日商簿記2級</strong></div><div><span>科目</span><strong>{selectedItem.subject}</strong></div><div><span>大問対策</span><strong>{selectedItem.section}</strong></div><div><span>論点</span><strong>{selectedItem.topic}</strong></div><div><span>cpaTrialSectionRef</span><strong>{selectedItem.cpaTrialSectionRef}</strong></div><div><span>答案</span><strong>{templateLabels[selectedItem.answerTemplateId]}</strong></div>{choice === 'external_material' && <div><span>ページメモ</span><strong>{(selectedItem as ExternalProblemRef).pageMemo || '未設定'}</strong></div>}{isBuiltIn(selectedItem) && <div><span>検証</span><strong>{selectedItem.verificationStatus}</strong></div>}</div></section>; }
+  function renderAnswerInput(readOnly = false) { const reviewCells = (r: AnswerLine, i: number) => <><label>メモ<input value={r.memo ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { memo: e.target.value })} /></label><label>採点<select value={r.grade} disabled={readOnly} onChange={(e) => updateRow(i, { grade: e.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></label><label>得点<input value={String(r.points || '')} disabled={readOnly} inputMode="numeric" onChange={(e) => updateRow(i, { points: Number(normalizeNumberText(e.target.value)) || 0 })} /></label></>; if (selectedItem.answerTemplateId === 'journal') return <section className="answer-input-main original-answer-input"><div className="pc-answer-only"><table className="answer-table"><thead><tr><th>行</th><th>借方科目</th><th>借方金額</th><th>貸方科目</th><th>貸方金額</th><th>メモ</th><th>採点</th><th>得点</th></tr></thead><tbody>{rows.map((r, i) => <tr key={r.id}><td>{i + 1}</td><td><input value={r.debitAccount ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { debitAccount: e.target.value })} /></td><td><input value={formatAmount(r.debitAmount)} disabled={readOnly} inputMode="numeric" onChange={(e) => updateRow(i, { debitAmount: normalizeNumberText(e.target.value) })} /></td><td><input value={r.creditAccount ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { creditAccount: e.target.value })} /></td><td><input value={formatAmount(r.creditAmount)} disabled={readOnly} inputMode="numeric" onChange={(e) => updateRow(i, { creditAmount: normalizeNumberText(e.target.value) })} /></td><td><input value={r.memo ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { memo: e.target.value })} /></td><td><select value={r.grade} disabled={readOnly} onChange={(e) => updateRow(i, { grade: e.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></td><td><input value={String(r.points || '')} disabled={readOnly} onChange={(e) => updateRow(i, { points: Number(normalizeNumberText(e.target.value)) || 0 })} /></td></tr>)}</tbody></table></div><div className="mobile-journal-input">{rows.map((r, i) => <article className="journal-entry-card" key={r.id}><h3>仕訳{i + 1}</h3><div className="journal-entry-side"><h4>借方</h4><label>借方科目<input value={r.debitAccount ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { debitAccount: e.target.value })} /></label><label>借方金額<input value={formatAmount(r.debitAmount)} disabled={readOnly} inputMode="numeric" onChange={(e) => updateRow(i, { debitAmount: normalizeNumberText(e.target.value) })} /></label></div><div className="journal-entry-side"><h4>貸方</h4><label>貸方科目<input value={r.creditAccount ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { creditAccount: e.target.value })} /></label><label>貸方金額<input value={formatAmount(r.creditAmount)} disabled={readOnly} inputMode="numeric" onChange={(e) => updateRow(i, { creditAmount: normalizeNumberText(e.target.value) })} /></label></div>{reviewCells(r, i)}</article>)}</div>{!readOnly && <button className="secondary" onClick={addRow}>＋ 行を追加</button>}</section>; return <section className="answer-input-main original-answer-input"><table className="answer-table"><thead><tr><th>行</th><th>項目名</th><th>入力値</th><th>メモ</th><th>採点</th><th>得点</th></tr></thead><tbody>{rows.map((r, i) => <tr key={r.id}><td>{i + 1}</td><td><input value={r.itemName ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { itemName: e.target.value })} /></td><td><input value={formatAmount(r.value ?? r.value1)} disabled={readOnly} onChange={(e) => updateRow(i, selectedItem.answerTemplateId === 'numeric' ? { value: normalizeNumberText(e.target.value) } : { value1: normalizeNumberText(e.target.value) })} /></td><td><input value={r.memo ?? ''} disabled={readOnly} onChange={(e) => updateRow(i, { memo: e.target.value })} /></td><td><select value={r.grade} disabled={readOnly} onChange={(e) => updateRow(i, { grade: e.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></td><td><input value={String(r.points || '')} disabled={readOnly} onChange={(e) => updateRow(i, { points: Number(normalizeNumberText(e.target.value)) || 0 })} /></td></tr>)}</tbody></table>{!readOnly && <button className="secondary" onClick={addRow}>＋ 行を追加</button>}</section>; }
+  function renderModelAnswer() { if (!isBuiltIn(selectedItem)) return null; return <section className="panel model-answer-card"><p className="eyebrow">模範解答・解説</p><pre>{modelAnswerText(selectedItem)}</pre><p className="readable-question-text">{selectedItem.explanation}</p></section>; }
 
-  function updateRow(index: number, patch: Partial<AnswerLine>) {
-    setRows((current) => current.map((row, rowIndex) => rowIndex === index ? { ...row, ...patch } : row));
-  }
-
-  function addRow() {
-    setRows((current) => [...current, newLine('')]);
-  }
-
-  function applyRowPoints() {
-    setScore(rowPointsTotal(rows));
-  }
-
-  function toggleReason(reason: MissReason) {
-    setSelectedReasons((current) => current.includes(reason) ? current.filter((item) => item !== reason) : [...current, reason]);
-  }
-
-  async function saveCurrentAttempt() {
-    const finalScore = score || rowPointsTotal(rows);
-    const review = buildReviewSchedule(selected, rank, finalScore, latestReview);
-    const attempt: AnswerAttempt = {
-      id: crypto.randomUUID(),
-      questionId: selected.id,
-      questionTitle: selected.title,
-      subject: selected.subject,
-      section: selected.section,
-      topic: selected.topic,
-      answeredAt: new Date().toISOString(),
-      answerTemplateId: selected.answerTemplateId,
-      rows,
-      score: finalScore,
-      maxScore: selected.maxScore,
-      rank,
-      missReasons: selectedReasons,
-      reviewMemo,
-      nextReviewDate: review.nextReviewDate,
-    };
-    await saveAttempt(attempt);
-    await saveReviewSchedule(review);
-    await refreshAll();
-    setMessage(`保存しました。次回復習日：${review.nextReviewDate}${review.isWeak ? '（連続Cの苦手問題）' : ''}`);
-    const currentIndex = questions.findIndex((question) => question.id === selected.id);
-    const next = questions[currentIndex + 1] ?? questions[0];
-    setSelectedId(next.id);
-    setMode('solve');
-  }
-
-  async function saveQuestionForm() {
-    const question = formToQuestion(form);
-    if (!question.id || !question.title) {
-      setMessage('問題IDとタイトルは必須です');
-      return;
-    }
-    await saveQuestion(question);
-    await refreshAll();
-    setSelectedId(question.id);
-    setMessage('ユーザー作成問題を保存しました');
-  }
-
-  async function handleExport() {
-    const payload = await exportStudyData(originalQuestions);
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'boki2-original-study-backup.json';
-    a.click();
-    URL.revokeObjectURL(url);
-    setMessage('JSONエクスポートを作成しました');
-  }
-
-  async function handleImport(file?: File) {
-    if (!file) return;
-    try {
-      const payload = JSON.parse(await file.text()) as StudyBackupPayload;
-      await importStudyData(payload);
-      await refreshAll();
-      setMessage('JSONインポートが完了しました');
-    } catch {
-      setMessage('JSONインポートに失敗しました');
-    }
-  }
-
-  function renderProblemCard() {
-    return <section className="panel question-reference-card original-question-card">
-      <p className="eyebrow">問題文</p>
-      <h2>{problemLabel(selected)}</h2>
-      <p className="readable-question-text">{selected.questionText || '問題文は未登録です。必要に応じて管理画面から問題文を追加してください。'}</p>
-      {selected.conditions.length > 0 && <div className="condition-list"><strong>条件</strong>{selected.conditions.map((condition) => <span key={condition}>{condition}</span>)}</div>}
-      <div className="answer-summary-grid compact-meta-grid">
-        <div><span>科目</span><strong>{selected.subject}</strong></div><div><span>大問対策</span><strong>{selected.section}</strong></div><div><span>論点</span><strong>{selected.topic}</strong></div><div><span>満点</span><strong>{selected.maxScore}点</strong></div><div><span>形式</span><strong>{templateLabels[selected.answerTemplateId]}</strong></div><div><span>出典</span><strong>{selected.sourceType}</strong></div>
-      </div>
-    </section>;
-  }
-
-  function renderAnswerInput(readOnly = false) {
-    const commonReview = (row: AnswerLine, index: number) => <>
-      <label>メモ<textarea value={row.memo ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { memo: event.target.value })} /></label>
-      <label>採点<select value={row.grade} disabled={readOnly} onChange={(event) => updateRow(index, { grade: event.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></label>
-      <label>得点<input value={String(row.points || '')} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, { points: Number(normalizeNumberText(event.target.value)) || 0 })} /></label>
-    </>;
-
-    if (selected.answerTemplateId === 'journal') {
-      return <section className="answer-input-main original-answer-input"><div className="pc-answer-only"><table className="answer-table"><thead><tr><th>行</th><th>借方科目</th><th>借方金額</th><th>貸方科目</th><th>貸方金額</th><th>メモ</th><th>採点</th><th>得点</th></tr></thead><tbody>{rows.map((row, index) => <tr key={row.id}><td>{index + 1}</td><td><input value={row.debitAccount ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { debitAccount: event.target.value })} /></td><td><input value={formatAmount(row.debitAmount)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, { debitAmount: normalizeNumberText(event.target.value) })} /></td><td><input value={row.creditAccount ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { creditAccount: event.target.value })} /></td><td><input value={formatAmount(row.creditAmount)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, { creditAmount: normalizeNumberText(event.target.value) })} /></td><td><input value={row.memo ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { memo: event.target.value })} /></td><td><select value={row.grade} disabled={readOnly} onChange={(event) => updateRow(index, { grade: event.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></td><td><input value={String(row.points || '')} disabled={readOnly} onChange={(event) => updateRow(index, { points: Number(normalizeNumberText(event.target.value)) || 0 })} /></td></tr>)}</tbody></table></div><div className="mobile-journal-input">{rows.map((row, index) => <article className="journal-entry-card" key={row.id}><h3>仕訳{index + 1}</h3><div className="journal-entry-side"><h4>借方</h4><label>借方科目<input value={row.debitAccount ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { debitAccount: event.target.value })} /></label><label>借方金額<input value={formatAmount(row.debitAmount)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, { debitAmount: normalizeNumberText(event.target.value) })} /></label></div><div className="journal-entry-side"><h4>貸方</h4><label>貸方科目<input value={row.creditAccount ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { creditAccount: event.target.value })} /></label><label>貸方金額<input value={formatAmount(row.creditAmount)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, { creditAmount: normalizeNumberText(event.target.value) })} /></label></div>{commonReview(row, index)}</article>)}</div>{!readOnly && <button className="secondary" onClick={addRow}>＋ 行を追加</button>}</section>;
-    }
-
-    return <section className="answer-input-main original-answer-input"><div className="pc-answer-only"><table className="answer-table"><thead><tr><th>行</th><th>項目名</th><th>{selected.answerTemplateId === 'numeric' ? '入力欄' : '入力値1'}</th>{selected.answerTemplateId !== 'numeric' && <><th>入力値2</th><th>入力値3</th><th>入力値4</th></>}<th>メモ</th><th>採点</th><th>得点</th></tr></thead><tbody>{rows.map((row, index) => <tr key={row.id}><td>{index + 1}</td><td><input value={row.itemName ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { itemName: event.target.value })} /></td><td><input value={formatAmount(row.value ?? row.value1)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, selected.answerTemplateId === 'numeric' ? { value: normalizeNumberText(event.target.value) } : { value1: normalizeNumberText(event.target.value) })} /></td>{selected.answerTemplateId !== 'numeric' && <><td><input value={formatAmount(row.value2)} disabled={readOnly} onChange={(event) => updateRow(index, { value2: normalizeNumberText(event.target.value) })} /></td><td><input value={formatAmount(row.value3)} disabled={readOnly} onChange={(event) => updateRow(index, { value3: normalizeNumberText(event.target.value) })} /></td><td><input value={formatAmount(row.value4)} disabled={readOnly} onChange={(event) => updateRow(index, { value4: normalizeNumberText(event.target.value) })} /></td></>}<td><input value={row.memo ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { memo: event.target.value })} /></td><td><select value={row.grade} disabled={readOnly} onChange={(event) => updateRow(index, { grade: event.target.value as AnswerLine['grade'] })}><option>未採点</option><option>○</option><option>△</option><option>×</option></select></td><td><input value={String(row.points || '')} disabled={readOnly} onChange={(event) => updateRow(index, { points: Number(normalizeNumberText(event.target.value)) || 0 })} /></td></tr>)}</tbody></table></div><div className="mobile-journal-input">{rows.map((row, index) => <article className="journal-entry-card" key={row.id}><h3>解答{index + 1}</h3><label>項目名<input value={row.itemName ?? ''} disabled={readOnly} onChange={(event) => updateRow(index, { itemName: event.target.value })} /></label><label>入力値<input value={formatAmount(row.value ?? row.value1)} disabled={readOnly} inputMode="numeric" onChange={(event) => updateRow(index, selected.answerTemplateId === 'numeric' ? { value: normalizeNumberText(event.target.value) } : { value1: normalizeNumberText(event.target.value) })} /></label>{commonReview(row, index)}</article>)}</div>{!readOnly && <button className="secondary" onClick={addRow}>＋ 行を追加</button>}</section>;
-  }
-
-  function renderModelAnswer() {
-    return <section className="panel model-answer-card"><p className="eyebrow">模範答案・解説</p><h2>自己採点用</h2>{selected.modelAnswer?.length ? <div className="model-answer-list">{selected.modelAnswer.map((row, index) => <div key={`${selected.id}-${index}`}><strong>{index + 1}</strong><span>{selected.answerTemplateId === 'journal' ? `${row.debitAccount || ''} ${formatAmount(row.debitAmount)} / ${row.creditAccount || ''} ${formatAmount(row.creditAmount)}` : `${row.itemName || ''}：${formatAmount(row.value ?? row.value1)}`}</span></div>)}</div> : <p>{selected.modelAnswerText || '模範答案は未登録です。'}</p>}<p className="readable-question-text">{selected.explanation || '解説は未登録です。'}</p></section>;
-  }
-
-  return <main className="app-shell simplified-shell original-study-app">
-    <header className="app-header compact-header"><div><h1>日商簿記2級 オリジナル問題演習・復習管理アプリ</h1><p>PDF抽出に依存せず、オリジナル問題データから問題文・答案欄・自己採点・復習予定を同期します。</p></div><div className="practice-progress-box"><strong>{questions.length}</strong><span>内蔵・追加問題</span></div></header>
-    <nav className="mode-nav"><button className={mode === 'solve' ? 'active' : ''} onClick={() => setMode('solve')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'review' ? 'active' : ''} onClick={() => setMode('review')}>復習する</button><button className={mode === 'management' ? 'active' : ''} onClick={() => setMode('management')}>管理</button></nav>
-    <div className="status-bar">{message}</div>
-
-    {mode === 'solve' && <section className="mode-section solve-mode-section"><section className="panel answer-summary-card"><label>問題ID<select value={selected.id} onChange={(event) => setSelectedId(event.target.value)}>{questions.map((question) => <option key={question.id} value={question.id}>{problemLabel(question)}</option>)}</select></label><div className="button-row"><button onClick={() => setRows(emptyRows(selected))}>一時保存代わりに入力を初期化</button><button className="accent" onClick={() => { applyRowPoints(); setMode('grading'); }}>採点へ進む</button></div></section>{renderProblemCard()}<section className="focused-answer-area answer-only-main"><div className="focused-answer-title"><div><p className="eyebrow">答案入力</p><h2>{templateLabels[selected.answerTemplateId]}</h2></div><button className="secondary" onClick={applyRowPoints}>行別得点合計を問題得点へ反映</button></div>{renderAnswerInput(false)}</section></section>}
-
-    {mode === 'grading' && <section className="mode-section grading-mode-section">{renderProblemCard()}<section className="focused-answer-area"><div className="focused-answer-title"><div><p className="eyebrow">自分の答案</p><h2>{selected.title}</h2></div><button className="secondary" onClick={applyRowPoints}>行別得点合計を反映</button></div>{renderAnswerInput(false)}</section>{renderModelAnswer()}<section className="panel self-score-box"><h2>自己採点</h2><div className="score-grid"><label>問題得点<input type="number" value={score} onChange={(event) => setScore(Number(event.target.value || 0))} /></label><label>満点<input type="number" value={selected.maxScore} disabled /></label><label>A/B/C判定<select value={rank} onChange={(event) => setRank(event.target.value as ReviewRank)}><option value="A">A：自力で解けた・説明できる</option><option value="B">B：正解または惜しいが手順に不安</option><option value="C">C：不正解・解説なしでは再現できない</option></select></label><label>次回復習日<input value={buildReviewSchedule(selected, rank, score || rowPointsTotal(rows), latestReview).nextReviewDate} disabled /></label></div><h3>ミス原因</h3><div className="check-list compact-check-list">{missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={selectedReasons.includes(reason)} onChange={() => toggleReason(reason)} />{reason}</label>)}</div><label>復習メモ<textarea value={reviewMemo} onChange={(event) => setReviewMemo(event.target.value)} placeholder="次回解く前に見る注意点" /></label><button className="accent" onClick={() => void saveCurrentAttempt()}>保存して次へ</button></section></section>}
-
-    {mode === 'review' && <section className="mode-section review-mode-section"><section className="panel progress-overview-panel"><div><p className="eyebrow">復習する</p><h2>今日やる問題をカードで確認</h2></div><div className="progress-summary-grid"><div><strong>{dueCards.filter((item) => item.review.nextReviewDate <= todayString()).length}</strong><span>今日やる問題</span></div><div><strong>{dueCards.filter((item) => item.review.nextReviewDate < todayString()).length}</strong><span>期限超過</span></div><div><strong>{reviews.filter((item) => item.latestRank === 'C').length}</strong><span>C判定</span></div><div><strong>{reviews.filter((item) => item.latestRank === 'B').length}</strong><span>B判定</span></div><div><strong>{untouchedQuestions.length}</strong><span>未着手</span></div><div><strong>{reviews.filter((item) => item.isWeak).length}</strong><span>連続ミス</span></div></div></section>{dueCards.length === 0 && <section className="panel"><h2>今日の復習はありません</h2><button className="accent" onClick={() => { setSelectedId(untouchedQuestions[0]?.id ?? questions[0].id); setMode('solve'); }}>未着手問題を解く</button></section>}{dueCards.map(({ question, review }) => <article className="panel priority-card" key={question.id}><p className="eyebrow">{review.isWeak ? '連続ミス' : review.nextReviewDate <= todayString() ? '今日の最優先' : '復習候補'}</p><h3>{question.id}　{question.title}</h3><p>前回：{review.latestRank || '未判定'}判定 / {review.latestScore}点 / 復習日：{review.nextReviewDate}</p><button onClick={() => { setSelectedId(question.id); setMode('solve'); }}>解く</button></article>)}</section>}
-
-    {mode === 'management' && <section className="mode-section progress-mode-section"><section className="panel"><p className="eyebrow">管理</p><h2>問題追加・JSON・保存状態</h2><p>通常学習では開かなくてよい画面です。PDF補助取込は今回の主機能ではありません。</p></section><details className="panel management-panel" open><summary>問題一覧</summary><div className="management-list">{questions.map((question) => <button key={question.id} onClick={() => { setSelectedId(question.id); setForm(questionToForm(question)); }}>{question.id}｜{question.title}｜{question.sourceType}</button>)}</div></details><details className="panel management-panel" open><summary>問題追加・編集</summary><div className="question-form-grid"><label>問題ID<input value={form.id} onChange={(event) => setForm({ ...form, id: event.target.value })} /></label><label>科目<select value={form.subject} onChange={(event) => setForm({ ...form, subject: event.target.value as QuestionItem['subject'] })}><option>商業簿記</option><option>工業簿記</option></select></label><label>大問対策<select value={form.section} onChange={(event) => setForm({ ...form, section: event.target.value as QuestionItem['section'] })}><option>第1問対策</option><option>第2問対策</option><option>第3問対策</option><option>第4問対策</option><option>第5問対策</option></select></label><label>論点<input value={form.topic} onChange={(event) => setForm({ ...form, topic: event.target.value })} /></label><label>タイトル<input value={form.title} onChange={(event) => setForm({ ...form, title: event.target.value })} /></label><label>答案テンプレート<select value={form.answerTemplateId} onChange={(event) => setForm({ ...form, answerTemplateId: event.target.value as AnswerTemplateId })}><option value="journal">仕訳</option><option value="numeric">数値入力</option><option value="statementTable">表形式</option><option value="free">自由</option></select></label><label>満点<input type="number" value={form.maxScore} onChange={(event) => setForm({ ...form, maxScore: Number(event.target.value) })} /></label><label>想定時間<input type="number" value={form.estimatedMinutes ?? ''} onChange={(event) => setForm({ ...form, estimatedMinutes: Number(event.target.value) })} /></label><label>難易度<select value={form.difficulty} onChange={(event) => setForm({ ...form, difficulty: event.target.value as QuestionItem['difficulty'] })}><option>易しい</option><option>標準</option><option>やや難</option><option>難しい</option></select></label><label>sourceType<select value={form.sourceType} onChange={(event) => setForm({ ...form, sourceType: event.target.value as SourceType })}>{sourceTypes.map((type) => <option key={type}>{type}</option>)}</select></label><label>確認済み<select value={String(form.isVerified)} onChange={(event) => setForm({ ...form, isVerified: event.target.value === 'true' })}><option value="true">true</option><option value="false">false</option></select></label><label className="wide-field">問題文<textarea value={form.questionText} onChange={(event) => setForm({ ...form, questionText: event.target.value })} /></label><label className="wide-field">条件<textarea value={form.conditionsText} onChange={(event) => setForm({ ...form, conditionsText: event.target.value })} /></label><label className="wide-field">解説<textarea value={form.explanation ?? ''} onChange={(event) => setForm({ ...form, explanation: event.target.value })} /></label><label className="wide-field">模範答案JSON<textarea value={form.modelAnswerJson} onChange={(event) => setForm({ ...form, modelAnswerJson: event.target.value })} /></label><label className="wide-field">模範答案メモ<textarea value={form.modelAnswerText ?? ''} onChange={(event) => setForm({ ...form, modelAnswerText: event.target.value })} /></label></div><button className="accent" onClick={() => void saveQuestionForm()}>ユーザー作成問題として保存</button><button className="secondary" onClick={() => setForm(questionToForm())}>新規問題フォーム</button></details><details className="panel management-panel"><summary>JSONインポート・エクスポート / CSV出力</summary><div className="button-row"><button onClick={() => void handleExport()}>JSONエクスポート</button><label className="import-label">JSONインポート<input type="file" accept="application/json" onChange={(event) => void handleImport(event.target.files?.[0])} /></label><button onClick={() => { const csv = attempts.map((a) => [a.answeredAt, a.questionId, a.questionTitle, a.score, a.maxScore, a.rank, a.nextReviewDate].join(',')).join('\n'); const blob = new Blob([`日時,問題ID,タイトル,得点,満点,判定,次回復習日\n${csv}`], { type: 'text/csv;charset=utf-8' }); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'boki2-attempts.csv'; a.click(); URL.revokeObjectURL(url); }}>CSV出力</button></div></details><details className="panel management-panel"><summary>履歴一覧</summary><div className="history-list">{attempts.map((attempt) => <div key={attempt.id}><strong>{attempt.questionId}</strong><span>{attempt.score}/{attempt.maxScore}点・{attempt.rank}・{attempt.nextReviewDate}</span></div>)}</div></details><details className="panel management-panel"><summary>PDF補助取込</summary><p className="warning-text">PDFの種類によっては正確に抽出できません。学習画面では確認済みの問題データのみ使用してください。今回の主機能ではないため、PDF抽出精度改善・OCR・完全自動問題生成は実装していません。</p></details><details className="panel management-panel"><summary>保存状態確認</summary><p>IndexedDBに questions / answerAttempts / reviewSchedules / settings / userProblems / histories を保存します。</p><p>問題数：{summary?.questionCount ?? '-'} / 履歴：{summary?.attemptCount ?? '-'} / 復習予定：{summary?.reviewCount ?? '-'}</p><button onClick={() => void refreshAll()}>保存状態を再確認</button></details></section>}
-  </main>;
+  return <main className="app-shell simplified-shell original-study-app"><header className="app-header compact-header"><div><h1>資格横断型 問題演習・採点・復習管理アプリ</h1><p>簿記2級では「CPA教材を見ながら解く」と「教材なしで解く」の2モードを使います。PDF抽出・教材本文取り込みは行いません。</p></div><div className="practice-progress-box"><strong>{externalRefs.length}</strong><span>外部教材区分</span></div></header><nav className="mode-nav"><button className={mode === 'solve' ? 'active' : ''} onClick={() => setMode('solve')}>今すぐ解く</button><button className={mode === 'grading' ? 'active' : ''} onClick={() => setMode('grading')}>採点する</button><button className={mode === 'review' ? 'active' : ''} onClick={() => setMode('review')}>復習する</button><button className={mode === 'management' ? 'active' : ''} onClick={() => setMode('management')}>管理</button></nav><div className="status-bar">{message}</div>{mode === 'solve' && <section className="mode-section solve-mode-section">{renderStudyChoice()}{renderProblemSelector()}{renderQuestionCard()}<section className="focused-answer-area answer-only-main"><div className="focused-answer-title"><div><p className="eyebrow">答案入力</p><h2>{templateLabels[selectedItem.answerTemplateId]}</h2></div><button className="secondary" onClick={applyRowPoints}>行別得点合計を問題得点へ反映</button></div>{renderAnswerInput(false)}</section></section>}{mode === 'grading' && <section className="mode-section grading-mode-section">{renderQuestionCard()}<section className="focused-answer-area"><div className="focused-answer-title"><div><p className="eyebrow">自分の答案</p><h2>{selectedItem.title}</h2></div><button className="secondary" onClick={applyRowPoints}>行別得点合計を反映</button></div>{renderAnswerInput(false)}</section>{renderModelAnswer()}<section className="panel self-score-box"><h2>自己採点</h2><div className="score-grid"><label>問題得点<input type="number" value={score} onChange={(e) => setScore(Number(e.target.value || 0))} /></label><label>満点<input type="number" value={selectedItem.maxScore} disabled /></label><label>A/B/C判定<select value={rank} onChange={(e) => { const next = e.target.value as ReviewRank; setRank(next); setManualReviewDate(nextReviewDateFor(next, latestReview)); }}><option value="A">A：自力で解けた・説明できる</option><option value="B">B：正解または惜しいが手順に不安</option><option value="C">C：不正解・解説なしでは再現できない</option></select></label><label>次回復習日<input type="date" value={manualReviewDate || nextReviewDateFor(rank, latestReview)} onChange={(e) => setManualReviewDate(e.target.value)} /></label></div><h3>ミス原因</h3><div className="check-list compact-check-list">{missReasons.map((reason) => <label key={reason}><input type="checkbox" checked={selectedReasons.includes(reason)} onChange={() => toggleReason(reason)} />{reason}</label>)}</div><label>復習メモ<textarea value={reviewMemo} onChange={(e) => setReviewMemo(e.target.value)} placeholder="次回解く前に見る注意点" /></label><button className="accent" onClick={() => void saveCurrentAttempt()}>保存して次へ</button></section></section>}{mode === 'review' && <section className="mode-section review-mode-section"><section className="panel progress-overview-panel"><div><p className="eyebrow">復習する</p><h2>今日やる問題をカードで確認</h2></div><div className="progress-summary-grid"><div><strong>{dueCards.filter(({ review }) => review.nextReviewDate <= todayString()).length}</strong><span>今日の復習</span></div><div><strong>{dueCards.filter(({ review }) => review.nextReviewDate < todayString()).length}</strong><span>期限超過</span></div><div><strong>{reviews.filter((r) => r.isWeak).length}</strong><span>苦手固定</span></div><div><strong>{reviews.filter((r) => r.latestRank === 'C').length}</strong><span>C判定</span></div><div><strong>{reviews.filter((r) => r.latestRank === 'B').length}</strong><span>B判定</span></div><div><strong>{untouchedItems.length}</strong><span>未着手</span></div></div></section>{dueCards.length === 0 && <section className="panel"><h2>今日の復習はありません</h2><button className="accent" onClick={() => selectPracticeItem(untouchedItems[0] ?? externalRefs[0])}>未着手問題を解く</button></section>}{dueCards.map(({ item, review }) => <article className="panel priority-card" key={review.id}><p className="eyebrow">{item.studyMode === 'external_material' ? '外部教材' : '教材なし'} / {review.isWeak ? '苦手固定' : review.nextReviewDate <= todayString() ? '今日の復習' : '復習候補'}</p><h3>{item.id}　{item.topic}</h3><p>Ref：{item.cpaTrialSectionRef} / 前回：{review.latestRank || '未判定'} / {review.latestScore}点 / 復習日：{review.nextReviewDate}</p><button onClick={() => selectPracticeItem(item)}>解く</button></article>)}</section>}{mode === 'management' && <section className="mode-section progress-mode-section"><section className="panel"><p className="eyebrow">管理</p><h2>低頻度機能</h2><p>通常学習では開かなくてよい画面です。PDF抽出・PDF範囲指定は今回実装していません。</p></section><details className="panel management-panel" open><summary>問題ID一覧・品質状態</summary><div className="progress-summary-grid"><div><strong>{externalRefs.length}</strong><span>外部教材区分</span></div><div><strong>{questions.filter((q) => q.verificationStatus === 'approved').length}</strong><span>approved</span></div><div><strong>{questions.filter((q) => q.verificationStatus === 'draft').length}</strong><span>draft</span></div><div><strong>{questions.filter((q) => q.verificationStatus === 'rejected').length}</strong><span>rejected</span></div></div><div className="management-list">{externalRefs.map((item) => <button key={item.id} onClick={() => { setExternalJson(JSON.stringify(item, null, 2)); selectPracticeItem(item); }}>{item.id}｜{item.topic}｜{item.cpaTrialSectionRef}</button>)}{questions.map((item) => <button key={item.id} onClick={() => { setQuestionJson(JSON.stringify(item, null, 2)); if (item.verificationStatus === 'approved') selectPracticeItem(item); }}>{item.id}｜{item.topic}｜{item.cpaTrialSectionRef}｜{item.verificationStatus}</button>)}</div></details><details className="panel management-panel"><summary>外部教材モード用問題ID追加</summary><textarea className="json-editor" value={externalJson} onChange={(e) => setExternalJson(e.target.value)} placeholder="ExternalProblemRef JSON" /><button className="accent" onClick={() => void saveExternalJson()}>外部教材問題IDを保存</button></details><details className="panel management-panel"><summary>オリジナル問題追加・編集・verificationStatus変更</summary><p>通常演習に出るのは verificationStatus が approved の問題だけです。draft は管理画面でのみ確認できます。</p><textarea className="json-editor" value={questionJson} onChange={(e) => setQuestionJson(e.target.value)} placeholder="QuestionItem JSON" /><button className="accent" onClick={() => void saveQuestionJson()}>オリジナル問題を保存</button></details><details className="panel management-panel"><summary>JSONバックアップ・JSON復元 / CSV出力</summary><div className="button-row"><button onClick={() => void handleExport()}>JSONバックアップ</button><label className="import-label">JSON復元<input type="file" accept="application/json" onChange={(e) => void handleImport(e.target.files?.[0])} /></label><button onClick={() => { const csv = attempts.map((a) => [a.answeredAt, a.studyMode, a.questionId, a.cpaTrialSectionRef, a.score, a.maxScore, a.rank, a.nextReviewDate].join(',')).join('\n'); const blob = new Blob([`日時,モード,問題ID,cpaTrialSectionRef,得点,満点,判定,次回復習日\n${csv}`], { type: 'text/csv;charset=utf-8' }); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'study-attempts.csv'; a.click(); URL.revokeObjectURL(url); }}>CSV出力</button></div></details><details className="panel management-panel"><summary>履歴一覧</summary><div className="history-list">{attempts.map((attempt) => <div key={attempt.id}><strong>{attempt.studyMode === 'external_material' ? '外部教材' : '教材なし'}｜{attempt.questionId}</strong><span>{attempt.cpaTrialSectionRef}｜{attempt.score}/{attempt.maxScore}点｜{attempt.rank}｜{attempt.nextReviewDate}</span></div>)}</div></details><details className="panel management-panel"><summary>PDF補助取込</summary><p className="warning-text">PDF抽出、PDF範囲指定、PDF画像表示改善は今回実装していません。CPA教材本文・解答・解説・数値・表構成はアプリに収録しません。</p></details><details className="panel management-panel"><summary>保存状態確認</summary><p>IndexedDBに questions / externalProblemRefs / answerAttempts / reviewSchedules / settings / userProblems / histories を保存します。</p><p>問題数：{summary?.questionCount ?? '-'} / 外部教材区分：{summary?.externalRefCount ?? '-'} / 履歴：{summary?.attemptCount ?? '-'} / 復習予定：{summary?.reviewCount ?? '-'}</p><button onClick={() => void refreshAll()}>保存状態を再確認</button></details></section>}</main>;
 }

--- a/cpa-boki2-trial-section-answer-manager/src/data/cpaTrialSections.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/cpaTrialSections.ts
@@ -1,0 +1,67 @@
+import type { AnswerTemplateId, CpaTrialSectionRef, ExternalProblemRef, SectionName, SubjectName } from '../originalStudyTypes';
+
+const NOW = '2026-05-24T00:00:00.000Z';
+const COPYRIGHT_NOTE = 'CPA問題集の試験対策編の区分のみ参考。問題文・解答・解説・数値・表構成は未使用。';
+
+type SectionDef = {
+  ref: CpaTrialSectionRef;
+  id: string;
+  subject: SubjectName;
+  section: SectionName;
+  topic: string;
+  template: AnswerTemplateId;
+  maxScore: number;
+  minutes: number;
+};
+
+export const cpaTrialSections: SectionDef[] = [
+  { ref: 'commercial_1_1', id: '1-1', subject: '商業簿記', section: '第1問対策', topic: '商品、収益認識、現金預金', template: 'journal', maxScore: 20, minutes: 12 },
+  { ref: 'commercial_1_2', id: '1-2', subject: '商業簿記', section: '第1問対策', topic: '債権債務、有価証券', template: 'journal', maxScore: 20, minutes: 12 },
+  { ref: 'commercial_1_3', id: '1-3', subject: '商業簿記', section: '第1問対策', topic: '有形固定資産、無形資産', template: 'journal', maxScore: 20, minutes: 12 },
+  { ref: 'commercial_1_4', id: '1-4', subject: '商業簿記', section: '第1問対策', topic: 'リース取引、引当金、株式会社会計', template: 'journal', maxScore: 20, minutes: 12 },
+  { ref: 'commercial_1_5', id: '1-5', subject: '商業簿記', section: '第1問対策', topic: '外貨建取引、税効果会計、本支店会計、連結会計', template: 'journal', maxScore: 20, minutes: 12 },
+  { ref: 'commercial_2_1', id: '2-1', subject: '商業簿記', section: '第2問対策', topic: '株主資本等変動計算書', template: 'statementTable', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_2_2', id: '2-2', subject: '商業簿記', section: '第2問対策', topic: '連結会計①', template: 'statementTable', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_2_3', id: '2-3', subject: '商業簿記', section: '第2問対策', topic: '連結会計②', template: 'statementTable', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_2_4', id: '2-4', subject: '商業簿記', section: '第2問対策', topic: '勘定記入①（商品）', template: 'accountLedger', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_2_5', id: '2-5', subject: '商業簿記', section: '第2問対策', topic: '勘定記入②（有形固定資産）', template: 'accountLedger', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_2_6', id: '2-6', subject: '商業簿記', section: '第2問対策', topic: '勘定記入③（有価証券）', template: 'accountLedger', maxScore: 20, minutes: 18 },
+  { ref: 'commercial_3_1', id: '3-1', subject: '商業簿記', section: '第3問対策', topic: '決算の総合問題①', template: 'free', maxScore: 20, minutes: 22 },
+  { ref: 'commercial_3_2', id: '3-2', subject: '商業簿記', section: '第3問対策', topic: '決算の総合問題②', template: 'free', maxScore: 20, minutes: 22 },
+  { ref: 'commercial_3_3', id: '3-3', subject: '商業簿記', section: '第3問対策', topic: '本支店会計の総合問題', template: 'free', maxScore: 20, minutes: 22 },
+  { ref: 'industrial_4_1', id: '4-1', subject: '工業簿記', section: '第4問対策', topic: '工業簿記 仕訳問題', template: 'journal', maxScore: 28, minutes: 15 },
+  { ref: 'industrial_4_2', id: '4-2', subject: '工業簿記', section: '第4問対策', topic: '工程別総合原価計算', template: 'statementTable', maxScore: 28, minutes: 18 },
+  { ref: 'industrial_4_3', id: '4-3', subject: '工業簿記', section: '第4問対策', topic: '部門別原価計算', template: 'statementTable', maxScore: 28, minutes: 18 },
+  { ref: 'industrial_4_4', id: '4-4', subject: '工業簿記', section: '第4問対策', topic: '財務諸表作成', template: 'statementTable', maxScore: 28, minutes: 18 },
+  { ref: 'industrial_5_1', id: '5-1', subject: '工業簿記', section: '第5問対策', topic: '標準原価計算', template: 'numeric', maxScore: 12, minutes: 12 },
+  { ref: 'industrial_5_2', id: '5-2', subject: '工業簿記', section: '第5問対策', topic: 'CVP分析', template: 'numeric', maxScore: 12, minutes: 12 },
+  { ref: 'industrial_5_3', id: '5-3', subject: '工業簿記', section: '第5問対策', topic: '全部原価計算と直接原価計算', template: 'numeric', maxScore: 12, minutes: 12 },
+];
+
+export const externalProblemRefs: ExternalProblemRef[] = cpaTrialSections.map((item) => ({
+  id: item.id,
+  examType: 'boki2',
+  studyMode: 'external_material',
+  qualificationName: '日商簿記2級',
+  materialName: 'CPAラーニング 日商簿記2級 試験対策編（外部教材参照）',
+  subject: item.subject,
+  section: item.section,
+  topic: item.topic,
+  title: item.topic,
+  pageMemo: '',
+  studyMemo: '',
+  answerTemplateId: item.template,
+  cpaTrialSectionRef: item.ref,
+  maxScore: item.maxScore,
+  estimatedMinutes: item.minutes,
+  difficulty: '標準',
+  sourceType: 'external_material_reference',
+  referenceScope: 'cpa_trial_section_structure_only',
+  copyrightNote: COPYRIGHT_NOTE,
+  createdAt: NOW,
+  updatedAt: NOW,
+}));
+
+export function findTrialSection(ref: CpaTrialSectionRef): SectionDef {
+  return cpaTrialSections.find((item) => item.ref === ref) ?? cpaTrialSections[0];
+}

--- a/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
@@ -1,50 +1,82 @@
-import type { AnswerLine, QuestionItem } from '../originalStudyTypes';
+import { cpaTrialSections, findTrialSection } from './cpaTrialSections';
+import type { AnswerLine, CpaTrialSectionRef, QuestionItem, VerificationStatus } from '../originalStudyTypes';
 
 const NOW = '2026-05-24T00:00:00.000Z';
+const COPYRIGHT_NOTE = 'CPA問題集の試験対策編の区分のみ参考。問題文・解答・解説・数値・表構成は未使用。';
 
 function line(input: Partial<AnswerLine>): AnswerLine {
   return { id: crypto.randomUUID(), grade: '未採点', points: 0, ...input };
 }
 
-function q(input: Omit<QuestionItem, 'examType' | 'sourceType' | 'isVerified' | 'createdAt' | 'updatedAt'>): QuestionItem {
-  return { examType: 'boki2', sourceType: 'original', isVerified: true, createdAt: NOW, updatedAt: NOW, ...input };
+function quality(approved: boolean, memo: string) {
+  return {
+    scopeChecked: approved,
+    cpaTrialSectionChecked: true,
+    accountTitleChecked: approved,
+    journalChecked: approved,
+    amountChecked: approved,
+    explanationChecked: approved,
+    difficultyChecked: approved,
+    copySimilarityChecked: true,
+    reviewer: 'ChatGPT implementation draft',
+    checkedAt: approved ? '2026-05-24' : '',
+    evidenceMemo: memo,
+  };
 }
 
-export const originalQuestions: QuestionItem[] = [
-  q({
-    id: '仕訳-001', subject: '商業簿記', section: '第1問対策', topic: '商品売買', title: '掛仕入と仕入諸掛', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい',
-    questionText: '商品200,000円を掛けで仕入れ、引取運賃6,000円は現金で支払った。なお、引取運賃は仕入原価に含める。必要な仕訳を答えなさい。',
-    conditions: ['税金は考慮しない。', '仕入諸掛は仕入勘定に含める。'],
-    modelAnswer: [line({ debitAccount: '仕入', debitAmount: '206000', creditAccount: '買掛金', creditAmount: '200000', points: 2 }), line({ debitAccount: '', debitAmount: '', creditAccount: '現金', creditAmount: '6000', points: 2 })],
-    explanation: '仕入諸掛を仕入原価に含めるため、仕入は商品代金と運賃の合計額になる。貸方は掛代金と現金支払を分けて記録する。',
-  }),
-  q({ id: '仕訳-002', subject: '商業簿記', section: '第1問対策', topic: '売上戻り', title: '掛売上の返品', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '前月に掛けで販売した商品80,000円について、品質不良により20,000円分の返品を受けた。必要な仕訳を答えなさい。', conditions: ['税金は考慮しない。'], modelAnswer: [line({ debitAccount: '売上', debitAmount: '20000', creditAccount: '売掛金', creditAmount: '20000', points: 4 })], explanation: '返品を受けた場合、売上を取り消し、売掛金も減少させる。' }),
-  q({ id: '仕訳-003', subject: '商業簿記', section: '第1問対策', topic: '固定資産売却', title: '備品の売却損益', answerTemplateId: 'journal', maxScore: 6, estimatedMinutes: 4, difficulty: '標準', questionText: '取得原価300,000円、減価償却累計額180,000円の備品を100,000円で売却し、代金は月末に受け取ることとした。必要な仕訳を答えなさい。', conditions: ['売却時の追加償却は不要。', '未収入金勘定を用いる。'], modelAnswer: [line({ debitAccount: '減価償却累計額', debitAmount: '180000', creditAccount: '備品', creditAmount: '300000', points: 2 }), line({ debitAccount: '未収入金', debitAmount: '100000', creditAccount: '', creditAmount: '', points: 2 }), line({ debitAccount: '固定資産売却損', debitAmount: '20000', creditAccount: '', creditAmount: '', points: 2 })], explanation: '帳簿価額は120,000円。売却価額100,000円との差額20,000円は固定資産売却損で処理する。' }),
-  q({ id: '仕訳-004', subject: '商業簿記', section: '第1問対策', topic: '貸倒引当金', title: '貸倒引当金の設定', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '決算にあたり、売掛金残高500,000円に対して2%の貸倒引当金を設定する。なお、貸倒引当金の期末残高は3,000円である。差額補充法により必要な仕訳を答えなさい。', conditions: ['貸倒引当金繰入を用いる。'], modelAnswer: [line({ debitAccount: '貸倒引当金繰入', debitAmount: '7000', creditAccount: '貸倒引当金', creditAmount: '7000', points: 4 })], explanation: '必要額は500,000円×2%=10,000円。既存残高3,000円との差額7,000円を繰り入れる。' }),
-  q({ id: '仕訳-005', subject: '商業簿記', section: '第1問対策', topic: '手形', title: '約束手形の振出し', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '買掛金150,000円の支払いとして、同額の約束手形を振り出した。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '買掛金', debitAmount: '150000', creditAccount: '支払手形', creditAmount: '150000', points: 4 })], explanation: '買掛金が減少し、手形債務である支払手形が増加する。' }),
-  q({ id: '仕訳-006', subject: '商業簿記', section: '第1問対策', topic: '電子記録債権', title: '電子記録債権の発生', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '売掛金120,000円について、取引先の承諾を得て電子記録債権へ振り替えた。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '電子記録債権', debitAmount: '120000', creditAccount: '売掛金', creditAmount: '120000', points: 4 })], explanation: '売掛金を電子記録債権に振り替える。' }),
-  q({ id: '仕訳-007', subject: '商業簿記', section: '第1問対策', topic: '有価証券', title: '売買目的有価証券の評価', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '売買目的有価証券の帳簿価額240,000円について、決算時の時価が255,000円であった。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '売買目的有価証券', debitAmount: '15000', creditAccount: '有価証券評価益', creditAmount: '15000', points: 4 })], explanation: '売買目的有価証券は時価評価し、増加額15,000円を評価益にする。' }),
-  q({ id: '仕訳-008', subject: '商業簿記', section: '第1問対策', topic: '消費税', title: '税抜方式の売上', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '商品330,000円を掛けで販売した。税込金額であり、消費税率は10%、税抜方式で処理する。必要な仕訳を答えなさい。', conditions: ['税抜売上300,000円、消費税30,000円。'], modelAnswer: [line({ debitAccount: '売掛金', debitAmount: '330000', creditAccount: '売上', creditAmount: '300000', points: 2 }), line({ debitAccount: '', debitAmount: '', creditAccount: '仮受消費税', creditAmount: '30000', points: 2 })], explanation: '税込金額を本体価格と消費税に分け、税抜方式で仮受消費税を計上する。' }),
-  q({ id: '仕訳-009', subject: '商業簿記', section: '第1問対策', topic: '前払費用', title: '保険料の前払い', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '当期首に1年分の保険料120,000円を支払い、全額を保険料として処理していた。決算日は支払日から9か月経過後である。必要な決算整理仕訳を答えなさい。', conditions: ['未経過分を前払保険料に振り替える。'], modelAnswer: [line({ debitAccount: '前払保険料', debitAmount: '30000', creditAccount: '保険料', creditAmount: '30000', points: 4 })], explanation: '未経過期間は3か月。120,000円×3/12=30,000円を前払処理する。' }),
-  q({ id: '仕訳-010', subject: '商業簿記', section: '第1問対策', topic: '未払費用', title: '利息の未払い', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '借入金600,000円について、年利3%、利息は毎年6月末に1年分を後払いする。決算日は3月31日であり、当期分9か月の利息を見越し計上する。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '支払利息', debitAmount: '13500', creditAccount: '未払利息', creditAmount: '13500', points: 4 })], explanation: '600,000円×3%×9/12=13,500円を未払計上する。' }),
-  q({ id: '仕訳-011', subject: '商業簿記', section: '第1問対策', topic: 'リース取引', title: 'ファイナンス・リース開始', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 4, difficulty: 'やや難', questionText: '所有権移転外ファイナンス・リース取引として機械を取得した。リース料総額は500,000円、利息相当額は考慮しない。リース取引開始時の仕訳を答えなさい。', conditions: ['リース資産、リース債務を用いる。'], modelAnswer: [line({ debitAccount: 'リース資産', debitAmount: '500000', creditAccount: 'リース債務', creditAmount: '500000', points: 4 })], explanation: 'ファイナンス・リースは売買取引に準じ、リース資産とリース債務を計上する。' }),
-  q({ id: '仕訳-012', subject: '商業簿記', section: '第1問対策', topic: '退職給付', title: '退職給付費用の計上', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '決算にあたり、当期の退職給付費用40,000円を計上する。必要な仕訳を答えなさい。', conditions: ['退職給付引当金を用いる。'], modelAnswer: [line({ debitAccount: '退職給付費用', debitAmount: '40000', creditAccount: '退職給付引当金', creditAmount: '40000', points: 4 })], explanation: '当期発生分を費用計上し、将来支払見込額を引当金として認識する。' }),
-  q({ id: '仕訳-013', subject: '商業簿記', section: '第1問対策', topic: '税効果会計', title: '繰延税金資産の計上', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 4, difficulty: 'やや難', questionText: '将来減算一時差異100,000円が発生した。法定実効税率を30%として税効果会計を適用する。必要な仕訳を答えなさい。', conditions: ['回収可能性はあるものとする。'], modelAnswer: [line({ debitAccount: '繰延税金資産', debitAmount: '30000', creditAccount: '法人税等調整額', creditAmount: '30000', points: 4 })], explanation: '将来減算一時差異に税率を乗じた30,000円を繰延税金資産として計上する。' }),
-  q({ id: '仕訳-014', subject: '商業簿記', section: '第1問対策', topic: '剰余金処分', title: '利益準備金の積立て', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '株主総会において、繰越利益剰余金から配当金100,000円を支払うことを決議し、会社法上必要な利益準備金10,000円を積み立てた。必要な仕訳を答えなさい。', conditions: ['未払配当金を用いる。'], modelAnswer: [line({ debitAccount: '繰越利益剰余金', debitAmount: '110000', creditAccount: '未払配当金', creditAmount: '100000', points: 2 }), line({ debitAccount: '', debitAmount: '', creditAccount: '利益準備金', creditAmount: '10000', points: 2 })], explanation: '配当と準備金積立の合計額だけ繰越利益剰余金が減少する。' }),
-  q({ id: '仕訳-015', subject: '商業簿記', section: '第1問対策', topic: '社債', title: '社債利息の支払い', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '額面1,000,000円、年利2%の社債について、半年分の利息を普通預金から支払った。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '社債利息', debitAmount: '10000', creditAccount: '普通預金', creditAmount: '10000', points: 4 })], explanation: '1,000,000円×2%×6/12=10,000円を支払う。' }),
-  q({ id: '仕訳-016', subject: '商業簿記', section: '第1問対策', topic: '収益認識', title: '前受金から売上への振替', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '商品代金として前受金50,000円を受け取っていた。本日、商品を引き渡し、売上として認識した。必要な仕訳を答えなさい。', conditions: ['税金は考慮しない。'], modelAnswer: [line({ debitAccount: '前受金', debitAmount: '50000', creditAccount: '売上', creditAmount: '50000', points: 4 })], explanation: '履行義務の充足により、前受金を売上へ振り替える。' }),
-  q({ id: '仕訳-017', subject: '商業簿記', section: '第1問対策', topic: '研究開発費', title: '研究開発費の支出', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '新製品の研究開発のため、試験材料費70,000円を現金で支払った。必要な仕訳を答えなさい。', conditions: ['研究開発費として処理する。'], modelAnswer: [line({ debitAccount: '研究開発費', debitAmount: '70000', creditAccount: '現金', creditAmount: '70000', points: 4 })], explanation: '研究開発目的の支出は研究開発費として発生時に費用処理する。' }),
-  q({ id: '仕訳-018', subject: '商業簿記', section: '第1問対策', topic: '連結会計', title: 'のれんの償却', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 4, difficulty: 'やや難', questionText: '連結決算において、当期ののれん償却額12,000円を計上する。必要な連結修正仕訳を答えなさい。', conditions: ['のれん償却を費用として処理する。'], modelAnswer: [line({ debitAccount: 'のれん償却', debitAmount: '12000', creditAccount: 'のれん', creditAmount: '12000', points: 4 })], explanation: 'のれんは効果の及ぶ期間にわたり償却し、費用化する。' }),
-  q({ id: '仕訳-019', subject: '商業簿記', section: '第1問対策', topic: '外貨建取引', title: '外貨売掛金の決済', answerTemplateId: 'journal', maxScore: 6, estimatedMinutes: 4, difficulty: 'やや難', questionText: '外貨建売掛金1,000ドルを決済し、普通預金に入金された。売掛金計上時の為替相場は1ドル140円、決済時は1ドル145円である。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '普通預金', debitAmount: '145000', creditAccount: '売掛金', creditAmount: '140000', points: 3 }), line({ debitAccount: '', debitAmount: '', creditAccount: '為替差益', creditAmount: '5000', points: 3 })], explanation: '入金額145,000円と売掛金帳簿価額140,000円との差額5,000円は為替差益である。' }),
-  q({ id: '仕訳-020', subject: '商業簿記', section: '第1問対策', topic: '決算整理', title: '売上原価の算定', answerTemplateId: 'journal', maxScore: 6, estimatedMinutes: 4, difficulty: '標準', questionText: '期首商品棚卸高30,000円、当期仕入高220,000円、期末商品棚卸高40,000円である。三分法で売上原価を算定するための決算整理仕訳を答えなさい。', conditions: ['仕入勘定で売上原価を計算する方法による。'], modelAnswer: [line({ debitAccount: '仕入', debitAmount: '30000', creditAccount: '繰越商品', creditAmount: '30000', points: 3 }), line({ debitAccount: '繰越商品', debitAmount: '40000', creditAccount: '仕入', creditAmount: '40000', points: 3 })], explanation: '期首商品を仕入へ振り替え、期末商品を繰越商品へ振り替える。' }),
-  q({ id: '工業-001', subject: '工業簿記', section: '第4問対策', topic: '材料費', title: '材料消費額の計上', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '直接材料80,000円、間接材料12,000円を当月製造のために消費した。必要な仕訳を答えなさい。', conditions: ['直接材料は仕掛品、間接材料は製造間接費に振り替える。'], modelAnswer: [line({ debitAccount: '仕掛品', debitAmount: '80000', creditAccount: '材料', creditAmount: '92000', points: 2 }), line({ debitAccount: '製造間接費', debitAmount: '12000', creditAccount: '', creditAmount: '', points: 2 })], explanation: '直接材料は仕掛品へ、間接材料は製造間接費へ集計する。' }),
-  q({ id: '工業-002', subject: '工業簿記', section: '第4問対策', topic: '労務費', title: '賃金消費額の計上', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '直接工の直接作業時間分の賃金90,000円、間接作業時間分の賃金15,000円を当月消費額として計上する。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '仕掛品', debitAmount: '90000', creditAccount: '賃金', creditAmount: '105000', points: 2 }), line({ debitAccount: '製造間接費', debitAmount: '15000', creditAccount: '', creditAmount: '', points: 2 })], explanation: '直接労務費は仕掛品、間接労務費は製造間接費に集計する。' }),
-  q({ id: '工業-003', subject: '工業簿記', section: '第4問対策', topic: '製造間接費', title: '予定配賦', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '標準', questionText: '製造間接費を予定配賦率600円/時間、実際直接作業時間150時間により仕掛品へ配賦した。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '仕掛品', debitAmount: '90000', creditAccount: '製造間接費', creditAmount: '90000', points: 4 })], explanation: '600円×150時間=90,000円を予定配賦する。' }),
-  q({ id: '工業-004', subject: '工業簿記', section: '第4問対策', topic: '完成品振替', title: '完成品原価の振替', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '当月完成した製品の製造原価260,000円を仕掛品から製品へ振り替える。必要な仕訳を答えなさい。', conditions: [], modelAnswer: [line({ debitAccount: '製品', debitAmount: '260000', creditAccount: '仕掛品', creditAmount: '260000', points: 4 })], explanation: '完成したものは仕掛品から製品へ振り替える。' }),
-  q({ id: '工業-005', subject: '工業簿記', section: '第4問対策', topic: '売上原価', title: '製品販売時の原価振替', answerTemplateId: 'journal', maxScore: 4, estimatedMinutes: 3, difficulty: '易しい', questionText: '製品を販売し、対応する製品原価180,000円を売上原価へ振り替える。必要な仕訳を答えなさい。', conditions: ['売上の仕訳は不要。'], modelAnswer: [line({ debitAccount: '売上原価', debitAmount: '180000', creditAccount: '製品', creditAmount: '180000', points: 4 })], explanation: '販売した製品の原価は製品から売上原価へ振り替える。' }),
-  q({ id: '計算-001', subject: '工業簿記', section: '第5問対策', topic: 'CVP', title: '損益分岐点売上高', answerTemplateId: 'numeric', maxScore: 6, estimatedMinutes: 5, difficulty: '標準', questionText: '販売価格1,000円、変動費率60%、固定費200,000円である。損益分岐点売上高を求めなさい。', conditions: ['金額は円単位で入力する。'], modelAnswer: [line({ itemName: '損益分岐点売上高', value: '500000', points: 6 })], explanation: '貢献利益率は40%。200,000円÷40%=500,000円。' }),
-  q({ id: '計算-002', subject: '工業簿記', section: '第5問対策', topic: 'CVP', title: '目標利益を達成する売上高', answerTemplateId: 'numeric', maxScore: 6, estimatedMinutes: 5, difficulty: '標準', questionText: '変動費率55%、固定費270,000円、目標営業利益90,000円である。目標利益を達成する売上高を求めなさい。', conditions: ['金額は円単位で入力する。'], modelAnswer: [line({ itemName: '目標利益達成売上高', value: '800000', points: 6 })], explanation: '貢献利益率45%。必要貢献利益は360,000円。360,000円÷45%=800,000円。' }),
-  q({ id: '計算-003', subject: '工業簿記', section: '第5問対策', topic: '標準原価計算', title: '直接材料費差異', answerTemplateId: 'numeric', maxScore: 8, estimatedMinutes: 6, difficulty: 'やや難', questionText: '直接材料の標準価格は1kgあたり500円、標準消費量は完成品1個あたり2kgである。当月完成品は100個、実際消費量は230kg、実際購入価格は1kgあたり480円であった。価格差異と数量差異を求めなさい。', conditions: ['有利差異はプラス、不利差異はマイナスで入力する。'], modelAnswer: [line({ itemName: '価格差異', value: '4600', points: 4 }), line({ itemName: '数量差異', value: '-15000', points: 4 })], explanation: '価格差異=(500-480)×230=4,600円有利。数量差異=(標準200kg-実際230kg)×500=-15,000円不利。' }),
-  q({ id: '計算-004', subject: '工業簿記', section: '第5問対策', topic: '標準原価計算', title: '直接労務費差異', answerTemplateId: 'numeric', maxScore: 8, estimatedMinutes: 6, difficulty: 'やや難', questionText: '標準賃率は1時間あたり1,200円、標準作業時間は完成品1個あたり0.5時間である。当月完成品は300個、実際作業時間は170時間、実際賃率は1時間あたり1,150円であった。賃率差異と作業時間差異を求めなさい。', conditions: ['有利差異はプラス、不利差異はマイナスで入力する。'], modelAnswer: [line({ itemName: '賃率差異', value: '8500', points: 4 }), line({ itemName: '作業時間差異', value: '-24000', points: 4 })], explanation: '賃率差異=(1,200-1,150)×170=8,500円有利。作業時間差異=(標準150時間-実際170時間)×1,200=-24,000円不利。' }),
-  q({ id: '計算-005', subject: '工業簿記', section: '第5問対策', topic: '直接原価計算', title: '全部原価計算との差異', answerTemplateId: 'numeric', maxScore: 6, estimatedMinutes: 5, difficulty: 'やや難', questionText: '固定製造間接費は月額120,000円である。当月は生産数量1,000個、販売数量900個で、月初製品はない。全部原価計算と直接原価計算の営業利益差額を求めなさい。', conditions: ['全部原価計算の営業利益が大きい場合はプラスで入力する。'], modelAnswer: [line({ itemName: '営業利益差額', value: '12000', points: 6 })], explanation: '固定製造間接費の単価は120円。期末在庫100個に含まれる固定費12,000円だけ、全部原価計算の利益が大きくなる。' }),
+function q(input: { ref: CpaTrialSectionRef; title: string; questionText: string; conditions?: string[]; modelAnswer?: AnswerLine[]; explanation?: string; maxScore?: number; status?: VerificationStatus }): QuestionItem {
+  const section = findTrialSection(input.ref);
+  const approved = (input.status ?? 'approved') === 'approved';
+  return {
+    id: `短問-${section.id}`,
+    examType: 'boki2',
+    studyMode: 'built_in_question',
+    subject: section.subject,
+    section: section.section,
+    topic: section.topic,
+    title: input.title,
+    questionText: input.questionText,
+    conditions: input.conditions ?? [],
+    answerTemplateId: section.template,
+    modelAnswer: input.modelAnswer ?? [line({ itemName: '解答欄', value: '', points: 0 })],
+    explanation: input.explanation ?? 'この問題は管理画面で検証後に通常演習へ表示してください。',
+    maxScore: input.maxScore ?? Math.min(section.maxScore, 10),
+    estimatedMinutes: Math.min(section.minutes, 8),
+    difficulty: approved ? '標準' : 'やや難',
+    sourceType: 'initial_original',
+    verificationStatus: input.status ?? 'approved',
+    qualityCheck: quality(approved, approved ? '一般的な簿記2級知識に基づく短問として、仕訳・金額・解説を自己検証済み。CPA教材本文・数値・表構成は未使用。' : '区分対応のみ設定。通常演習には出さない。'),
+    cpaTrialSectionRef: input.ref,
+    referenceScope: 'cpa_trial_section_structure_only',
+    copyrightNote: COPYRIGHT_NOTE,
+    isVerified: approved,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+const approvedQuestions: QuestionItem[] = [
+  q({ ref: 'commercial_1_1', title: '掛仕入と仕入諸掛', questionText: '商品200,000円を掛けで仕入れ、引取運賃6,000円を現金で支払った。引取運賃は仕入原価に含める。必要な仕訳を答えなさい。', conditions: ['税金は考慮しない。'], modelAnswer: [line({ debitAccount: '仕入', debitAmount: '206000', creditAccount: '買掛金', creditAmount: '200000', points: 2 }), line({ debitAccount: '', debitAmount: '', creditAccount: '現金', creditAmount: '6000', points: 2 })], explanation: '仕入諸掛は仕入原価に含めるため、仕入は206,000円になる。貸方は買掛金と現金支払に分ける。', maxScore: 4 }),
+  q({ ref: 'commercial_1_2', title: '電子記録債権への振替', questionText: '売掛金120,000円について、取引先の承諾を得て電子記録債権へ振り替えた。必要な仕訳を答えなさい。', modelAnswer: [line({ debitAccount: '電子記録債権', debitAmount: '120000', creditAccount: '売掛金', creditAmount: '120000', points: 4 })], explanation: '売掛金という通常債権を電子記録債権へ振り替える。', maxScore: 4 }),
+  q({ ref: 'commercial_1_3', title: '備品売却損', questionText: '取得原価300,000円、減価償却累計額180,000円の備品を100,000円で売却し、代金は翌月受け取ることにした。必要な仕訳を答えなさい。', conditions: ['未収入金勘定を用いる。'], modelAnswer: [line({ debitAccount: '減価償却累計額', debitAmount: '180000', creditAccount: '備品', creditAmount: '300000', points: 2 }), line({ debitAccount: '未収入金', debitAmount: '100000', creditAccount: '', creditAmount: '', points: 2 }), line({ debitAccount: '固定資産売却損', debitAmount: '20000', creditAccount: '', creditAmount: '', points: 2 })], explanation: '帳簿価額は120,000円。売却価額100,000円との差額20,000円は売却損。', maxScore: 6 }),
+  q({ ref: 'commercial_1_4', title: 'ファイナンス・リース開始', questionText: '所有権移転外ファイナンス・リース取引として機械を取得した。リース料総額500,000円、利息相当額は考慮しない。開始時の仕訳を答えなさい。', conditions: ['リース資産、リース債務を用いる。'], modelAnswer: [line({ debitAccount: 'リース資産', debitAmount: '500000', creditAccount: 'リース債務', creditAmount: '500000', points: 4 })], explanation: 'ファイナンス・リースは売買取引に準じて資産と債務を認識する。', maxScore: 4 }),
+  q({ ref: 'commercial_1_5', title: '外貨建売掛金の決済', questionText: '外貨建売掛金1,000ドルを決済し、普通預金に入金された。売掛金計上時は1ドル140円、決済時は1ドル145円である。必要な仕訳を答えなさい。', modelAnswer: [line({ debitAccount: '普通預金', debitAmount: '145000', creditAccount: '売掛金', creditAmount: '140000', points: 3 }), line({ debitAccount: '', debitAmount: '', creditAccount: '為替差益', creditAmount: '5000', points: 3 })], explanation: '入金145,000円と売掛金帳簿価額140,000円との差額5,000円は為替差益。', maxScore: 6 }),
+  q({ ref: 'industrial_4_1', title: '材料消費額の計上', questionText: '直接材料80,000円、間接材料12,000円を当月製造のために消費した。必要な仕訳を答えなさい。', conditions: ['直接材料は仕掛品、間接材料は製造間接費へ振り替える。'], modelAnswer: [line({ debitAccount: '仕掛品', debitAmount: '80000', creditAccount: '材料', creditAmount: '92000', points: 2 }), line({ debitAccount: '製造間接費', debitAmount: '12000', creditAccount: '', creditAmount: '', points: 2 })], explanation: '直接材料は仕掛品へ、間接材料は製造間接費へ集計する。', maxScore: 4 }),
+  q({ ref: 'industrial_5_1', title: '直接材料費差異', questionText: '標準価格は1kgあたり500円、標準消費量は完成品1個あたり2kgである。完成品100個、実際消費量230kg、実際価格480円/kgの場合、価格差異と数量差異を求めなさい。', conditions: ['有利差異はプラス、不利差異はマイナスで入力する。'], modelAnswer: [line({ itemName: '価格差異', value: '4600', points: 4 }), line({ itemName: '数量差異', value: '-15000', points: 4 })], explanation: '価格差異=(500-480)×230=4,600円有利。数量差異=(200kg-230kg)×500=-15,000円不利。', maxScore: 8 }),
+  q({ ref: 'industrial_5_2', title: '損益分岐点売上高', questionText: '販売価格1,000円、変動費率60%、固定費200,000円である。損益分岐点売上高を求めなさい。', conditions: ['金額は円単位で入力する。'], modelAnswer: [line({ itemName: '損益分岐点売上高', value: '500000', points: 6 })], explanation: '貢献利益率は40%。200,000円÷40%=500,000円。', maxScore: 6 }),
+  q({ ref: 'industrial_5_3', title: '全部原価計算と直接原価計算の利益差', questionText: '固定製造間接費は月額120,000円。当月は生産1,000個、販売900個、月初製品なしである。全部原価計算の営業利益が直接原価計算よりいくら大きいか求めなさい。', conditions: ['差額は円単位で入力する。'], modelAnswer: [line({ itemName: '営業利益差額', value: '12000', points: 6 })], explanation: '固定製造間接費の単価は120円。期末在庫100個に含まれる固定費12,000円だけ、全部原価計算の利益が大きい。', maxScore: 6 }),
 ];
+
+const approvedRefs = new Set(approvedQuestions.map((question) => question.cpaTrialSectionRef));
+const draftQuestions: QuestionItem[] = cpaTrialSections.filter((section) => !approvedRefs.has(section.ref)).map((section) => q({
+  ref: section.ref,
+  title: `${section.topic}（ドラフト）`,
+  questionText: 'この区分は試験対策編の対応カテゴリとして登録済みです。問題本文・模範解答・解説は未検証のため、通常演習には表示しません。',
+  conditions: ['管理画面で検証後、verificationStatusをapprovedにしてください。'],
+  status: 'draft',
+  maxScore: Math.min(section.maxScore, 10),
+}));
+
+export const originalQuestions: QuestionItem[] = [...approvedQuestions, ...draftQuestions];
+export const approvedOriginalQuestions: QuestionItem[] = originalQuestions.filter((question) => question.verificationStatus === 'approved');
+export const draftOriginalQuestions: QuestionItem[] = originalQuestions.filter((question) => question.verificationStatus === 'draft');

--- a/cpa-boki2-trial-section-answer-manager/src/originalStudyStorage.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/originalStudyStorage.ts
@@ -1,8 +1,8 @@
-import type { AnswerAttempt, QuestionItem, ReviewSchedule, StudyBackupPayload } from './originalStudyTypes';
+import type { AnswerAttempt, ExternalProblemRef, QuestionItem, ReviewSchedule, StudyBackupPayload } from './originalStudyTypes';
 
 const DB_NAME = 'nissho-boki2-original-study-app';
-const DB_VERSION = 1;
-const STORES = ['questions', 'answerAttempts', 'reviewSchedules', 'settings', 'userProblems', 'histories'] as const;
+const DB_VERSION = 2;
+const STORES = ['questions', 'externalProblemRefs', 'answerAttempts', 'reviewSchedules', 'settings', 'userProblems', 'histories'] as const;
 type StoreName = (typeof STORES)[number];
 
 function openDb(): Promise<IDBDatabase> {
@@ -46,6 +46,26 @@ export async function saveQuestions(questions: QuestionItem[]): Promise<void> {
   });
 }
 
+export async function saveExternalProblemRef(ref: ExternalProblemRef): Promise<void> {
+  await tx('externalProblemRefs', 'readwrite', (store) => store.put(ref));
+}
+
+export async function saveExternalProblemRefs(refs: ExternalProblemRef[]): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction('externalProblemRefs', 'readwrite');
+    const store = transaction.objectStore('externalProblemRefs');
+    refs.forEach((ref) => store.put(ref));
+    transaction.oncomplete = () => { db.close(); resolve(); };
+    transaction.onerror = () => { db.close(); reject(transaction.error); };
+  });
+}
+
+export async function getStoredExternalProblemRefs(): Promise<ExternalProblemRef[]> {
+  const rows = await tx<ExternalProblemRef[]>('externalProblemRefs', 'readonly', (store) => store.getAll());
+  return rows.sort((a, b) => a.id.localeCompare(b.id, 'ja'));
+}
+
 export async function getStoredQuestions(): Promise<QuestionItem[]> {
   const [questions, userProblems] = await Promise.all([
     tx<QuestionItem[]>('questions', 'readonly', (store) => store.getAll()),
@@ -73,16 +93,20 @@ export async function getReviewSchedules(): Promise<ReviewSchedule[]> {
   return rows.sort((a, b) => a.nextReviewDate.localeCompare(b.nextReviewDate));
 }
 
-export async function exportStudyData(appQuestions: QuestionItem[]): Promise<StudyBackupPayload> {
-  const [storedQuestions, answerAttempts, reviewSchedules] = await Promise.all([getStoredQuestions(), getAttempts(), getReviewSchedules()]);
-  const merged = new Map<string, QuestionItem>();
-  appQuestions.forEach((question) => merged.set(question.id, question));
-  storedQuestions.forEach((question) => merged.set(question.id, question));
+export async function exportStudyData(appQuestions: QuestionItem[], appExternalRefs: ExternalProblemRef[]): Promise<StudyBackupPayload> {
+  const [storedQuestions, storedExternalRefs, answerAttempts, reviewSchedules] = await Promise.all([getStoredQuestions(), getStoredExternalProblemRefs(), getAttempts(), getReviewSchedules()]);
+  const mergedQuestions = new Map<string, QuestionItem>();
+  appQuestions.forEach((question) => mergedQuestions.set(question.id, question));
+  storedQuestions.forEach((question) => mergedQuestions.set(question.id, question));
+  const mergedRefs = new Map<string, ExternalProblemRef>();
+  appExternalRefs.forEach((ref) => mergedRefs.set(ref.id, ref));
+  storedExternalRefs.forEach((ref) => mergedRefs.set(ref.id, ref));
   return {
     exportedAt: new Date().toISOString(),
-    appName: '日商簿記2級 オリジナル問題演習・復習管理アプリ',
-    version: '1.0.0',
-    questions: Array.from(merged.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja')),
+    appName: '資格横断型 問題演習・採点・復習管理アプリ',
+    version: '2.0.0',
+    questions: Array.from(mergedQuestions.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja')),
+    externalProblemRefs: Array.from(mergedRefs.values()).sort((a, b) => a.id.localeCompare(b.id, 'ja')),
     answerAttempts,
     reviewSchedules,
   };
@@ -92,8 +116,9 @@ export async function importStudyData(payload: StudyBackupPayload): Promise<void
   if (!payload || !Array.isArray(payload.questions)) throw new Error('invalid payload');
   const db = await openDb();
   await new Promise<void>((resolve, reject) => {
-    const transaction = db.transaction(['questions', 'userProblems', 'answerAttempts', 'reviewSchedules', 'histories'], 'readwrite');
+    const transaction = db.transaction(['questions', 'externalProblemRefs', 'userProblems', 'answerAttempts', 'reviewSchedules', 'histories'], 'readwrite');
     payload.questions.forEach((question) => transaction.objectStore(question.sourceType === 'user_created' ? 'userProblems' : 'questions').put(question));
+    (payload.externalProblemRefs ?? []).forEach((ref) => transaction.objectStore('externalProblemRefs').put(ref));
     (payload.answerAttempts ?? []).forEach((attempt) => {
       transaction.objectStore('answerAttempts').put(attempt);
       transaction.objectStore('histories').put(attempt);
@@ -104,8 +129,8 @@ export async function importStudyData(payload: StudyBackupPayload): Promise<void
   });
 }
 
-export async function storageSummary(): Promise<{ questionCount: number; attemptCount: number; reviewCount: number; usage: number | null; quota: number | null }> {
-  const [questions, attempts, reviews] = await Promise.all([getStoredQuestions(), getAttempts(), getReviewSchedules()]);
+export async function storageSummary(): Promise<{ questionCount: number; externalRefCount: number; attemptCount: number; reviewCount: number; usage: number | null; quota: number | null }> {
+  const [questions, externalRefs, attempts, reviews] = await Promise.all([getStoredQuestions(), getStoredExternalProblemRefs(), getAttempts(), getReviewSchedules()]);
   const estimate = navigator.storage?.estimate ? await navigator.storage.estimate() : null;
-  return { questionCount: questions.length, attemptCount: attempts.length, reviewCount: reviews.length, usage: estimate?.usage ?? null, quota: estimate?.quota ?? null };
+  return { questionCount: questions.length, externalRefCount: externalRefs.length, attemptCount: attempts.length, reviewCount: reviews.length, usage: estimate?.usage ?? null, quota: estimate?.quota ?? null };
 }

--- a/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
@@ -1,18 +1,61 @@
-export type ExamType = 'boki2' | 'kensetsu_keiri_2' | 'gyouseishoshi' | 'benrishi' | string;
+export type ExamType = 'boki2' | 'kensetsu_keiri2' | 'benrishi' | 'gyoseishoshi';
+export type StudyMode = 'external_material' | 'built_in_question';
 export type SubjectName = '商業簿記' | '工業簿記';
 export type SectionName = '第1問対策' | '第2問対策' | '第3問対策' | '第4問対策' | '第5問対策';
 export type Difficulty = '易しい' | '標準' | 'やや難' | '難しい';
-export type SourceType = 'original' | 'public_domain' | 'licensed' | 'user_created';
-export type AnswerTemplateId = 'journal' | 'numeric' | 'statementTable' | 'free';
+export type SourceType = 'external_material_reference' | 'initial_original' | 'user_created' | 'law_text' | 'official_past_exam' | 'licensed';
+export type VerificationStatus = 'draft' | 'self_checked' | 'source_checked' | 'approved' | 'rejected';
+export type CpaTrialSectionRef =
+  | 'commercial_1_1'
+  | 'commercial_1_2'
+  | 'commercial_1_3'
+  | 'commercial_1_4'
+  | 'commercial_1_5'
+  | 'commercial_2_1'
+  | 'commercial_2_2'
+  | 'commercial_2_3'
+  | 'commercial_2_4'
+  | 'commercial_2_5'
+  | 'commercial_2_6'
+  | 'commercial_3_1'
+  | 'commercial_3_2'
+  | 'commercial_3_3'
+  | 'industrial_4_1'
+  | 'industrial_4_2'
+  | 'industrial_4_3'
+  | 'industrial_4_4'
+  | 'industrial_5_1'
+  | 'industrial_5_2'
+  | 'industrial_5_3';
+export type ReferenceScope = 'cpa_trial_section_structure_only';
+export type AnswerTemplateId = 'journal' | 'numeric' | 'statementTable' | 'accountLedger' | 'free';
 export type GradeMark = '未採点' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
 export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方逆' | '金額ミス' | '集計ミス' | '転記ミス' | '表の入力位置ミス' | '下書き不足' | '時間不足' | '解答形式の誤認' | '問題文読み落とし' | 'その他';
 
+export interface QualityCheck {
+  scopeChecked: boolean;
+  cpaTrialSectionChecked: boolean;
+  accountTitleChecked: boolean;
+  journalChecked: boolean;
+  amountChecked: boolean;
+  explanationChecked: boolean;
+  difficultyChecked: boolean;
+  copySimilarityChecked: boolean;
+  reviewer: string;
+  checkedAt: string;
+  evidenceMemo: string;
+}
+
 export interface AnswerLine {
   id: string;
   itemName?: string;
+  debitDate?: string;
+  debitSummary?: string;
   debitAccount?: string;
   debitAmount?: string;
+  creditDate?: string;
+  creditSummary?: string;
   creditAccount?: string;
   creditAmount?: string;
   value?: string;
@@ -25,9 +68,34 @@ export interface AnswerLine {
   points: number;
 }
 
+export interface ExternalProblemRef {
+  id: string;
+  examType: 'boki2';
+  studyMode: 'external_material';
+  qualificationName: '日商簿記2級';
+  materialName: string;
+  subject: SubjectName;
+  section: SectionName;
+  topic: string;
+  title: string;
+  pageMemo: string;
+  studyMemo: string;
+  answerTemplateId: AnswerTemplateId;
+  cpaTrialSectionRef: CpaTrialSectionRef;
+  maxScore: number;
+  estimatedMinutes?: number;
+  difficulty?: Difficulty;
+  sourceType: 'external_material_reference';
+  referenceScope: ReferenceScope;
+  copyrightNote: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface QuestionItem {
   id: string;
   examType: 'boki2';
+  studyMode: 'built_in_question';
   subject: SubjectName;
   section: SectionName;
   topic: string;
@@ -35,25 +103,35 @@ export interface QuestionItem {
   questionText: string;
   conditions: string[];
   answerTemplateId: AnswerTemplateId;
+  modelAnswer: AnswerLine[];
+  explanation: string;
   maxScore: number;
   estimatedMinutes?: number;
   difficulty?: Difficulty;
-  explanation?: string;
   sourceType: SourceType;
+  verificationStatus: VerificationStatus;
+  qualityCheck: QualityCheck;
+  cpaTrialSectionRef: CpaTrialSectionRef;
+  referenceScope: ReferenceScope;
+  copyrightNote: string;
   isVerified: boolean;
   createdAt: string;
   updatedAt: string;
-  modelAnswer?: AnswerLine[];
   modelAnswerText?: string;
 }
 
+export type PracticeItem = ExternalProblemRef | QuestionItem;
+
 export interface AnswerAttempt {
   id: string;
+  examType: ExamType;
+  studyMode: StudyMode;
   questionId: string;
   questionTitle: string;
   subject: SubjectName;
   section: SectionName;
   topic: string;
+  cpaTrialSectionRef: CpaTrialSectionRef;
   answeredAt: string;
   answerTemplateId: AnswerTemplateId;
   rows: AnswerLine[];
@@ -67,7 +145,10 @@ export interface AnswerAttempt {
 
 export interface ReviewSchedule {
   id: string;
+  examType: ExamType;
+  studyMode: StudyMode;
   questionId: string;
+  cpaTrialSectionRef: CpaTrialSectionRef;
   nextReviewDate: string;
   latestRank: ReviewRank;
   latestScore: number;
@@ -84,6 +165,7 @@ export interface StudyBackupPayload {
   appName: string;
   version: string;
   questions: QuestionItem[];
+  externalProblemRefs: ExternalProblemRef[];
   answerAttempts: AnswerAttempt[];
   reviewSchedules: ReviewSchedule[];
 }


### PR DESCRIPTION
## 1. 今回の目的

今回の目的は、簿記2級アプリを講義アプリ・PDF抽出アプリ・教材本文収録アプリではなく、**資格横断型の問題演習・採点・復習管理アプリ**として整理することです。

中核機能は以下に絞っています。

1. 問題を選ぶ
2. 答案を入力する
3. 自己採点する
4. A/B/C判定を付ける
5. ミス原因を記録する
6. 次回復習日を自動設定する
7. 今日の復習に出す
8. 履歴を保存する

## 2. 外部教材モードの内容

`CPA教材を見ながら解く` モードを追加・整理しました。

このモードでは、CPAラーニング問題集・PDF・紙教材を手元で見ながら、アプリでは以下だけを管理します。

- 資格：日商簿記2級
- 教材名
- 科目
- 大問対策
- 問題ID
- 論点名
- ページメモ
- 推奨答案テンプレート
- 答案入力
- 自己採点
- A/B/C判定
- ミス原因
- 次回復習日
- 履歴

外部教材モードでは、CPA教材の問題文・解答・解説・数値・表構成は表示しません。

## 3. 外部教材モードに登録した21区分

CPAラーニング問題集の試験対策編に対応する以下21区分を、外部教材モードの問題IDとして登録しました。

### 商業簿記

- 第1問対策 1-1 商品、収益認識、現金預金
- 第1問対策 1-2 債権債務、有価証券
- 第1問対策 1-3 有形固定資産、無形資産
- 第1問対策 1-4 リース取引、引当金、株式会社会計
- 第1問対策 1-5 外貨建取引、税効果会計、本支店会計、連結会計
- 第2問対策 2-1 株主資本等変動計算書
- 第2問対策 2-2 連結会計①
- 第2問対策 2-3 連結会計②
- 第2問対策 2-4 勘定記入①（商品）
- 第2問対策 2-5 勘定記入②（有形固定資産）
- 第2問対策 2-6 勘定記入③（有価証券）
- 第3問対策 3-1 決算の総合問題①
- 第3問対策 3-2 決算の総合問題②
- 第3問対策 3-3 本支店会計の総合問題

### 工業簿記

- 第4問対策 4-1 工業簿記 仕訳問題
- 第4問対策 4-2 工程別総合原価計算
- 第4問対策 4-3 部門別原価計算
- 第4問対策 4-4 財務諸表作成
- 第5問対策 5-1 標準原価計算
- 第5問対策 5-2 CVP分析
- 第5問対策 5-3 全部原価計算と直接原価計算

## 4. 教材なしモードの内容

`教材なしで解く` モードを追加・整理しました。

このモードでは、検証済みの完全オリジナル短問のみを通常演習に表示します。

初期実装では、品質保証を優先し、approved問題は第1優先区分に限定しています。

## 5. 初期搭載オリジナル問題数

- approved：9問
- draft：12問
- rejected：0問

approved問題は以下です。

- commercial_1_1：商品、収益認識、現金預金
- commercial_1_2：債権債務、有価証券
- commercial_1_3：有形固定資産、無形資産
- commercial_1_4：リース取引、引当金、株式会社会計
- commercial_1_5：外貨建取引、税効果会計、本支店会計、連結会計
- industrial_4_1：工業簿記 仕訳問題
- industrial_5_1：標準原価計算
- industrial_5_2：CVP分析
- industrial_5_3：全部原価計算と直接原価計算

第2優先・第3優先の区分は draft として管理画面に保持していますが、通常演習には表示しません。

## 6. オリジナル問題の対象範囲

オリジナル問題は、簿記2級の全論点網羅ではありません。

対象は、CPAラーニング問題集の **試験対策編の21区分のみ** です。

基本編・模擬試験編は、今回のオリジナル問題作成対象から除外しています。

## 7. PDF抽出をやめたこと

今回、以下は実装していません。

- PDF抽出
- PDF範囲指定
- PDF画像表示改善
- PDFからの完全自動問題生成
- OCR

PDF関連は学習画面の主役にせず、必要な場合は管理側の補助機能扱いにしています。

## 8. 問題文内蔵の範囲

問題文をアプリ内に持つのは、`sourceType: initial_original` のオリジナル短問だけです。

CPA教材本文・問題文・解答・解説・数値・表構成は入れていません。

## 9. データ構造

資格横断型にするため、以下を追加・整理しました。

- examType
- studyMode
- sourceType
- cpaTrialSectionRef
- referenceScope
- verificationStatus
- qualityCheck

今回の実装対象は `examType: boki2` のみです。

ただし、将来の建設業経理士2級・弁理士・行政書士展開に備え、型定義上は以下を持てる構造にしています。

- boki2
- kensetsu_keiri2
- benrishi
- gyoseishoshi

## 10. 答案テンプレート

以下のテンプレートに対応しました。

- 仕訳テンプレート
- 数値入力テンプレート
- 表形式テンプレート
- 勘定記入テンプレート
- 自由テンプレート

PCではテーブル型、スマホでは仕訳入力がカード型になる構成を維持しています。

## 11. 復習ロジック

A/B/C判定に応じて次回復習日を自動設定します。

- A：7日後
- B：3日後
- C：翌日
- 2回連続A：14日後
- 3回連続A：30日後
- 2回連続C：翌日＋苦手固定

次回復習日は手動変更できます。

## 12. 問題品質保証の確認方法

各オリジナル問題に `qualityCheck` を持たせました。

確認項目は以下です。

- 出題範囲確認
- CPA試験対策編区分との対応確認
- 勘定科目確認
- 仕訳確認
- 金額計算確認
- 解説確認
- 難易度確認
- コピー類似性確認
- 確認者
- 確認日
- 根拠メモ

approved問題は、一般的な簿記2級知識に基づく短問として、仕訳・金額・解説を自己検証済みです。

draft問題は通常演習には出しません。

## 13. 著作権対応

以下は行っていません。

- CPA教材本文の収録
- CPA問題文の収録
- CPA解答の収録
- CPA解説の収録
- CPA教材の数値・表構成の利用
- CPAロゴ・教材画像の利用
- 日本商工会議所公式サンプル問題本文の利用
- 日本商工会議所公式サンプル問題答案用紙の利用
- 日本商工会議所公式サンプル問題解答の利用
- 市販教材本文の利用
- ネット上の解説記事の問題文の利用

オリジナル問題は、一般的な簿記2級知識に基づき、独自の取引設定・数値・解説で作成しています。

## 14. 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/src/App.tsx`
- `cpa-boki2-trial-section-answer-manager/src/data/cpaTrialSections.ts`
- `cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts`
- `cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts`
- `cpa-boki2-trial-section-answer-manager/src/originalStudyStorage.ts`

## 15. 既存案件管理アプリへの影響なし

変更対象は `cpa-boki2-trial-section-answer-manager/` 配下のみです。

以下は変更していません。

- ルート `index.html`
- ルート `app.js`
- ルート `styles.css`
- 既存案件管理アプリ本体
- 既存案件管理アプリの保存処理
- 既存GitHub PagesトップURL
- 既存Pages workflow

## 16. 動作確認項目

マージ前に以下を確認してください。

1. 公開URLを開く
2. 簿記2級アプリを開く
3. 初期表示が「今すぐ解く」であることを確認
4. 「CPA教材を見ながら解く」を選択
5. 商業簿記 第1問対策 1-1 を選択
6. 仕訳テンプレートが表示されることを確認
7. 問題文が表示されないことを確認
8. 答案を入力
9. 採点へ進む
10. A/B/C判定で次回復習日が自動設定されることを確認
11. 保存後、復習画面に反映されることを確認
12. 「教材なしで解く」を選択
13. approved のオリジナル問題が表示されることを確認
14. 問題文・模範解答・解説が表示されることを確認
15. cpaTrialSectionRef が保持されていることを確認
16. draft 問題が通常演習に出ないことを確認
17. スマホ幅で答案入力がカード型になることを確認
18. 既存案件管理アプリのトップURLが壊れていないことを確認

## 17. GitHub Actions / build結果

PR作成後、GitHub Actions の `CPA Boki2 App Build Check` で以下を確認します。

- npm install
- npm run build

## 18. 未確認事項

- 実URLでの手動表示確認
- スマホ実機での操作感
- approved 9問の問題品質のユーザー最終確認
- draft 12区分の追加問題作成・検証

## 19. 今回やっていないこと

以下は実装していません。

- PDF抽出
- PDF範囲指定
- PDF画像表示改善
- 自動採点
- 講義機能
- 動画機能
- AI解説
- スタディング全体の再現
- CPA教材本文の取り込み
- 市販教材の取り込み
- 公式サンプル問題の取り込み
- 基本編ベースの全論点網羅問題作成
- 模擬試験編ベースの問題作成
- 建設業経理士モードの本実装
- 弁理士モードの本実装
- ログイン
- Supabase同期
- 課金機能

## 20. マージについて

このPRは、マージ直前で停止します。

ユーザー確認後にマージ判断してください。