### PR TITLE
Feature boki2 industrial account flow visual aid

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import type { IndustrialAccountFlowData, PracticeItem, VisualAidType } from '../originalStudyTypes';
+import './visualAids.css';
+
+function renderIndustrialAccountFlow(data: IndustrialAccountFlowData) {
+  const nodeSet = new Set(data.nodes);
+  const safeEdges = data.edges.filter(([from, to]) => nodeSet.has(from) && nodeSet.has(to));
+
+  return (
+    <div className="visual-aid-diagram industrial-account-flow" aria-label="勘定連絡図">
+      <div className="flow-row flow-input-row">
+        <div className="flow-node">材料</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node flow-main-node">仕掛品</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node">製品</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node">売上原価</div>
+      </div>
+      <div className="flow-row flow-support-row">
+        <div className="flow-node">賃金</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node flow-main-node">仕掛品</div>
+      </div>
+      <div className="flow-row flow-support-row">
+        <div className="flow-node">経費</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node">製造間接費</div>
+        <div className="flow-arrow" aria-hidden="true">→</div>
+        <div className="flow-node flow-main-node">仕掛品</div>
+      </div>
+      <div className="flow-edge-list" aria-label="表示している流れ">
+        {safeEdges.map(([from, to]) => <span key={`${from}-${to}`}>{from} → {to}</span>)}
+      </div>
+    </div>
+  );
+}
+
+function hasVisualAid(item: PracticeItem): boolean {
+  return Array.isArray(item.visualAidTypes) && item.visualAidTypes.length > 0;
+}
+
+export function VisualAidPanel({ item }: { item: PracticeItem }) {
+  const [open, setOpen] = useState(false);
+  const firstType = item.visualAidTypes?.[0] as VisualAidType | undefined;
+  const accountFlow = item.visualAidData?.industrial_account_flow;
+
+  if (!hasVisualAid(item) || !firstType) return null;
+
+  return (
+    <section className="panel visual-aid-panel" aria-label="図表で確認">
+      <div className="visual-aid-header">
+        <div>
+          <p className="eyebrow">図表で確認</p>
+          <h2>{accountFlow?.title ?? '図表'}</h2>
+        </div>
+        <button type="button" className="secondary" onClick={() => setOpen((value) => !value)}>
+          {open ? '図表を閉じる' : '図表で確認'}
+        </button>
+      </div>
+      {open && firstType === 'industrial_account_flow' && accountFlow && (
+        <div className="visual-aid-body">
+          <p className="visual-aid-description">
+            {accountFlow.description ?? '材料・賃金・経費が製造活動を通じて仕掛品、製品、売上原価へ流れる関係を確認する図です。'}
+          </p>
+          {renderIndustrialAccountFlow(accountFlow)}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default VisualAidPanel;

--- a/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
@@ -1,0 +1,83 @@
+import './visualAids.css';
+
+const VISUAL_AID_ROOT_ID = 'industrial-account-flow-visual-aid-root';
+
+const INDUSTRIAL_ACCOUNT_FLOW_HTML = `
+  <section class="panel visual-aid-panel" aria-label="図表で確認">
+    <div class="visual-aid-header">
+      <div>
+        <p class="eyebrow">図表で確認</p>
+        <h2>勘定連絡図</h2>
+      </div>
+      <button type="button" class="secondary" data-visual-aid-toggle>図表で確認</button>
+    </div>
+    <div class="visual-aid-body" data-visual-aid-body hidden>
+      <p class="visual-aid-description">材料・賃金・経費が製造活動を通じて仕掛品、製品、売上原価へ流れる関係を確認する図です。</p>
+      <div class="visual-aid-diagram industrial-account-flow" aria-label="勘定連絡図">
+        <div class="flow-row flow-input-row">
+          <div class="flow-node">材料</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">売上原価</div>
+        </div>
+        <div class="flow-row flow-support-row">
+          <div class="flow-node">賃金</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
+        </div>
+        <div class="flow-row flow-support-row">
+          <div class="flow-node">経費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製造間接費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
+        </div>
+        <div class="flow-edge-list" aria-label="表示している流れ">
+          <span>材料 → 仕掛品</span><span>賃金 → 仕掛品</span><span>経費 → 製造間接費</span><span>製造間接費 → 仕掛品</span><span>仕掛品 → 製品</span><span>製品 → 売上原価</span>
+        </div>
+      </div>
+    </div>
+  </section>
+`;
+
+function currentQuestionHasIndustrial41(): boolean {
+  const questionCard = document.querySelector('.question-reference-card');
+  return Boolean(questionCard?.textContent?.includes('industrial_4_1'));
+}
+
+function removeVisualAidIfNeeded() {
+  const root = document.getElementById(VISUAL_AID_ROOT_ID);
+  if (root && !currentQuestionHasIndustrial41()) root.remove();
+}
+
+function ensureVisualAid() {
+  if (typeof document === 'undefined') return;
+  const questionCard = document.querySelector('.question-reference-card');
+  const answerArea = document.querySelector('.focused-answer-area.answer-only-main');
+  if (!questionCard || !answerArea) return;
+  if (!currentQuestionHasIndustrial41()) {
+    removeVisualAidIfNeeded();
+    return;
+  }
+  if (document.getElementById(VISUAL_AID_ROOT_ID)) return;
+
+  const root = document.createElement('div');
+  root.id = VISUAL_AID_ROOT_ID;
+  root.innerHTML = INDUSTRIAL_ACCOUNT_FLOW_HTML;
+  answerArea.parentElement?.insertBefore(root, answerArea);
+
+  const button = root.querySelector<HTMLButtonElement>('[data-visual-aid-toggle]');
+  const body = root.querySelector<HTMLElement>('[data-visual-aid-body]');
+  button?.addEventListener('click', () => {
+    if (!body || !button) return;
+    const nextOpen = body.hasAttribute('hidden');
+    if (nextOpen) {
+      body.removeAttribute('hidden');
+      button.textContent = '図表を閉じる';
+    } else {
+      body.setAttribute('hidden', '');
+      button.textContent = '図表で確認';
+    }
+  });
+}
+
+export function installVisualAidBridge() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if ((window as Window & { __boki2VisualAidBridgeInstalled?: boolean }).__boki2VisualAidBridgeInstalled) return;
+  (window as Window & { __boki2VisualAidBridgeInstalled?: boolean }).__boki2VisualAidBridgeInstalled = true;
+
+  const observer = new MutationObserver(() => ensureVisualAid());
+  observer.observe(document.body, { childList: true, subtree: true });
+  window.setTimeout(() => ensureVisualAid(), 0);
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
@@ -1,6 +1,74 @@
-import './visualAids.css';
-
 const VISUAL_AID_ROOT_ID = 'industrial-account-flow-visual-aid-root';
+const VISUAL_AID_STYLE_ID = 'industrial-account-flow-visual-aid-style';
+
+const VISUAL_AID_STYLE = `
+  .visual-aid-panel {
+    border: 1px solid #cfe5d6;
+    background: #f6fbf7;
+    border-radius: 14px;
+    margin: 16px 0;
+    padding: 14px;
+  }
+  .visual-aid-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+  }
+  .visual-aid-header h2 { margin: 2px 0 0; }
+  .visual-aid-body { margin-top: 12px; }
+  .visual-aid-description { margin: 0 0 12px; color: #31543d; line-height: 1.7; }
+  .visual-aid-diagram {
+    background: #fff;
+    border: 1px solid #d9eadf;
+    border-radius: 12px;
+    padding: 14px;
+    overflow-x: auto;
+  }
+  .flow-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+    min-width: 620px;
+  }
+  .flow-node {
+    min-width: 96px;
+    padding: 10px 12px;
+    border: 1px solid #8fc39e;
+    border-radius: 10px;
+    background: #eef8f0;
+    text-align: center;
+    font-weight: 700;
+    color: #173a22;
+  }
+  .flow-main-node { background: #dff2e4; border-color: #4c9b61; }
+  .flow-arrow { color: #2f7d45; font-weight: 800; }
+  .flow-edge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .flow-edge-list span {
+    background: #f1f6f3;
+    border: 1px solid #d8e8dd;
+    border-radius: 999px;
+    padding: 5px 9px;
+    color: #31543d;
+    font-size: 0.9rem;
+  }
+  @media (max-width: 760px) {
+    .visual-aid-header { align-items: flex-start; flex-direction: column; }
+    .flow-row {
+      align-items: stretch;
+      flex-direction: column;
+      min-width: 0;
+    }
+    .flow-arrow { transform: rotate(90deg); align-self: center; }
+    .flow-node { width: 100%; box-sizing: border-box; }
+  }
+`;
 
 const INDUSTRIAL_ACCOUNT_FLOW_HTML = `
   <section class="panel visual-aid-panel" aria-label="図表で確認">
@@ -31,9 +99,18 @@ const INDUSTRIAL_ACCOUNT_FLOW_HTML = `
   </section>
 `;
 
+function ensureVisualAidStyle() {
+  if (document.getElementById(VISUAL_AID_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = VISUAL_AID_STYLE_ID;
+  style.textContent = VISUAL_AID_STYLE;
+  document.head.appendChild(style);
+}
+
 function currentQuestionHasIndustrial41(): boolean {
   const questionCard = document.querySelector('.question-reference-card');
-  return Boolean(questionCard?.textContent?.includes('industrial_4_1'));
+  const text = questionCard?.textContent ?? '';
+  return text.includes('教材なしモード') && text.includes('industrial_4_1');
 }
 
 function removeVisualAidIfNeeded() {
@@ -43,9 +120,9 @@ function removeVisualAidIfNeeded() {
 
 function ensureVisualAid() {
   if (typeof document === 'undefined') return;
-  const questionCard = document.querySelector('.question-reference-card');
+  ensureVisualAidStyle();
   const answerArea = document.querySelector('.focused-answer-area.answer-only-main');
-  if (!questionCard || !answerArea) return;
+  if (!answerArea) return;
   if (!currentQuestionHasIndustrial41()) {
     removeVisualAidIfNeeded();
     return;

--- a/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
@@ -1,5 +1,8 @@
 import { cpaTrialSections, findTrialSection } from './cpaTrialSections';
 import type { AnswerLine, CpaTrialSectionRef, QuestionItem, VerificationStatus } from '../originalStudyTypes';
+import { installVisualAidBridge } from '../components/visualAidBridge';
+
+installVisualAidBridge();
 
 const NOW = '2026-05-24T00:00:00.000Z';
 const COPYRIGHT_NOTE = 'CPA問題集の試験対策編の区分のみ参考。問題文・解答・解説・数値・表構成は未使用。';

--- a/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
@@ -3,6 +3,19 @@ import type { AnswerLine, CpaTrialSectionRef, QuestionItem, VerificationStatus }
 
 const NOW = '2026-05-24T00:00:00.000Z';
 const COPYRIGHT_NOTE = 'CPA問題集の試験対策編の区分のみ参考。問題文・解答・解説・数値・表構成は未使用。';
+const INDUSTRIAL_ACCOUNT_FLOW = {
+  title: '勘定連絡図',
+  description: '材料・賃金・経費が製造活動を通じて仕掛品、製品、売上原価へ流れる関係を確認する図です。',
+  nodes: ['材料', '賃金', '経費', '製造間接費', '仕掛品', '製品', '売上原価'],
+  edges: [
+    ['材料', '仕掛品'],
+    ['賃金', '仕掛品'],
+    ['経費', '製造間接費'],
+    ['製造間接費', '仕掛品'],
+    ['仕掛品', '製品'],
+    ['製品', '売上原価'],
+  ] as [string, string][],
+};
 
 function line(input: Partial<AnswerLine>): AnswerLine {
   return { id: crypto.randomUUID(), grade: '未採点', points: 0, ...input };
@@ -27,7 +40,7 @@ function quality(approved: boolean, memo: string) {
 function q(input: { ref: CpaTrialSectionRef; title: string; questionText: string; conditions?: string[]; modelAnswer?: AnswerLine[]; explanation?: string; maxScore?: number; status?: VerificationStatus }): QuestionItem {
   const section = findTrialSection(input.ref);
   const approved = (input.status ?? 'approved') === 'approved';
-  return {
+  const base: QuestionItem = {
     id: `短問-${section.id}`,
     examType: 'boki2',
     studyMode: 'built_in_question',
@@ -53,6 +66,14 @@ function q(input: { ref: CpaTrialSectionRef; title: string; questionText: string
     createdAt: NOW,
     updatedAt: NOW,
   };
+  if (input.ref === 'industrial_4_1') {
+    return {
+      ...base,
+      visualAidTypes: ['industrial_account_flow'],
+      visualAidData: { industrial_account_flow: INDUSTRIAL_ACCOUNT_FLOW },
+    };
+  }
+  return base;
 }
 
 const approvedQuestions: QuestionItem[] = [

--- a/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
@@ -32,6 +32,7 @@ export type AnswerTemplateId = 'journal' | 'numeric' | 'statementTable' | 'accou
 export type GradeMark = '未採点' | '正解' | '不正解' | '要確認' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
 export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方逆' | '金額ミス' | '集計ミス' | '転記ミス' | '表の入力位置ミス' | '下書き不足' | '時間不足' | '解答形式の誤認' | '問題文読み落とし' | 'その他';
+export type VisualAidType = 'industrial_account_flow';
 
 export interface QualityCheck {
   scopeChecked: boolean;
@@ -45,6 +46,17 @@ export interface QualityCheck {
   reviewer: string;
   checkedAt: string;
   evidenceMemo: string;
+}
+
+export interface IndustrialAccountFlowData {
+  title: string;
+  description?: string;
+  nodes: string[];
+  edges: [string, string][];
+}
+
+export interface VisualAidDataMap {
+  industrial_account_flow?: IndustrialAccountFlowData;
 }
 
 export interface AnswerLine {
@@ -88,6 +100,8 @@ export interface ExternalProblemRef {
   sourceType: 'external_material_reference';
   referenceScope: ReferenceScope;
   copyrightNote: string;
+  visualAidTypes?: VisualAidType[];
+  visualAidData?: VisualAidDataMap;
   createdAt: string;
   updatedAt: string;
 }
@@ -118,6 +132,8 @@ export interface QuestionItem {
   createdAt: string;
   updatedAt: string;
   modelAnswerText?: string;
+  visualAidTypes?: VisualAidType[];
+  visualAidData?: VisualAidDataMap;
 }
 
 export type PracticeItem = ExternalProblemRef | QuestionItem;


### PR DESCRIPTION
## 目的

簿記2級アプリに、図表機能の第1PRとして、工業簿記4-1専用の勘定連絡図を追加する。

今回は図表機能の最小完成版であり、土台だけではなく、実際に1つの図表を表示できる状態にする。

## 変更内容

- 工業簿記4-1に visualAidTypes / visualAidData を追加
- 勘定連絡図表示用の VisualAidPanel を追加
- 既存問題画面へ図表を表示する bridge を追加
- visualAidType / visualAidData 関連の型を追加

## 今回実装した図表

- 工業簿記4-1の勘定連絡図のみ

## 今回実装していないもの

- 仕掛品BOX
- T勘定
- 連結タイムテーブル
- B/S・P/L
- シュラッター図
- 図表上での直接入力
- 図表の自動採点

## 既存機能への影響確認

- [ ] 日本語IME入力（実画面未確認）
- [ ] 金額入力（実画面未確認）
- [ ] 自動採点（実画面未確認）
- [ ] side_multiset採点（実画面未確認）
- [ ] 一時保存（実画面未確認）
- [ ] もう一度解く（実画面未確認）
- [ ] 復習管理（実画面未確認）
- [ ] 外部教材モード（実画面未確認）
- [ ] 教材なしモード（実画面未確認）
- [ ] 既存案件管理アプリ本体（差分上は対象ファイル外。実画面未確認）

## 著作権対応

勘定連絡図はHTML/CSSまたはSVGで自前生成。
CPA教材、日商サンプル問題、他サイト画像、スクリーンショットは使用していない。

## 確認事項

- [x] Files changed が以下4ファイルのみであることを確認
  - `cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx`
  - `cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts`
  - `cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts`
  - `cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts`
- [x] GitHub Actions / CPA Boki2 App Build Check passed
- [ ] 工業簿記4-1で図表で確認が表示される（実画面未確認）
- [ ] 勘定連絡図が表示される（実画面未確認）
- [ ] 図表を開閉しても入力内容が消えない（実画面未確認）
- [ ] 一時保存が壊れていない（実画面未確認）
- [ ] 自動採点または自己採点が壊れていない（実画面未確認）
- [ ] 日本語IMEで金額入力してもホワイトアウトしない（実画面未確認）
- [ ] Consoleに赤エラーが出ない（実画面未確認）
- [ ] 既存案件管理アプリに影響がない（差分上は対象外。実画面未確認）

## 確認結果メモ

- PRの changed files は指定4ファイルのみ。
- `main / master / gh-pages` への直接書き込みはしていない。
- 最新 head SHA の `CPA Boki2 App Build Check` は completed / success。
- 実URL・実ブラウザでの操作確認は未実施のため、実画面確認項目は未チェックのまま残す。

## 次PR以降のロードマップ

PR2：工業簿記 4-2 / 4-4 用の仕掛品BOX図  
PR3：商業簿記 2-4 / 2-5 / 2-6 用のT勘定  
PR4：商業簿記 2-2 / 2-3 用の連結タイムテーブル  
PR5：商業簿記 3-1 / 3-2 用のB/S・P/Lテンプレート  
PR6：工業簿記 5-1 用の差異分析図・シュラッター図の骨格