### PR TITLE
Add Boki2 4-1 account flow editor v1

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/package.json
+++ b/cpa-boki2-trial-section-answer-manager/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "latest",
+    "@xyflow/react": "latest",
     "pdfjs-dist": "latest",
     "react": "latest",
     "react-dom": "latest",

--- a/cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent, DragEvent } from 'react';
+import {
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  Background,
+  Controls,
+  Handle,
+  MarkerType,
+  MiniMap,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+} from '@xyflow/react';
+import type { Connection, Edge, EdgeChange, Node, NodeChange, NodeProps, NodeTypes } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import './accountFlowEditor.css';
+
+type AccountBoxData = {
+  accountName: string;
+  amount: string;
+  memo: string;
+  onChange?: (nodeId: string, patch: Partial<AccountBoxData>) => void;
+};
+
+type AccountBoxNode = Node<AccountBoxData, 'accountBox'>;
+type AccountFlowDraft = {
+  nodes: AccountBoxNode[];
+  edges: Edge[];
+};
+
+const STORAGE_KEY = 'boki2-industrial-4-1-account-flow-draft-v1';
+const paletteItems = ['材料', '賃金', '経費', '製造間接費', '仕掛品', '製品', '売上原価', '自由入力ボックス'];
+
+function stripRuntimeNodeData(node: AccountBoxNode): AccountBoxNode {
+  const { onChange: _onChange, ...data } = node.data;
+  return { ...node, data };
+}
+
+function sampleDraft(): AccountFlowDraft {
+  return {
+    nodes: [
+      { id: 'sample-material', type: 'accountBox', position: { x: 40, y: 90 }, data: { accountName: '材料', amount: '', memo: '' } },
+      { id: 'sample-wip', type: 'accountBox', position: { x: 260, y: 90 }, data: { accountName: '仕掛品', amount: '', memo: '' } },
+      { id: 'sample-product', type: 'accountBox', position: { x: 480, y: 90 }, data: { accountName: '製品', amount: '', memo: '' } },
+      { id: 'sample-cogs', type: 'accountBox', position: { x: 700, y: 90 }, data: { accountName: '売上原価', amount: '', memo: '' } },
+    ],
+    edges: [
+      { id: 'edge-sample-material-wip', source: 'sample-material', target: 'sample-wip', markerEnd: { type: MarkerType.ArrowClosed } },
+      { id: 'edge-sample-wip-product', source: 'sample-wip', target: 'sample-product', markerEnd: { type: MarkerType.ArrowClosed } },
+      { id: 'edge-sample-product-cogs', source: 'sample-product', target: 'sample-cogs', markerEnd: { type: MarkerType.ArrowClosed } },
+    ],
+  };
+}
+
+function loadDraft(): AccountFlowDraft {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return sampleDraft();
+    const parsed = JSON.parse(raw) as Partial<AccountFlowDraft>;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return sampleDraft();
+    return {
+      nodes: parsed.nodes.map((node) => stripRuntimeNodeData({
+        ...node,
+        type: 'accountBox',
+        data: {
+          accountName: String(node.data?.accountName ?? ''),
+          amount: String(node.data?.amount ?? ''),
+          memo: String(node.data?.memo ?? ''),
+        },
+      } as AccountBoxNode)),
+      edges: parsed.edges,
+    };
+  } catch (error) {
+    console.warn('勘定連絡図エディタの一時保存データを読み込めませんでした', error);
+    return sampleDraft();
+  }
+}
+
+function saveDraft(nodes: AccountBoxNode[], edges: Edge[]) {
+  try {
+    const payload: AccountFlowDraft = {
+      nodes: nodes.map(stripRuntimeNodeData),
+      edges,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    window.dispatchEvent(new CustomEvent('boki2-account-flow-draft-saved', { detail: payload }));
+  } catch (error) {
+    console.warn('勘定連絡図エディタの一時保存に失敗しました', error);
+  }
+}
+
+function AccountBoxNodeView({ id, data, selected }: NodeProps) {
+  const box = data as AccountBoxData;
+  const update = box.onChange;
+
+  const handleChange = (field: keyof Omit<AccountBoxData, 'onChange'>) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    update?.(id, { [field]: event.currentTarget.value });
+  };
+
+  return (
+    <div className={selected ? 'account-flow-node selected' : 'account-flow-node'}>
+      <Handle type="target" position={Position.Left} className="account-flow-handle" />
+      <Handle type="source" position={Position.Right} className="account-flow-handle" />
+      <label>
+        <span>勘定科目</span>
+        <input value={box.accountName} onChange={handleChange('accountName')} lang="ja" autoComplete="off" spellCheck={false} />
+      </label>
+      <label>
+        <span>金額</span>
+        <input value={box.amount} onChange={handleChange('amount')} inputMode="numeric" autoComplete="off" spellCheck={false} placeholder="例：2000" />
+      </label>
+      <label>
+        <span>メモ</span>
+        <textarea value={box.memo} onChange={handleChange('memo')} rows={2} lang="ja" spellCheck={false} />
+      </label>
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { accountBox: AccountBoxNodeView };
+
+function AccountFlowEditorCanvas() {
+  const initial = useMemo(() => loadDraft(), []);
+  const [nodes, setNodes] = useState<AccountBoxNode[]>(initial.nodes);
+  const [edges, setEdges] = useState<Edge[]>(initial.edges);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  const [status, setStatus] = useState('図表データは自動で一時保存されます。');
+  const flowWrapperRef = useRef<HTMLDivElement | null>(null);
+  const { screenToFlowPosition } = useReactFlow();
+
+  const updateNodeData = useCallback((nodeId: string, patch: Partial<AccountBoxData>) => {
+    setNodes((current) => current.map((node) => node.id === nodeId ? { ...node, data: { ...node.data, ...patch } } : node));
+  }, []);
+
+  const nodesWithHandlers = useMemo<AccountBoxNode[]>(() => nodes.map((node) => ({
+    ...node,
+    data: { ...node.data, onChange: updateNodeData },
+  })), [nodes, updateNodeData]);
+
+  useEffect(() => {
+    saveDraft(nodes, edges);
+  }, [nodes, edges]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => setNodes((current) => applyNodeChanges(changes, current) as AccountBoxNode[]), []);
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => setEdges((current) => applyEdgeChanges(changes, current)), []);
+  const onConnect = useCallback((connection: Connection) => setEdges((current) => addEdge({ ...connection, markerEnd: { type: MarkerType.ArrowClosed } }, current)), []);
+
+  const addNode = useCallback((accountName: string, x = 120, y = 120) => {
+    const label = accountName === '自由入力ボックス' ? '' : accountName;
+    const id = `node-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    setNodes((current) => [...current, { id, type: 'accountBox', position: { x, y }, data: { accountName: label, amount: '', memo: '' } }]);
+    setStatus(`${accountName}を追加しました。`);
+  }, []);
+
+  const onDragStart = (event: DragEvent<HTMLButtonElement>, accountName: string) => {
+    event.dataTransfer.setData('application/x-account-flow-node', accountName);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const accountName = event.dataTransfer.getData('application/x-account-flow-node');
+    if (!accountName) return;
+    const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
+    addNode(accountName, position.x, position.y);
+  };
+
+  const deleteSelected = () => {
+    if (selectedNodeId) {
+      setNodes((current) => current.filter((node) => node.id !== selectedNodeId));
+      setEdges((current) => current.filter((edge) => edge.source !== selectedNodeId && edge.target !== selectedNodeId));
+      setSelectedNodeId(null);
+      setStatus('選択中のボックスを削除しました。');
+      return;
+    }
+    if (selectedEdgeId) {
+      setEdges((current) => current.filter((edge) => edge.id !== selectedEdgeId));
+      setSelectedEdgeId(null);
+      setStatus('選択中の矢印を削除しました。');
+    }
+  };
+
+  const resetSample = () => {
+    if (!window.confirm('現在の勘定連絡図をサンプルに戻しますか？')) return;
+    const next = sampleDraft();
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    setSelectedNodeId(null);
+    setSelectedEdgeId(null);
+    setStatus('材料 → 仕掛品 → 製品 → 売上原価のサンプルに戻しました。');
+  };
+
+  return (
+    <div className="account-flow-editor-shell">
+      <aside className="account-flow-palette" aria-label="ボックス追加サイドバー">
+        <h3>ボックスを追加</h3>
+        <p>ドラッグして右のキャンバスへ追加します。クリックでも追加できます。</p>
+        <div className="account-flow-palette-list">
+          {paletteItems.map((name) => (
+            <button key={name} type="button" draggable onDragStart={(event) => onDragStart(event, name)} onClick={() => addNode(name)}>
+              {name}
+            </button>
+          ))}
+        </div>
+        <div className="account-flow-editor-actions">
+          <button type="button" className="secondary" onClick={deleteSelected} disabled={!selectedNodeId && !selectedEdgeId}>選択中を削除</button>
+          <button type="button" className="secondary" onClick={resetSample}>サンプルに戻す</button>
+        </div>
+        <p className="account-flow-editor-note">金額欄は文字列のまま保存します。自動採点とは連動しません。</p>
+      </aside>
+      <div className="account-flow-canvas-panel" ref={flowWrapperRef} onDragOver={onDragOver} onDrop={onDrop}>
+        <ReactFlow
+          nodes={nodesWithHandlers}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onNodeClick={(_, node) => { setSelectedNodeId(node.id); setSelectedEdgeId(null); }}
+          onEdgeClick={(_, edge) => { setSelectedEdgeId(edge.id); setSelectedNodeId(null); }}
+          onPaneClick={() => { setSelectedNodeId(null); setSelectedEdgeId(null); }}
+          fitView
+          defaultEdgeOptions={{ markerEnd: { type: MarkerType.ArrowClosed } }}
+        >
+          <MiniMap pannable zoomable />
+          <Controls />
+          <Background />
+        </ReactFlow>
+      </div>
+      <p className="account-flow-editor-status">{status}</p>
+    </div>
+  );
+}
+
+export function AccountFlowEditor() {
+  return (
+    <ReactFlowProvider>
+      <AccountFlowEditorCanvas />
+    </ReactFlowProvider>
+  );
+}
+
+export default AccountFlowEditor;

--- a/cpa-boki2-trial-section-answer-manager/src/components/accountFlowEditor.css
+++ b/cpa-boki2-trial-section-answer-manager/src/components/accountFlowEditor.css
@@ -1,0 +1,149 @@
+.account-flow-editor-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.account-flow-palette,
+.account-flow-canvas-panel {
+  border: 1px solid #d7e8dd;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.account-flow-palette {
+  padding: 12px;
+}
+
+.account-flow-palette h3 {
+  margin: 0 0 6px;
+  color: #173a22;
+}
+
+.account-flow-palette p {
+  margin: 0 0 10px;
+  color: #52705d;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.account-flow-palette-list {
+  display: grid;
+  gap: 8px;
+}
+
+.account-flow-palette-list button {
+  width: 100%;
+  cursor: grab;
+  border: 1px solid #9ccdad;
+  background: #eff9f2;
+  color: #173a22;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-weight: 700;
+  text-align: left;
+}
+
+.account-flow-palette-list button:active {
+  cursor: grabbing;
+}
+
+.account-flow-editor-actions {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.account-flow-editor-note,
+.account-flow-editor-status {
+  color: #52705d;
+  font-size: 0.88rem;
+}
+
+.account-flow-canvas-panel {
+  min-height: 420px;
+  overflow: hidden;
+}
+
+.account-flow-canvas-panel .react-flow {
+  min-height: 420px;
+}
+
+.account-flow-node {
+  min-width: 170px;
+  max-width: 220px;
+  border: 1px solid #5fa977;
+  border-radius: 12px;
+  background: #f6fbf7;
+  box-shadow: 0 8px 20px rgba(24, 84, 42, 0.12);
+  padding: 10px;
+}
+
+.account-flow-node.selected {
+  border-color: #1f7a3c;
+  box-shadow: 0 0 0 3px rgba(64, 155, 92, 0.22), 0 8px 20px rgba(24, 84, 42, 0.12);
+}
+
+.account-flow-node label {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 7px;
+  color: #173a22;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.account-flow-node input,
+.account-flow-node textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cfe5d6;
+  border-radius: 8px;
+  background: #fff;
+  padding: 6px 7px;
+  font-size: 0.92rem;
+}
+
+.account-flow-node textarea {
+  resize: vertical;
+}
+
+.account-flow-handle {
+  width: 10px;
+  height: 10px;
+  background: #2f7d45;
+  border: 2px solid #fff;
+}
+
+.visual-aid-mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.visual-aid-mode-tabs button.active {
+  background: #225c34;
+  color: #fff;
+}
+
+.account-flow-static-area[hidden],
+.account-flow-editor-area[hidden] {
+  display: none;
+}
+
+@media (max-width: 860px) {
+  .account-flow-editor-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .account-flow-canvas-panel,
+  .account-flow-canvas-panel .react-flow {
+    min-height: 360px;
+  }
+
+  .account-flow-palette-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
@@ -1,5 +1,16 @@
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { AccountFlowEditor } from './AccountFlowEditor';
+
 const VISUAL_AID_ROOT_ID = 'industrial-account-flow-visual-aid-root';
 const VISUAL_AID_STYLE_ID = 'industrial-account-flow-visual-aid-style';
+const EDITOR_MOUNT_ID = 'industrial-account-flow-editor-root';
+
+type BridgeWindow = Window & {
+  __boki2VisualAidBridgeInstalled?: boolean;
+  __boki2AccountFlowEditorRoot?: Root | null;
+};
 
 const VISUAL_AID_STYLE = `
   .visual-aid-panel {
@@ -81,19 +92,29 @@ const INDUSTRIAL_ACCOUNT_FLOW_HTML = `
     </div>
     <div class="visual-aid-body" data-visual-aid-body hidden>
       <p class="visual-aid-description">材料・賃金・経費が製造活動を通じて仕掛品、製品、売上原価へ流れる関係を確認する図です。</p>
-      <div class="visual-aid-diagram industrial-account-flow" aria-label="勘定連絡図">
-        <div class="flow-row flow-input-row">
-          <div class="flow-node">材料</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">売上原価</div>
+      <div class="visual-aid-mode-tabs" role="tablist" aria-label="勘定連絡図の表示切替">
+        <button type="button" class="active" data-visual-mode="basic">基本図を見る</button>
+        <button type="button" data-visual-mode="editor">自分で作る</button>
+      </div>
+      <div class="account-flow-static-area" data-visual-basic-area>
+        <div class="visual-aid-diagram industrial-account-flow" aria-label="勘定連絡図">
+          <div class="flow-row flow-input-row">
+            <div class="flow-node">材料</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製品</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">売上原価</div>
+          </div>
+          <div class="flow-row flow-support-row">
+            <div class="flow-node">賃金</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
+          </div>
+          <div class="flow-row flow-support-row">
+            <div class="flow-node">経費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製造間接費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
+          </div>
+          <div class="flow-edge-list" aria-label="表示している流れ">
+            <span>材料 → 仕掛品</span><span>賃金 → 仕掛品</span><span>経費 → 製造間接費</span><span>製造間接費 → 仕掛品</span><span>仕掛品 → 製品</span><span>製品 → 売上原価</span>
+          </div>
         </div>
-        <div class="flow-row flow-support-row">
-          <div class="flow-node">賃金</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
-        </div>
-        <div class="flow-row flow-support-row">
-          <div class="flow-node">経費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node">製造間接費</div><div class="flow-arrow" aria-hidden="true">→</div><div class="flow-node flow-main-node">仕掛品</div>
-        </div>
-        <div class="flow-edge-list" aria-label="表示している流れ">
-          <span>材料 → 仕掛品</span><span>賃金 → 仕掛品</span><span>経費 → 製造間接費</span><span>製造間接費 → 仕掛品</span><span>仕掛品 → 製品</span><span>製品 → 売上原価</span>
-        </div>
+      </div>
+      <div class="account-flow-editor-area" data-visual-editor-area hidden>
+        <p class="visual-aid-description">サイドバーからボックスをドラッグして追加し、接続点から矢印を伸ばして勘定の流れを作れます。図表データはこのブラウザに一時保存されます。</p>
+        <div id="${EDITOR_MOUNT_ID}"></div>
       </div>
     </div>
   </section>
@@ -113,9 +134,66 @@ function currentQuestionHasIndustrial41(): boolean {
   return text.includes('教材なしモード') && text.includes('industrial_4_1');
 }
 
+function unmountEditor() {
+  const appWindow = window as BridgeWindow;
+  try {
+    appWindow.__boki2AccountFlowEditorRoot?.unmount();
+  } catch (error) {
+    console.warn('勘定連絡図エディタのunmountをスキップしました', error);
+  }
+  appWindow.__boki2AccountFlowEditorRoot = null;
+}
+
 function removeVisualAidIfNeeded() {
   const root = document.getElementById(VISUAL_AID_ROOT_ID);
-  if (root && !currentQuestionHasIndustrial41()) root.remove();
+  if (root && !currentQuestionHasIndustrial41()) {
+    unmountEditor();
+    root.remove();
+  }
+}
+
+function mountEditorIfNeeded() {
+  const appWindow = window as BridgeWindow;
+  const target = document.getElementById(EDITOR_MOUNT_ID);
+  if (!target || appWindow.__boki2AccountFlowEditorRoot) return;
+  const editorRoot = createRoot(target);
+  editorRoot.render(createElement(AccountFlowEditor));
+  appWindow.__boki2AccountFlowEditorRoot = editorRoot;
+}
+
+function wireVisualAidControls(root: HTMLElement) {
+  const button = root.querySelector<HTMLButtonElement>('[data-visual-aid-toggle]');
+  const body = root.querySelector<HTMLElement>('[data-visual-aid-body]');
+  const basicArea = root.querySelector<HTMLElement>('[data-visual-basic-area]');
+  const editorArea = root.querySelector<HTMLElement>('[data-visual-editor-area]');
+  const modeButtons = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-visual-mode]'));
+
+  function setMode(mode: 'basic' | 'editor') {
+    if (!basicArea || !editorArea) return;
+    basicArea.hidden = mode !== 'basic';
+    editorArea.hidden = mode !== 'editor';
+    modeButtons.forEach((modeButton) => modeButton.classList.toggle('active', modeButton.dataset.visualMode === mode));
+    if (mode === 'editor') mountEditorIfNeeded();
+  }
+
+  button?.addEventListener('click', () => {
+    if (!body || !button) return;
+    const nextOpen = body.hasAttribute('hidden');
+    if (nextOpen) {
+      body.removeAttribute('hidden');
+      button.textContent = '図表を閉じる';
+    } else {
+      body.setAttribute('hidden', '');
+      button.textContent = '図表で確認';
+    }
+  });
+
+  modeButtons.forEach((modeButton) => {
+    modeButton.addEventListener('click', () => {
+      const mode = modeButton.dataset.visualMode === 'editor' ? 'editor' : 'basic';
+      setMode(mode);
+    });
+  });
 }
 
 function ensureVisualAid() {
@@ -133,26 +211,14 @@ function ensureVisualAid() {
   root.id = VISUAL_AID_ROOT_ID;
   root.innerHTML = INDUSTRIAL_ACCOUNT_FLOW_HTML;
   answerArea.parentElement?.insertBefore(root, answerArea);
-
-  const button = root.querySelector<HTMLButtonElement>('[data-visual-aid-toggle]');
-  const body = root.querySelector<HTMLElement>('[data-visual-aid-body]');
-  button?.addEventListener('click', () => {
-    if (!body || !button) return;
-    const nextOpen = body.hasAttribute('hidden');
-    if (nextOpen) {
-      body.removeAttribute('hidden');
-      button.textContent = '図表を閉じる';
-    } else {
-      body.setAttribute('hidden', '');
-      button.textContent = '図表で確認';
-    }
-  });
+  wireVisualAidControls(root);
 }
 
 export function installVisualAidBridge() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
-  if ((window as Window & { __boki2VisualAidBridgeInstalled?: boolean }).__boki2VisualAidBridgeInstalled) return;
-  (window as Window & { __boki2VisualAidBridgeInstalled?: boolean }).__boki2VisualAidBridgeInstalled = true;
+  const appWindow = window as BridgeWindow;
+  if (appWindow.__boki2VisualAidBridgeInstalled) return;
+  appWindow.__boki2VisualAidBridgeInstalled = true;
 
   const observer = new MutationObserver(() => ensureVisualAid());
   observer.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
## 目的

PR #252 で追加した工業簿記4-1専用の静的な勘定連絡図を土台に、同じ図表エリア内で「自分で勘定連絡図を作る」ための最小エディタ v1 を追加します。

今回の対象は **工業簿記4-1のみ** です。大型図表機能の一括実装ではありません。

## 実装内容

- 既存の「図表で確認」エリアに表示切替を追加
  - 基本図を見る
  - 自分で作る
- 「基本図を見る」では PR #252 の静的な勘定連絡図を維持
- 「自分で作る」では React Flow を使った勘定連絡図エディタを表示
- サイドバーから以下のボックスをドラッグまたはクリックで追加可能
  - 材料
  - 賃金
  - 経費
  - 製造間接費
  - 仕掛品
  - 製品
  - 売上原価
  - 自由入力ボックス
- ボックス内に以下を入力可能
  - 勘定科目
  - 金額
  - メモ
- ボックス同士を接続点から矢印で接続可能
- 選択中のボックスまたは矢印を削除可能
- 初期サンプルとして `材料 → 仕掛品 → 製品 → 売上原価` を表示
- 図表データをブラウザ内に自動一時保存

## React Flowを使った理由

- ノードをキャンバス上に配置できる
- ノード同士をエッジで接続できる
- ノードをドラッグ移動できる
- 接続点から矢印を伸ばせる
- nodes / edges を状態として保存しやすい

## 追加した依存関係

- `@xyflow/react`

追加依存は React Flow のみです。他の図表ライブラリは追加していません。

## 図表データの保存方法

エディタの図表データは以下を含む形でブラウザ内に自動一時保存します。

- nodes
- edges
- 各nodeのposition
- 各nodeのaccountName
- 各nodeのamount
- 各nodeのmemo

保存キー：

`boki2-industrial-4-1-account-flow-draft-v1`

今回のv1では、既存答案入力・採点・復習管理を壊さないことを優先し、図表データは既存答案データとは分離して保存しています。自動採点とは連動しません。

## 今回実装していないこと

- 図表の自動採点
- 矢印の正誤判定
- 勘定科目の正誤判定
- 金額集計の自動検証
- 図表から答案欄への自動転記
- 図表と仕訳答案の自動連動
- 仕掛品BOX
- T勘定
- 連結タイムテーブル
- B/S・P/L
- シュラッター図
- 他問題への展開
- スマホ専用の高度なドラッグUI
- 複雑なUndo/Redo
- 画像出力
- PDF出力

## 著作権対応

- CPA教材の図画像は使用していません
- CPA教材の図表をコピーしていません
- CPA教材の文章・問題文・解答・解説・数値は使用していません
- 日商サンプル問題の図表・答案用紙は使用していません
- 他サイトの図・スクリーンショットは使用していません
- React Flow 上でノードとエッジを自前生成しています

## 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/package.json`
- `cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/accountFlowEditor.css`
- `cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts`

## 既存機能への影響

以下は意図して変更していません。

- 答案入力
- 日本語IME入力
- 金額入力
- `2000 → 2,000` の既存正規化
- `Cannot read properties of null (reading 'value')` の再発防止処理
- 通常入力後の矢印キー移動
- ダブルクリック／F2で入力欄内カーソル移動
- 自動採点
- side_multiset採点
- 一時保存
- 採点画面の「もう一度解く」
- 外部教材モード
- 教材なしモード
- 復習管理
- 既存案件管理アプリ本体
- GitHub PagesトップURL

## 確認事項

- [ ] npm run build が通る
- [ ] GitHub Actions が通る
- [ ] 工業簿記4-1だけに「自分で作る」モードが表示される
- [ ] 既存の「基本図を見る」が残っている
- [ ] サイドバーからボックスをドラッグして追加できる
- [ ] ボックスをキャンバス上で移動できる
- [ ] ボックス内に勘定科目・金額・メモを入力できる
- [ ] ボックス同士を矢印で接続できる
- [ ] ボックスを削除できる
- [ ] 矢印を削除できる
- [ ] 図表データがブラウザ内に一時保存される
- [ ] ページ移動後、図表データが復元される
- [ ] 答案入力データが消えない
- [ ] 既存の静的勘定連絡図が壊れていない
- [ ] 自動採点が壊れていない
- [ ] side_multiset採点が壊れていない
- [ ] 日本語IME入力が壊れていない
- [ ] 既存の金額入力が壊れていない
- [ ] 図表エディタ内の金額欄で日本語入力モードでもホワイトアウトしない
- [ ] 一時保存が壊れていない
- [ ] もう一度解くが壊れていない
- [ ] 外部教材モードが壊れていない
- [ ] 教材なしモードが壊れていない
- [ ] スマホ表示が大きく崩れていない
- [ ] Consoleに赤エラーが出ない
- [ ] 既存案件管理アプリに影響がない

## 未確認事項

現時点ではPR作成直後のため、実URLでの手動操作確認・Console確認は未実施です。
GitHub Actions結果を確認後、実画面確認が必要です。

## 実URLで確認すべき項目

1. 簿記2級アプリを開く
2. 教材なしモードを開く
3. 工業簿記4-1を開く
4. 図表で確認を開く
5. 「基本図を見る」で静的な勘定連絡図が表示されることを確認
6. 「自分で作る」に切り替える
7. サイドバーから「材料」をキャンバスへドラッグする
8. 材料ボックスが追加されることを確認
9. 材料ボックスに勘定科目、金額、メモを入力する
10. サイドバーから「仕掛品」を追加する
11. 材料ボックスから仕掛品ボックスへ矢印を接続する
12. ボックスを移動できることを確認
13. 矢印を削除できることを確認
14. ボックスを削除できることを確認
15. 材料 → 仕掛品 → 製品 → 売上原価 の簡単な図を作る
16. 答案欄にも入力する
17. 一時保存する
18. 別問題へ移動する
19. 工業簿記4-1へ戻る
20. 作成した図表データと答案入力が復元されることを確認
21. 日本語IMEで既存金額入力欄を操作してもホワイトアウトしないことを確認
22. 自動採点または自己採点が壊れていないことを確認
23. もう一度解くが壊れていないことを確認
24. Consoleに赤エラーが出ていないことを確認

## マージについて

このPRはユーザー確認前にはマージしません。