### PR TITLE
Improve Boki2 account flow editor delete shortcuts

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx
@@ -39,6 +39,24 @@ function stripRuntimeNodeData(node: AccountBoxNode): AccountBoxNode {
   return { ...node, data };
 }
 
+function isEditableElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  return target.isContentEditable || tagName === 'input' || tagName === 'textarea' || tagName === 'select';
+}
+
+function shouldIgnoreDeleteShortcut(event: KeyboardEvent): boolean {
+  const legacyEvent = event as KeyboardEvent & { keyCode?: number; which?: number };
+  return Boolean(
+    event.isComposing
+    || event.key === 'Process'
+    || legacyEvent.keyCode === 229
+    || legacyEvent.which === 229
+    || isEditableElement(document.activeElement)
+    || isEditableElement(event.target),
+  );
+}
+
 function sampleDraft(): AccountFlowDraft {
   return {
     nodes: [
@@ -126,8 +144,8 @@ function AccountFlowEditorCanvas() {
   const initial = useMemo(() => loadDraft(), []);
   const [nodes, setNodes] = useState<AccountBoxNode[]>(initial.nodes);
   const [edges, setEdges] = useState<Edge[]>(initial.edges);
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
+  const [selectedEdgeIds, setSelectedEdgeIds] = useState<string[]>([]);
   const [status, setStatus] = useState('図表データは自動で一時保存されます。');
   const flowWrapperRef = useRef<HTMLDivElement | null>(null);
   const { screenToFlowPosition } = useReactFlow();
@@ -148,6 +166,11 @@ function AccountFlowEditorCanvas() {
   const onNodesChange = useCallback((changes: NodeChange[]) => setNodes((current) => applyNodeChanges(changes, current) as AccountBoxNode[]), []);
   const onEdgesChange = useCallback((changes: EdgeChange[]) => setEdges((current) => applyEdgeChanges(changes, current)), []);
   const onConnect = useCallback((connection: Connection) => setEdges((current) => addEdge({ ...connection, markerEnd: { type: MarkerType.ArrowClosed } }, current)), []);
+
+  const onSelectionChange = useCallback(({ nodes: selectedNodes, edges: selectedEdges }: { nodes: AccountBoxNode[]; edges: Edge[] }) => {
+    setSelectedNodeIds(selectedNodes.map((node) => node.id));
+    setSelectedEdgeIds(selectedEdges.map((edge) => edge.id));
+  }, []);
 
   const addNode = useCallback((accountName: string, x = 120, y = 120) => {
     const label = accountName === '自由入力ボックス' ? '' : accountName;
@@ -174,28 +197,41 @@ function AccountFlowEditorCanvas() {
     addNode(accountName, position.x, position.y);
   };
 
-  const deleteSelected = () => {
-    if (selectedNodeId) {
-      setNodes((current) => current.filter((node) => node.id !== selectedNodeId));
-      setEdges((current) => current.filter((edge) => edge.source !== selectedNodeId && edge.target !== selectedNodeId));
-      setSelectedNodeId(null);
-      setStatus('選択中のボックスを削除しました。');
-      return;
-    }
-    if (selectedEdgeId) {
-      setEdges((current) => current.filter((edge) => edge.id !== selectedEdgeId));
-      setSelectedEdgeId(null);
-      setStatus('選択中の矢印を削除しました。');
-    }
-  };
+  const deleteSelected = useCallback(() => {
+    const nodeIdSet = new Set(selectedNodeIds);
+    const edgeIdSet = new Set(selectedEdgeIds);
+    if (nodeIdSet.size === 0 && edgeIdSet.size === 0) return;
+
+    setNodes((current) => current.filter((node) => !nodeIdSet.has(node.id)));
+    setEdges((current) => current.filter((edge) => !edgeIdSet.has(edge.id) && !nodeIdSet.has(edge.source) && !nodeIdSet.has(edge.target)));
+    setSelectedNodeIds([]);
+    setSelectedEdgeIds([]);
+
+    const nodeText = nodeIdSet.size ? `${nodeIdSet.size}件のボックス` : '';
+    const edgeText = edgeIdSet.size ? `${edgeIdSet.size}件の矢印` : '';
+    setStatus(`${[nodeText, edgeText].filter(Boolean).join('と')}を削除しました。`);
+  }, [selectedEdgeIds, selectedNodeIds]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+      if (selectedNodeIds.length === 0 && selectedEdgeIds.length === 0) return;
+      if (shouldIgnoreDeleteShortcut(event)) return;
+      event.preventDefault();
+      deleteSelected();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [deleteSelected, selectedEdgeIds.length, selectedNodeIds.length]);
 
   const resetSample = () => {
     if (!window.confirm('現在の勘定連絡図をサンプルに戻しますか？')) return;
     const next = sampleDraft();
     setNodes(next.nodes);
     setEdges(next.edges);
-    setSelectedNodeId(null);
-    setSelectedEdgeId(null);
+    setSelectedNodeIds([]);
+    setSelectedEdgeIds([]);
     setStatus('材料 → 仕掛品 → 製品 → 売上原価のサンプルに戻しました。');
   };
 
@@ -212,7 +248,7 @@ function AccountFlowEditorCanvas() {
           ))}
         </div>
         <div className="account-flow-editor-actions">
-          <button type="button" className="secondary" onClick={deleteSelected} disabled={!selectedNodeId && !selectedEdgeId}>選択中を削除</button>
+          <button type="button" className="secondary" onClick={deleteSelected} disabled={selectedNodeIds.length === 0 && selectedEdgeIds.length === 0}>選択中を削除</button>
           <button type="button" className="secondary" onClick={resetSample}>サンプルに戻す</button>
         </div>
         <p className="account-flow-editor-note">金額欄は文字列のまま保存します。自動採点とは連動しません。</p>
@@ -225,9 +261,13 @@ function AccountFlowEditorCanvas() {
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
-          onNodeClick={(_, node) => { setSelectedNodeId(node.id); setSelectedEdgeId(null); }}
-          onEdgeClick={(_, edge) => { setSelectedEdgeId(edge.id); setSelectedNodeId(null); }}
-          onPaneClick={() => { setSelectedNodeId(null); setSelectedEdgeId(null); }}
+          onSelectionChange={onSelectionChange}
+          onNodeClick={(_, node) => { setSelectedNodeIds([node.id]); setSelectedEdgeIds([]); }}
+          onEdgeClick={(_, edge) => { setSelectedEdgeIds([edge.id]); setSelectedNodeIds([]); }}
+          onPaneClick={() => { setSelectedNodeIds([]); setSelectedEdgeIds([]); }}
+          deleteKeyCode={null}
+          multiSelectionKeyCode={['Control', 'Meta']}
+          selectionKeyCode="Shift"
           fitView
           defaultEdgeOptions={{ markerEnd: { type: MarkerType.ArrowClosed } }}
         >


### PR DESCRIPTION
## 目的

工業簿記4-1限定の勘定連絡図エディタについて、削除操作だけを改善します。

今回のPRは機能拡張ではなく、Delete / Backspace による削除操作を Excel・draw.io 系の操作感に近づけるための最小修正です。

## 修正内容

- 選択中のボックスを Delete / Backspace で削除できるようにしました
- 選択中の矢印を Delete / Backspace で削除できるようにしました
- Ctrl / Meta を使ったReact Flow標準の複数選択状態を保持し、複数選択したボックス・矢印を一括削除できるようにしました
- ノード削除時、そのノードに接続された矢印も同時に削除されるようにしました
- 既存の「選択中を削除」ボタンは維持しました
- 削除後の nodes / edges が既存の自動一時保存処理に反映されるようにしました

## 入力欄フォーカス中の誤削除防止

以下の場合は Delete / Backspace を図表削除に使わないようにしています。

- input にフォーカスがある場合
- textarea にフォーカスがある場合
- select にフォーカスがある場合
- contenteditable にフォーカスがある場合
- event.isComposing が true の場合
- event.key が Process の場合
- keyCode / which が 229 の場合

そのため、ボックス内の勘定科目・金額・メモ入力中や、答案入力欄の編集中に Backspace / Delete を押しても、図表ノードは削除されません。

## 既存の削除ボタン

既存の「選択中を削除」ボタンは残しています。

削除手段は以下の3つです。

1. 選択中を削除ボタン
2. Deleteキー
3. Backspaceキー

## 一時保存への影響

削除操作は既存の `nodes` / `edges` state を更新します。既存の `useEffect` による自動保存処理により、削除後の状態がブラウザ内の図表一時保存へ反映されます。

## 既存機能への影響

以下は意図して変更していません。

- 工業簿記4-1の勘定連絡図エディタ本体
- 基本図を見る
- 自分で作る
- ボックス追加
- ボックス移動
- ボックス内の勘定科目入力
- ボックス内の金額入力
- ボックス内のメモ入力
- 矢印接続
- 答案入力
- 日本語IME入力
- 既存金額入力
- 自動採点
- side_multiset採点
- もう一度解く
- 外部教材モード
- 教材なしモード
- 既存案件管理アプリ本体
- GitHub PagesトップURL

## 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/src/components/AccountFlowEditor.tsx`

## 確認事項

- [ ] 単一ボックスを選択して Delete で削除できる
- [x] 単一ボックスを選択して Backspace で削除できる
- [ ] 単一矢印を選択して Delete で削除できる
- [ ] 単一矢印を選択して Backspace で削除できる
- [ ] Ctrl / Meta で複数ボックスを選択できる
- [ ] 複数選択したボックスを Delete / Backspace で一括削除できる
- [ ] 複数選択した矢印を Delete / Backspace で一括削除できる
- [ ] ノード削除時、接続された矢印が残らない
- [ ] ボックス内 input でBackspaceを押してもボックスが誤削除されない
- [ ] ボックス内 textarea でDelete / Backspaceを押してもボックスが誤削除されない
- [ ] 答案入力欄でDelete / Backspaceを押しても図表ノードが削除されない
- [ ] IME変換中にDelete / Backspaceを押しても図表ノードが削除されない
- [ ] 既存の「選択中を削除」ボタンが引き続き使える
- [ ] 削除後に一時保存し、ページ移動して戻っても削除状態が復元される
- [ ] Consoleに赤エラーが出ない
- [ ] npm run build が通る
- [ ] GitHub Actions が通る
- [ ] 既存案件管理アプリに影響がない

## npm run build 結果

未確認。GitHub Actionsで確認予定です。

## GitHub Actions 結果

未確認。PR作成後に確認します。

## Console確認結果

未確認。実URLでの手動確認が必要です。

## 未確認事項

- 実URLでのDelete / Backspace削除
- 実URLでの複数選択削除
- 実URLでの入力欄フォーカス中の誤削除防止
- 実URLでのIME変換中の誤削除防止
- 実URLでの一時保存復元
- スマホ表示

## マージについて

ユーザー確認前にはマージしません。