### PR TITLE
建設業許可モジュール第1-A：保存基盤（SQL・state・fetch/upsert/delete・バックアップ対応）を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,19 @@ const DAILY_REPORT_INTERACTION_TYPES = ["作業", "電話", "メール", "面談
 const REMINDER_METHODS = ["電話", "メール", "LINE", "郵送", "訪問", "その他"];
 const PAYMENT_METHODS = ["現金", "振込", "その他"];
 const CASE_DOCUMENT_STATUSES = ["未回収", "回収済", "確認済", "不備あり", "不要"];
+const CONSTRUCTION_PROCEDURE_TYPES = [
+  { value: "construction_license_new", label: "建設業許可 新規" },
+  { value: "construction_license_renewal", label: "建設業許可 更新" },
+  { value: "construction_license_add_business", label: "業種追加" },
+  { value: "annual_closing_report", label: "決算変更届" },
+  { value: "change_notification", label: "変更届" },
+  { value: "keishin", label: "経審" },
+  { value: "management_analysis", label: "経営状況分析" },
+];
+const CONSTRUCTION_PROCEDURE_TYPE_LABELS = Object.freeze(CONSTRUCTION_PROCEDURE_TYPES.reduce((acc, entry) => {
+  acc[entry.value] = entry.label;
+  return acc;
+}, {}));
 const OFFICE_INFO = {
   name: "あかし行政書士事務所",
   zip: "574-0044",
@@ -64,6 +77,8 @@ const state = {
   caseTasks: [],
   caseDocuments: [],
   permitHearings: [],
+  constructionCaseDetails: [],
+  businessResourceTemplates: [],
   selectedAggregation: "month",
   selectedMonth: toMonthKey(new Date()),
   selectedYear: new Date().getFullYear(),
@@ -637,9 +652,9 @@ let eventsBound = false;
 let loadingCount = 0;
 let loadingTimer = null;
 let isApplyingAuthState = false;
-const BACKUP_TABLE_KEYS = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_INSERT_ORDER = ["clients", "work_templates", "cases", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
-const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "estimate_calculations", "sales", "expenses", "fixed_expenses", "daily_reports", "permit_hearings", "case_documents", "case_tasks", "estimates", "cases", "work_templates", "clients", "app_settings"];
+const BACKUP_TABLE_KEYS = ["clients", "work_templates", "business_resource_templates", "cases", "construction_case_details", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_INSERT_ORDER = ["clients", "work_templates", "business_resource_templates", "cases", "construction_case_details", "case_tasks", "case_documents", "permit_hearings", "estimates", "estimate_items", "estimate_calculations", "sales", "payments", "expenses", "fixed_expenses", "daily_reports", "app_settings"];
+const RESTORE_DELETE_ORDER = ["payments", "estimate_items", "estimate_calculations", "sales", "expenses", "fixed_expenses", "daily_reports", "permit_hearings", "case_documents", "case_tasks", "construction_case_details", "estimates", "cases", "business_resource_templates", "work_templates", "clients", "app_settings"];
 const CASE_MUTATION_COLUMNS = [
   "user_id",
   "client_id",
@@ -680,6 +695,8 @@ const PAYMENT_MUTATION_COLUMNS = ["user_id", "sale_id", "payment_date", "amount"
 const FIXED_EXPENSE_MUTATION_COLUMNS = ["user_id", "content", "amount", "day_of_month", "start_date", "active"];
 const CASE_TASK_MUTATION_COLUMNS = ["user_id", "case_id", "task_title", "task_memo", "due_date", "status", "completed_at"];
 const CASE_DOCUMENT_MUTATION_COLUMNS = ["user_id", "case_id", "document_name", "status", "received_date", "checked_date", "memo", "file_url"];
+const CONSTRUCTION_CASE_DETAIL_MUTATION_COLUMNS = ["id", "user_id", "case_id", "procedure_type", "permit_expiry_date", "fiscal_month", "application_route", "memo"];
+const BUSINESS_RESOURCE_TEMPLATE_MUTATION_COLUMNS = ["id", "user_id", "procedure_type", "resource_category", "resource_name", "description", "url", "file_url", "customer_visible", "required", "last_checked_at", "source_type", "source_name", "memo", "related_task_type", "related_estimate_item", "related_expense_item", "sort_order", "is_active"];
 const CLIENT_INTERACTION_MUTATION_COLUMNS = ["user_id", "client_id", "interaction_date", "interaction_type", "summary", "next_action", "next_action_date", "memo"];
 const RESTORE_MUTATION_COLUMNS = {
   clients: CLIENT_MUTATION_COLUMNS,
@@ -690,6 +707,8 @@ const RESTORE_MUTATION_COLUMNS = {
   fixed_expenses: FIXED_EXPENSE_MUTATION_COLUMNS,
   case_tasks: CASE_TASK_MUTATION_COLUMNS,
   case_documents: CASE_DOCUMENT_MUTATION_COLUMNS,
+  construction_case_details: CONSTRUCTION_CASE_DETAIL_MUTATION_COLUMNS,
+  business_resource_templates: BUSINESS_RESOURCE_TEMPLATE_MUTATION_COLUMNS,
   client_interactions: CLIENT_INTERACTION_MUTATION_COLUMNS,
   work_templates: ["user_id", "name", "items", "memo"],
   permit_hearings: ["id", "user_id", "case_id", "scenario_key", "scenario_label", "industry_primary", "industry_secondary", "industry_notes", "preparation_status", "application_route", "corporation_plan", "applicant_name", "applicant_kana", "contact_name", "contact_tel", "contact_email", "office_name", "office_address", "office_postal_code", "business_type", "capital", "employees_count", "officers_count", "years_in_business", "fiscal_month", "insurance_joined", "construction_career_system", "social_insurance_notes", "requested_permissions", "existing_permits", "past_admin_dispositions", "documents", "tasks", "hearing_notes", "next_actions", "status", "updated_at"],
@@ -2252,6 +2271,154 @@ async function loadCaseDocuments() {
   }
 }
 
+
+async function fetchConstructionCaseDetails() {
+  if (!currentUser || isLoggingOut) {
+    state.constructionCaseDetails = [];
+    return [];
+  }
+  try {
+    const { data, error } = await sbClient
+      .from("construction_case_details")
+      .select("*")
+      .eq("user_id", currentUser.id)
+      .order("updated_at", { ascending: false });
+    if (error) {
+      console.error("LOAD constructionCaseDetails ERROR", error);
+      state.constructionCaseDetails = [];
+      return [];
+    }
+    state.constructionCaseDetails = data || [];
+    return state.constructionCaseDetails;
+  } catch (error) {
+    console.error("LOAD constructionCaseDetails ERROR", error);
+    state.constructionCaseDetails = [];
+    return [];
+  }
+}
+
+async function loadConstructionCaseDetails() {
+  return fetchConstructionCaseDetails();
+}
+
+async function upsertConstructionCaseDetail(detail) {
+  if (!currentUser) {
+    showAppMessage("ログイン状態を確認できません。", true);
+    return null;
+  }
+  const rawPayload = { ...(detail || {}), user_id: currentUser.id };
+  const payload = pickObjectKeys(rawPayload, CONSTRUCTION_CASE_DETAIL_MUTATION_COLUMNS);
+  if (!payload.case_id) {
+    showAppMessage("建設業許可案件詳細の案件IDがありません。", true);
+    return null;
+  }
+
+  const mutation = async () => {
+    const query = payload.id
+      ? sbClient.from("construction_case_details").update(payload).eq("id", payload.id).eq("user_id", currentUser.id)
+      : sbClient.from("construction_case_details").insert(payload);
+    const { data, error } = await query.select().single();
+    if (error) throw error;
+    return data;
+  };
+  return runMutation("建設業許可案件詳細の保存", mutation, { successMessage: "建設業許可案件詳細を保存しました。" });
+}
+
+async function deleteConstructionCaseDetail(id) {
+  if (!currentUser) {
+    showAppMessage("ログイン状態を確認できません。", true);
+    return null;
+  }
+  if (!id) {
+    showAppMessage("建設業許可案件詳細の削除対象IDを取得できませんでした。", true);
+    return null;
+  }
+  return runMutation("建設業許可案件詳細の削除", async () => {
+    const { data, error } = await sbClient
+      .from("construction_case_details")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", currentUser.id)
+      .select("id");
+    if (error) throw error;
+    return data;
+  }, { successMessage: "建設業許可案件詳細を削除しました。" });
+}
+
+async function fetchBusinessResourceTemplates() {
+  if (!currentUser || isLoggingOut) {
+    state.businessResourceTemplates = [];
+    return [];
+  }
+  try {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .select("*")
+      .eq("user_id", currentUser.id)
+      .order("sort_order", { ascending: true })
+      .order("resource_name", { ascending: true });
+    if (error) {
+      console.error("LOAD businessResourceTemplates ERROR", error);
+      state.businessResourceTemplates = [];
+      return [];
+    }
+    state.businessResourceTemplates = data || [];
+    return state.businessResourceTemplates;
+  } catch (error) {
+    console.error("LOAD businessResourceTemplates ERROR", error);
+    state.businessResourceTemplates = [];
+    return [];
+  }
+}
+
+async function loadBusinessResourceTemplates() {
+  return fetchBusinessResourceTemplates();
+}
+
+async function upsertBusinessResourceTemplate(template) {
+  if (!currentUser) {
+    showAppMessage("ログイン状態を確認できません。", true);
+    return null;
+  }
+  const rawPayload = { ...(template || {}), user_id: currentUser.id };
+  const payload = pickObjectKeys(rawPayload, BUSINESS_RESOURCE_TEMPLATE_MUTATION_COLUMNS);
+  if (!payload.resource_name) {
+    showAppMessage("業務資料テンプレート名を入力してください。", true);
+    return null;
+  }
+
+  const mutation = async () => {
+    const query = payload.id
+      ? sbClient.from("business_resource_templates").update(payload).eq("id", payload.id).eq("user_id", currentUser.id)
+      : sbClient.from("business_resource_templates").insert(payload);
+    const { data, error } = await query.select().single();
+    if (error) throw error;
+    return data;
+  };
+  return runMutation("業務資料テンプレートの保存", mutation, { successMessage: "業務資料テンプレートを保存しました。" });
+}
+
+async function deleteBusinessResourceTemplate(id) {
+  if (!currentUser) {
+    showAppMessage("ログイン状態を確認できません。", true);
+    return null;
+  }
+  if (!id) {
+    showAppMessage("業務資料テンプレートの削除対象IDを取得できませんでした。", true);
+    return null;
+  }
+  return runMutation("業務資料テンプレートの削除", async () => {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", currentUser.id)
+      .select("id");
+    if (error) throw error;
+    return data;
+  }, { successMessage: "業務資料テンプレートを削除しました。" });
+}
+
 async function loadPermitHearings() {
   if (!currentUser || isLoggingOut) {
     state.permitHearings = [];
@@ -2484,6 +2651,8 @@ async function loadAllDataSafely() {
     ["cases", loadCases],
     ["caseTasks", loadCaseTasks],
     ["caseDocuments", loadCaseDocuments],
+    ["constructionCaseDetails", loadConstructionCaseDetails],
+    ["businessResourceTemplates", loadBusinessResourceTemplates],
     ["permitHearings", loadPermitHearings],
     ["estimates", loadEstimates],
     ["estimateItems", loadEstimateItems],
@@ -2520,6 +2689,8 @@ async function loadAllDataSafely() {
     estimates: state.estimates.length,
     caseTasks: state.caseTasks.length,
     caseDocuments: state.caseDocuments.length,
+    constructionCaseDetails: state.constructionCaseDetails.length,
+    businessResourceTemplates: state.businessResourceTemplates.length,
     payments: state.payments.length,
     appSettings: state.appSettings?.id ? 1 : 0,
   });
@@ -5107,6 +5278,8 @@ function buildBackupJson() {
       work_templates: Array.isArray(state.workTemplates) ? state.workTemplates : [],
       case_tasks: Array.isArray(state.caseTasks) ? state.caseTasks : [],
       case_documents: Array.isArray(state.caseDocuments) ? state.caseDocuments : [],
+      construction_case_details: Array.isArray(state.constructionCaseDetails) ? state.constructionCaseDetails : [],
+      business_resource_templates: Array.isArray(state.businessResourceTemplates) ? state.businessResourceTemplates : [],
       permit_hearings: Array.isArray(state.permitHearings) ? state.permitHearings : [],
       app_settings: state.appSettings?.id ? [{
         id: state.appSettings.id,
@@ -5133,6 +5306,10 @@ function validateBackupJsonPayload(payload) {
   if (!payload.data || typeof payload.data !== "object") throw new Error("バックアップJSONに data が存在しません。");
 
   for (const tableName of BACKUP_TABLE_KEYS) {
+    if (payload.data[tableName] === undefined) {
+      payload.data[tableName] = [];
+      continue;
+    }
     if (!Array.isArray(payload.data[tableName])) {
       throw new Error(`バックアップJSONの data.${tableName} が配列ではありません。`);
     }
@@ -11312,6 +11489,8 @@ function clearAppState() {
   state.cases = [];
   state.caseTasks = [];
   state.caseDocuments = [];
+  state.constructionCaseDetails = [];
+  state.businessResourceTemplates = [];
   state.estimates = [];
   state.estimateItems = [];
   state.estimateCalculations = [];
@@ -11347,6 +11526,16 @@ window.GyoseiApp = {
   getTaxRate: () => getCurrentTaxRate(),
   getClients: () => Array.isArray(state.clients) ? state.clients.slice() : [],
   getEstimateCalculations: () => Array.isArray(state.estimateCalculations) ? state.estimateCalculations.slice() : [],
+  getConstructionProcedureTypes: () => CONSTRUCTION_PROCEDURE_TYPES.map((entry) => ({ ...entry })),
+  getConstructionProcedureTypeLabels: () => ({ ...CONSTRUCTION_PROCEDURE_TYPE_LABELS }),
+  getConstructionCaseDetails: () => Array.isArray(state.constructionCaseDetails) ? state.constructionCaseDetails.slice() : [],
+  fetchConstructionCaseDetails,
+  upsertConstructionCaseDetail,
+  deleteConstructionCaseDetail,
+  getBusinessResourceTemplates: () => Array.isArray(state.businessResourceTemplates) ? state.businessResourceTemplates.slice() : [],
+  fetchBusinessResourceTemplates,
+  upsertBusinessResourceTemplate,
+  deleteBusinessResourceTemplate,
   reloadAllData: async () => {
     if (!currentUser) return;
     await loadAllDataSafely();

--- a/supabase_construction_module_foundation.sql
+++ b/supabase_construction_module_foundation.sql
@@ -1,0 +1,113 @@
+-- 建設業許可モジュール 第1-A: DB・状態管理・保存基盤
+-- Supabase SQL Editorで実行してください。
+
+create table if not exists construction_case_details (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  case_id uuid not null references cases(id) on delete cascade,
+  procedure_type text,
+  permit_expiry_date date,
+  fiscal_month integer,
+  application_route text,
+  memo text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  constraint construction_case_details_user_case_unique unique (user_id, case_id),
+  constraint construction_case_details_fiscal_month_check check (fiscal_month is null or (fiscal_month between 1 and 12))
+);
+
+create table if not exists business_resource_templates (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  procedure_type text,
+  resource_category text,
+  resource_name text not null,
+  description text,
+  url text,
+  file_url text,
+  customer_visible boolean not null default false,
+  required boolean not null default false,
+  last_checked_at date,
+  source_type text,
+  source_name text,
+  memo text,
+  related_task_type text,
+  related_estimate_item text,
+  related_expense_item text,
+  sort_order integer default 0,
+  is_active boolean not null default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create or replace function construction_module_set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_construction_case_details_updated_at on construction_case_details;
+create trigger set_construction_case_details_updated_at
+before update on construction_case_details
+for each row execute function construction_module_set_updated_at();
+
+drop trigger if exists set_business_resource_templates_updated_at on business_resource_templates;
+create trigger set_business_resource_templates_updated_at
+before update on business_resource_templates
+for each row execute function construction_module_set_updated_at();
+
+alter table construction_case_details enable row level security;
+alter table business_resource_templates enable row level security;
+
+drop policy if exists "construction_case_details_select_own" on construction_case_details;
+drop policy if exists "construction_case_details_insert_own" on construction_case_details;
+drop policy if exists "construction_case_details_update_own" on construction_case_details;
+drop policy if exists "construction_case_details_delete_own" on construction_case_details;
+
+create policy "construction_case_details_select_own" on construction_case_details
+for select
+using (auth.uid() = user_id);
+
+create policy "construction_case_details_insert_own" on construction_case_details
+for insert
+with check (auth.uid() = user_id);
+
+create policy "construction_case_details_update_own" on construction_case_details
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "construction_case_details_delete_own" on construction_case_details
+for delete
+using (auth.uid() = user_id);
+
+drop policy if exists "business_resource_templates_select_own" on business_resource_templates;
+drop policy if exists "business_resource_templates_insert_own" on business_resource_templates;
+drop policy if exists "business_resource_templates_update_own" on business_resource_templates;
+drop policy if exists "business_resource_templates_delete_own" on business_resource_templates;
+
+create policy "business_resource_templates_select_own" on business_resource_templates
+for select
+using (auth.uid() = user_id);
+
+create policy "business_resource_templates_insert_own" on business_resource_templates
+for insert
+with check (auth.uid() = user_id);
+
+create policy "business_resource_templates_update_own" on business_resource_templates
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "business_resource_templates_delete_own" on business_resource_templates
+for delete
+using (auth.uid() = user_id);
+
+create index if not exists idx_construction_case_details_user_id on construction_case_details(user_id);
+create index if not exists idx_construction_case_details_case_id on construction_case_details(case_id);
+create index if not exists idx_construction_case_details_procedure_type on construction_case_details(procedure_type);
+create index if not exists idx_business_resource_templates_user_id on business_resource_templates(user_id);
+create index if not exists idx_business_resource_templates_procedure_type on business_resource_templates(procedure_type);
+create index if not exists idx_business_resource_templates_active_order on business_resource_templates(user_id, is_active, sort_order);


### PR DESCRIPTION
### Motivation
- 第1-B/1-C の安全な実装のために、建設業許可データを既存 `cases` に過剰追加せず分離して保存する永続化基盤を先に用意するため。 
- 業務資料ライブラリのマスタと案件別詳細をユーザー別データとして扱えるようにし、後続の画面実装で使える fetch / upsert / delete API を整備するため。 

### Description
- Supabase 用 SQL を追加し、`construction_case_details` と `business_resource_templates` の2テーブル、`user_id`、`created_at`/`updated_at`、RLS ポリシー（select/insert/update/delete）、インデックス、`updated_at` トリガーを定義したファイルを追加しました (`supabase_construction_module_foundation.sql`). 
- アプリ側 (`app.js`) に 7 種の `procedure_type` 定義を `CONSTRUCTION_PROCEDURE_TYPES`／`CONSTRUCTION_PROCEDURE_TYPE_LABELS` として追加し、state に `constructionCaseDetails` と `businessResourceTemplates` を追加しました。 
- `fetchConstructionCaseDetails` / `upsertConstructionCaseDetail` / `deleteConstructionCaseDetail` と `fetchBusinessResourceTemplates` / `upsertBusinessResourceTemplate` / `deleteBusinessResourceTemplate` を追加し、いずれも `currentUser.id` によるユーザー限定アクセスと `pickObjectKeys` による許可カラムフィルタを適用しました。 
- JSON バックアップ/復元基盤へ新規テーブルを組み込み、`BACKUP_TABLE_KEYS`、`RESTORE_INSERT_ORDER`、`RESTORE_DELETE_ORDER`、`RESTORE_MUTATION_COLUMNS` を更新して復元順序と許可カラムを整え、古いバックアップに新規キーが無い場合でも空配列として扱う互換処理を追加しました。 
- `loadAllDataSafely` のロード一覧・デバッグカウント・ログアウト時のクリア処理に新しい state を組み込み、`window.GyoseiApp` から procedure type と CRUD 関数を公開しました。 

### Testing
- `node --check app.js` を実行して構文チェックを行い成功しました。 
- `git diff --check` とリポジトリ内の静的確認スクリプト（Python スクリプト）で、バックアップ/復元の登録、fetch/upsert/delete の存在、payload 制限、SQL 内容（テーブル・RLS・ポリシー・user_id）を確認し問題ありませんでした。 
- SQL の実行環境での検証（`psql`）はこの環境で未インストールのため実行していませんが、SQL ファイルの静的チェックは通っています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184e3a04f08333a92b370d32cbc30a)