### PR TITLE
Add business resource library UI (業務資料ライブラリ) under 業務テンプレート

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,15 @@ const CONSTRUCTION_PROCEDURE_TYPE_LABELS = Object.freeze(CONSTRUCTION_PROCEDURE_
   acc[entry.value] = entry.label;
   return acc;
 }, {}));
+const BUSINESS_RESOURCE_CATEGORIES = [
+  { value: "use", label: "使う資料" },
+  { value: "collect", label: "回収する資料" },
+  { value: "submit", label: "提出する資料" },
+];
+const BUSINESS_RESOURCE_CATEGORY_LABELS = Object.freeze(BUSINESS_RESOURCE_CATEGORIES.reduce((acc, entry) => {
+  acc[entry.value] = entry.label;
+  return acc;
+}, {}));
 const OFFICE_INFO = {
   name: "あかし行政書士事務所",
   zip: "574-0044",
@@ -89,6 +98,10 @@ const state = {
   expensesSearchQuery: "",
   dailyReportSearchQuery: "",
   dailyReportDateFilter: "all",
+  businessResourceProcedureFilter: "all",
+  businessResourceCategoryFilter: "all",
+  businessResourceActiveFilter: "active",
+  businessResourceSearchQuery: "",
   permitHearingSearchQuery: "",
   permitHearingCategoryFilter: "all",
   permitHearingUrgencyFilter: "all",
@@ -113,7 +126,7 @@ const state = {
   selectedDailyReportIds: [],
   selectedFixedExpenseIds: [],
 };
-const editState = { clientId: null, caseId: null, workTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null, caseDocumentId: null };
+const editState = { clientId: null, caseId: null, workTemplateId: null, businessResourceTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null, caseDocumentId: null };
 
 const CLICK_ACTION_HANDLERS = {
   activate_tab: (event, button) => activateTab(button?.dataset?.tab),
@@ -165,6 +178,9 @@ const CLICK_ACTION_HANDLERS = {
   register_sale_from_case: handleCaseListAction,
   edit_work_template: handleWorkTemplateListAction,
   delete_work_template: handleWorkTemplateListAction,
+  edit_business_resource_template: handleBusinessResourceTemplateListAction,
+  disable_business_resource_template: handleBusinessResourceTemplateListAction,
+  reactivate_business_resource_template: handleBusinessResourceTemplateListAction,
   edit_estimate: handleEstimateListAction,
   delete_estimate: handleEstimateListAction,
   create_case_from_estimate: handleEstimateListAction,
@@ -627,6 +643,16 @@ const workTemplateSubmitBtn = document.getElementById("work-template-submit-btn"
 const workTemplatesList = document.getElementById("work-templates-list");
 const workTemplatesEmpty = document.getElementById("work-templates-empty");
 const workTemplateItemTemplate = document.getElementById("work-template-item-template");
+const businessResourceTemplateForm = document.getElementById("business-resource-template-form");
+const businessResourceSubmitBtn = document.getElementById("business-resource-submit-btn");
+const businessResourceResetBtn = document.getElementById("business-resource-reset-btn");
+const businessResourceFilterProcedure = document.getElementById("business-resource-filter-procedure");
+const businessResourceFilterCategory = document.getElementById("business-resource-filter-category");
+const businessResourceFilterActive = document.getElementById("business-resource-filter-active");
+const businessResourceSearchInput = document.getElementById("business-resource-search");
+const businessResourceTemplatesEmpty = document.getElementById("business-resource-templates-empty");
+const businessResourceTemplatesWrap = document.getElementById("business-resource-templates-wrap");
+const businessResourceTemplatesBody = document.getElementById("business-resource-templates-body");
 const expenseItemTemplate = document.getElementById("expense-item-template");
 const fixedExpenseItemTemplate = document.getElementById("fixed-expense-item-template");
 const estimateForm = document.getElementById("estimate-form");
@@ -789,6 +815,12 @@ function bindEvents() {
   if (permitReflectEstimateBtn) permitReflectEstimateBtn.dataset.action = "reflect_permit_hearing_to_estimate";
   if (permitOverwriteHearingBtn) permitOverwriteHearingBtn.addEventListener("click", handleOverwritePermitHearing);
   workTemplateForm?.addEventListener("submit", handleWorkTemplateSubmit);
+  businessResourceTemplateForm?.addEventListener("submit", handleBusinessResourceTemplateSubmit);
+  businessResourceResetBtn?.addEventListener("click", resetBusinessResourceTemplateForm);
+  businessResourceFilterProcedure?.addEventListener("change", handleBusinessResourceFilterChange);
+  businessResourceFilterCategory?.addEventListener("change", handleBusinessResourceFilterChange);
+  businessResourceFilterActive?.addEventListener("change", handleBusinessResourceFilterChange);
+  businessResourceSearchInput?.addEventListener("input", handleBusinessResourceFilterChange);
   debugLog("SALE FORM FOUND", !!saleForm);
   debugLog("EXPENSE FORM FOUND", !!expenseForm);
   debugLog("DAILY REPORT FORM FOUND", !!dailyReportForm);
@@ -2382,6 +2414,10 @@ async function upsertBusinessResourceTemplate(template) {
   }
   const rawPayload = { ...(template || {}), user_id: currentUser.id };
   const payload = pickObjectKeys(rawPayload, BUSINESS_RESOURCE_TEMPLATE_MUTATION_COLUMNS);
+  payload.procedure_type = normalizeBusinessResourceProcedureType(payload.procedure_type);
+  payload.resource_category = normalizeBusinessResourceCategory(payload.resource_category);
+  payload.sort_order = getBusinessResourceSortOrder(payload.sort_order);
+  if (payload.is_active !== false) payload.is_active = true;
   if (!payload.resource_name) {
     showAppMessage("業務資料テンプレート名を入力してください。", true);
     return null;
@@ -2407,16 +2443,7 @@ async function deleteBusinessResourceTemplate(id) {
     showAppMessage("業務資料テンプレートの削除対象IDを取得できませんでした。", true);
     return null;
   }
-  return runMutation("業務資料テンプレートの削除", async () => {
-    const { data, error } = await sbClient
-      .from("business_resource_templates")
-      .delete()
-      .eq("id", id)
-      .eq("user_id", currentUser.id)
-      .select("id");
-    if (error) throw error;
-    return data;
-  }, { successMessage: "業務資料テンプレートを削除しました。" });
+  return setBusinessResourceTemplateActive(id, false);
 }
 
 async function loadPermitHearings() {
@@ -2894,6 +2921,108 @@ async function handleWorkTemplateSubmit(event) {
   } catch (error) {
     showAppMessage(`業務テンプレート保存に失敗しました。${formatSupabaseError(error)}`, true);
   }
+}
+
+function normalizeBusinessResourceProcedureType(value) {
+  const normalized = String(value || "").trim();
+  return CONSTRUCTION_PROCEDURE_TYPE_LABELS[normalized] ? normalized : CONSTRUCTION_PROCEDURE_TYPES[0].value;
+}
+
+function normalizeBusinessResourceCategory(value) {
+  const normalized = String(value || "").trim();
+  return BUSINESS_RESOURCE_CATEGORY_LABELS[normalized] ? normalized : BUSINESS_RESOURCE_CATEGORIES[0].value;
+}
+
+function getBusinessResourceProcedureLabel(value) {
+  return CONSTRUCTION_PROCEDURE_TYPE_LABELS[value] || value || "未設定";
+}
+
+function getBusinessResourceCategoryLabel(value) {
+  return BUSINESS_RESOURCE_CATEGORY_LABELS[value] || value || "未設定";
+}
+
+function getBusinessResourceSortOrder(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getBusinessResourceActiveValue(entry) {
+  return entry?.is_active !== false;
+}
+
+function getBusinessResourceText(entry, key) {
+  return asTrimmedText(entry?.[key]) || "";
+}
+
+function getBusinessResourceSourceLabel(entry) {
+  const sourceType = getBusinessResourceText(entry, "source_type");
+  const sourceName = getBusinessResourceText(entry, "source_name");
+  return [sourceType, sourceName].filter(Boolean).join(" / ") || "未設定";
+}
+
+function buildBusinessResourceTemplatePayload() {
+  if (!businessResourceTemplateForm || !currentUser) return null;
+  const elements = businessResourceTemplateForm.elements;
+  const resourceName = asTrimmedText(elements.resourceName.value);
+  if (!resourceName) {
+    showAppMessage("資料名を入力してください。", true);
+    return null;
+  }
+  return {
+    id: editState.businessResourceTemplateId || undefined,
+    user_id: currentUser.id,
+    procedure_type: normalizeBusinessResourceProcedureType(elements.procedureType.value),
+    resource_category: normalizeBusinessResourceCategory(elements.resourceCategory.value),
+    resource_name: resourceName,
+    description: asTrimmedText(elements.description.value) || null,
+    url: asTrimmedText(elements.url.value) || null,
+    file_url: asTrimmedText(elements.fileUrl.value) || null,
+    customer_visible: Boolean(elements.customerVisible.checked),
+    required: Boolean(elements.required.checked),
+    last_checked_at: elements.lastCheckedAt.value || null,
+    source_type: asTrimmedText(elements.sourceType.value) || null,
+    source_name: asTrimmedText(elements.sourceName.value) || null,
+    memo: asTrimmedText(elements.memo.value) || null,
+    related_task_type: asTrimmedText(elements.relatedTaskType.value) || null,
+    related_estimate_item: asTrimmedText(elements.relatedEstimateItem.value) || null,
+    related_expense_item: asTrimmedText(elements.relatedExpenseItem.value) || null,
+    sort_order: getBusinessResourceSortOrder(elements.sortOrder.value),
+    is_active: Boolean(elements.isActive.checked),
+  };
+}
+
+async function handleBusinessResourceTemplateSubmit(event) {
+  event.preventDefault();
+  const payload = buildBusinessResourceTemplatePayload();
+  if (!payload) return;
+  const isEdit = Boolean(editState.businessResourceTemplateId);
+  try {
+    await runMutation(isEdit ? "業務資料更新" : "業務資料登録", async () => {
+      const query = isEdit
+        ? sbClient.from("business_resource_templates").update(payload).eq("id", editState.businessResourceTemplateId).eq("user_id", currentUser.id)
+        : sbClient.from("business_resource_templates").insert(payload);
+      const { data, error } = await query.select().single();
+      if (error) throw error;
+      if (!data) throw new Error(isEdit ? "更新結果を取得できませんでした。" : "登録結果を取得できませんでした。");
+      return data;
+    }, {
+      successMessage: isEdit ? "業務資料を更新しました。" : "業務資料を登録しました。",
+      resetForm: resetBusinessResourceTemplateForm,
+      afterSuccess: () => {
+        subtabState["work-templates"] = "resource-library";
+      },
+    });
+  } catch (error) {
+    showAppMessage(`業務資料保存に失敗しました。${formatSupabaseError(error)}`, true);
+  }
+}
+
+function handleBusinessResourceFilterChange() {
+  state.businessResourceProcedureFilter = businessResourceFilterProcedure?.value || "all";
+  state.businessResourceCategoryFilter = businessResourceFilterCategory?.value || "all";
+  state.businessResourceActiveFilter = businessResourceFilterActive?.value || "active";
+  state.businessResourceSearchQuery = asTrimmedText(businessResourceSearchInput?.value).toLowerCase();
+  renderBusinessResourceTemplates();
 }
 
 async function createCaseTasksFromTemplate(caseRow, templateId) {
@@ -3558,6 +3687,82 @@ function startWorkTemplateEdit(templateId) {
   workTemplateSubmitBtn.textContent = "テンプレートを更新";
   activateTab("work-templates");
   workTemplateForm.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+async function handleBusinessResourceTemplateListAction(event) {
+  const btn = event.target.closest("button");
+  if (!(btn instanceof HTMLButtonElement) || !currentUser) return;
+  const id = btn.dataset.id || btn.closest("[data-id]")?.dataset?.id;
+  if (!id) return;
+  const listAction = btn.dataset.listAction;
+  if (listAction === "edit_business_resource_template") {
+    startBusinessResourceTemplateEdit(id);
+    return;
+  }
+  if (listAction === "disable_business_resource_template") {
+    await setBusinessResourceTemplateActive(id, false);
+    return;
+  }
+  if (listAction === "reactivate_business_resource_template") {
+    await setBusinessResourceTemplateActive(id, true);
+  }
+}
+
+function startBusinessResourceTemplateEdit(templateId) {
+  const target = state.businessResourceTemplates.find((entry) => String(entry.id) === String(templateId));
+  if (!target || !businessResourceTemplateForm) return;
+  editState.businessResourceTemplateId = target.id;
+  const elements = businessResourceTemplateForm.elements;
+  elements.procedureType.value = normalizeBusinessResourceProcedureType(target.procedure_type);
+  elements.resourceCategory.value = normalizeBusinessResourceCategory(target.resource_category);
+  elements.resourceName.value = target.resource_name || "";
+  elements.description.value = target.description || "";
+  elements.url.value = target.url || "";
+  elements.fileUrl.value = target.file_url || "";
+  elements.customerVisible.checked = Boolean(target.customer_visible);
+  elements.required.checked = Boolean(target.required);
+  elements.lastCheckedAt.value = target.last_checked_at || "";
+  elements.sourceType.value = target.source_type || "";
+  elements.sourceName.value = target.source_name || "";
+  elements.memo.value = target.memo || "";
+  elements.relatedTaskType.value = target.related_task_type || "";
+  elements.relatedEstimateItem.value = target.related_estimate_item || "";
+  elements.relatedExpenseItem.value = target.related_expense_item || "";
+  elements.sortOrder.value = getBusinessResourceSortOrder(target.sort_order);
+  elements.isActive.checked = getBusinessResourceActiveValue(target);
+  if (businessResourceSubmitBtn) businessResourceSubmitBtn.textContent = "業務資料を更新";
+  activateTab("work-templates");
+  activateSubtab("work-templates", "resource-library");
+  businessResourceTemplateForm.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+async function setBusinessResourceTemplateActive(templateId, isActive) {
+  const target = state.businessResourceTemplates.find((entry) => String(entry.id) === String(templateId));
+  if (!target) {
+    showAppMessage("対象の業務資料が見つかりません。", true);
+    return;
+  }
+  const actionName = isActive ? "業務資料再有効化" : "業務資料無効化";
+  const confirmMessage = isActive ? "この業務資料を有効化しますか？" : "この業務資料を無効化しますか？通常一覧から外れます。";
+  if (!window.confirm(confirmMessage)) return;
+  await runMutation(actionName, async () => {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .update({ is_active: Boolean(isActive), user_id: currentUser.id })
+      .eq("id", templateId)
+      .eq("user_id", currentUser.id)
+      .select()
+      .single();
+    if (error) throw error;
+    if (!data) throw new Error("更新結果を取得できませんでした。");
+    return data;
+  }, {
+    successMessage: isActive ? "業務資料を有効化しました。" : "業務資料を無効化しました。",
+    afterSuccess: () => {
+      if (editState.businessResourceTemplateId === templateId) resetBusinessResourceTemplateForm();
+      subtabState["work-templates"] = "resource-library";
+    },
+  });
 }
 
 
@@ -5387,6 +5592,7 @@ function renderAfterDataChanged() {
   safeRender("clientOptions", renderClientOptions);
   safeRender("clientHistory", renderClientHistory);
   safeRender("workTemplates", renderWorkTemplates);
+  safeRender("businessResourceTemplates", renderBusinessResourceTemplates);
   safeRender("workTemplateOptions", renderWorkTemplateOptions);
   safeRender("caseOptions", renderCaseOptions);
   safeRender("caseTasks", renderCaseTasks);
@@ -7412,6 +7618,80 @@ function renderWorkTemplates() {
   workTemplatesEmpty.hidden = sorted.length > 0;
 }
 
+function getFilteredBusinessResourceTemplates() {
+  const procedureFilter = state.businessResourceProcedureFilter || "all";
+  const categoryFilter = state.businessResourceCategoryFilter || "all";
+  const activeFilter = state.businessResourceActiveFilter || "active";
+  const query = asTrimmedText(state.businessResourceSearchQuery).toLowerCase();
+  return (Array.isArray(state.businessResourceTemplates) ? state.businessResourceTemplates : [])
+    .filter((entry) => {
+      if (procedureFilter !== "all" && entry.procedure_type !== procedureFilter) return false;
+      if (categoryFilter !== "all" && entry.resource_category !== categoryFilter) return false;
+      const isActive = getBusinessResourceActiveValue(entry);
+      if (activeFilter === "active" && !isActive) return false;
+      if (activeFilter === "inactive" && isActive) return false;
+      if (!query) return true;
+      return [entry.resource_name, entry.description, entry.source_name, entry.memo]
+        .some((value) => String(value || "").toLowerCase().includes(query));
+    })
+    .sort((a, b) => {
+      const proc = CONSTRUCTION_PROCEDURE_TYPES.findIndex((entry) => entry.value === a.procedure_type) - CONSTRUCTION_PROCEDURE_TYPES.findIndex((entry) => entry.value === b.procedure_type);
+      if (proc) return proc;
+      const category = BUSINESS_RESOURCE_CATEGORIES.findIndex((entry) => entry.value === a.resource_category) - BUSINESS_RESOURCE_CATEGORIES.findIndex((entry) => entry.value === b.resource_category);
+      if (category) return category;
+      const sortOrder = getBusinessResourceSortOrder(a.sort_order) - getBusinessResourceSortOrder(b.sort_order);
+      if (sortOrder) return sortOrder;
+      return String(a.resource_name || "").localeCompare(String(b.resource_name || ""), "ja");
+    });
+}
+
+function renderBusinessResourceTemplates() {
+  if (!businessResourceTemplatesBody || !businessResourceTemplatesEmpty || !businessResourceTemplatesWrap) return;
+  if (businessResourceFilterProcedure) businessResourceFilterProcedure.value = state.businessResourceProcedureFilter || "all";
+  if (businessResourceFilterCategory) businessResourceFilterCategory.value = state.businessResourceCategoryFilter || "all";
+  if (businessResourceFilterActive) businessResourceFilterActive.value = state.businessResourceActiveFilter || "active";
+  if (businessResourceSearchInput && businessResourceSearchInput.value !== (state.businessResourceSearchQuery || "")) {
+    businessResourceSearchInput.value = state.businessResourceSearchQuery || "";
+  }
+
+  const filtered = getFilteredBusinessResourceTemplates();
+  businessResourceTemplatesBody.innerHTML = "";
+  filtered.forEach((entry) => {
+    const tr = document.createElement("tr");
+    tr.dataset.id = entry.id;
+    const isActive = getBusinessResourceActiveValue(entry);
+    const urlLinks = [
+      entry.url ? `<a href="${escapeHtml(entry.url)}" target="_blank" rel="noopener noreferrer">参照URL</a>` : "",
+      entry.file_url ? `<a href="${escapeHtml(entry.file_url)}" target="_blank" rel="noopener noreferrer">ファイルURL</a>` : "",
+    ].filter(Boolean).join(" / ");
+    tr.innerHTML = `
+      <td>${escapeHtml(getBusinessResourceProcedureLabel(entry.procedure_type))}</td>
+      <td>${escapeHtml(getBusinessResourceCategoryLabel(entry.resource_category))}</td>
+      <td>
+        <strong>${escapeHtml(entry.resource_name || "未設定")}</strong>
+        <div class="meta">${escapeHtml(truncateText(entry.description || "説明なし", 80))}</div>
+        ${urlLinks ? `<div class="meta">${urlLinks}</div>` : ""}
+      </td>
+      <td>${entry.required ? "必須" : "任意"}</td>
+      <td>${entry.customer_visible ? "表示可" : "非表示"}</td>
+      <td>${entry.last_checked_at ? formatDate(entry.last_checked_at) : "未設定"}</td>
+      <td>${escapeHtml(getBusinessResourceSourceLabel(entry))}</td>
+      <td>${isActive ? "有効" : "無効"}</td>
+      <td>${escapeHtml(truncateText(entry.memo || "", 80)) || "-"}</td>
+      <td>
+        <div class="row-actions">
+          <button type="button" class="secondary-btn" data-action="edit_business_resource_template" data-list-action="edit_business_resource_template" data-id="${escapeHtml(entry.id)}">編集</button>
+          <button type="button" class="${isActive ? "danger-btn" : "secondary-btn"}" data-action="${isActive ? "disable_business_resource_template" : "reactivate_business_resource_template"}" data-list-action="${isActive ? "disable_business_resource_template" : "reactivate_business_resource_template"}" data-id="${escapeHtml(entry.id)}">${isActive ? "無効化" : "有効化"}</button>
+        </div>
+      </td>
+    `;
+    businessResourceTemplatesBody.appendChild(tr);
+  });
+  businessResourceTemplatesEmpty.hidden = filtered.length > 0;
+  businessResourceTemplatesEmpty.textContent = state.businessResourceTemplates.length ? "条件に一致する業務資料はありません。" : "業務資料はまだありません。";
+  businessResourceTemplatesWrap.hidden = filtered.length === 0;
+}
+
 function renderDailyReports() {
   if (!dailyReportsBody || !dailyReportsEmpty || !dailyReportsListWrap || !dailyReportSummaryList) return;
   const sorted = state.dailyReports.slice().sort((a, b) => toSortTimestamp(b.reportDate) - toSortTimestamp(a.reportDate));
@@ -8657,6 +8937,20 @@ function resetWorkTemplateForm() {
   resetEditMode("workTemplate");
   workTemplateForm?.reset();
   if (workTemplateSubmitBtn) workTemplateSubmitBtn.textContent = "テンプレートを登録";
+}
+
+function resetBusinessResourceTemplateForm() {
+  editState.businessResourceTemplateId = null;
+  businessResourceTemplateForm?.reset();
+  if (businessResourceTemplateForm?.elements?.procedureType) {
+    businessResourceTemplateForm.elements.procedureType.value = CONSTRUCTION_PROCEDURE_TYPES[0].value;
+  }
+  if (businessResourceTemplateForm?.elements?.resourceCategory) {
+    businessResourceTemplateForm.elements.resourceCategory.value = BUSINESS_RESOURCE_CATEGORIES[0].value;
+  }
+  if (businessResourceTemplateForm?.elements?.sortOrder) businessResourceTemplateForm.elements.sortOrder.value = "0";
+  if (businessResourceTemplateForm?.elements?.isActive) businessResourceTemplateForm.elements.isActive.checked = true;
+  if (businessResourceSubmitBtn) businessResourceSubmitBtn.textContent = "業務資料を登録";
 }
 
 function resetSaleForm() {
@@ -11462,6 +11756,10 @@ function resetViewState() {
   state.expensesSearchQuery = "";
   state.dailyReportSearchQuery = "";
   state.dailyReportDateFilter = "all";
+  state.businessResourceProcedureFilter = "all";
+  state.businessResourceCategoryFilter = "all";
+  state.businessResourceActiveFilter = "active";
+  state.businessResourceSearchQuery = "";
   state.estimateCustomerQuery = "";
   state.estimateTitleQuery = "";
   state.estimateStatusFilter = "all";
@@ -11472,6 +11770,7 @@ function resetEditState() {
   editState.clientId = null;
   editState.caseId = null;
   editState.workTemplateId = null;
+  editState.businessResourceTemplateId = null;
   editState.saleId = null;
   editState.expenseId = null;
   editState.fixedExpenseId = null;
@@ -11507,6 +11806,7 @@ function clearAppState() {
   resetCaseTaskForm();
   resetCaseDocumentForm();
   resetWorkTemplateForm();
+  resetBusinessResourceTemplateForm();
   resetEstimateForm();
   resetSaleForm();
   resetExpenseForm();

--- a/index.html
+++ b/index.html
@@ -938,7 +938,11 @@
         </section>
 
         <section id="tab-work-templates" class="tab-panel">
-          <div class="layout two-col">
+          <nav class="subtabs" aria-label="業務テンプレートサブタブ">
+            <button type="button" class="subtab-btn active" data-parent-tab="work-templates" data-subtab="entry">業務テンプレート</button>
+            <button type="button" class="subtab-btn" data-parent-tab="work-templates" data-subtab="resource-library">業務資料ライブラリ</button>
+          </nav>
+          <div class="layout two-col subtab-panel active" data-parent-tab="work-templates" data-subtab="entry">
             <section class="panel">
               <h2>業務テンプレート登録</h2>
               <form id="work-template-form" class="form">
@@ -957,6 +961,117 @@
               <ul id="work-templates-list" class="item-list"></ul>
             </section>
           </div>
+
+          <section class="panel subtab-panel" data-parent-tab="work-templates" data-subtab="resource-library">
+            <div class="section-header">
+              <div>
+                <h2>業務資料ライブラリ</h2>
+                <p class="muted">建設業許可関連の「使う資料」「回収する資料」「提出する資料」を管理します。file_url はURL文字列のみ保存し、ファイルアップロードは行いません。</p>
+              </div>
+            </div>
+            <form id="business-resource-template-form" class="form business-resource-form">
+              <div class="date-grid">
+                <label>手続種別 <span class="required">必須</span>
+                  <select id="business-resource-procedure-type" name="procedureType" required>
+                    <option value="construction_license_new">建設業許可 新規</option>
+                    <option value="construction_license_renewal">建設業許可 更新</option>
+                    <option value="construction_license_add_business">業種追加</option>
+                    <option value="annual_closing_report">決算変更届</option>
+                    <option value="change_notification">変更届</option>
+                    <option value="keishin">経審</option>
+                    <option value="management_analysis">経営状況分析</option>
+                  </select>
+                </label>
+                <label>資料分類 <span class="required">必須</span>
+                  <select id="business-resource-category" name="resourceCategory" required>
+                    <option value="use">使う資料</option>
+                    <option value="collect">回収する資料</option>
+                    <option value="submit">提出する資料</option>
+                  </select>
+                </label>
+              </div>
+              <label>資料名 <span class="required">必須</span><input id="business-resource-name" name="resourceName" type="text" required maxlength="160" /></label>
+              <label>説明<textarea id="business-resource-description" name="description" rows="2" maxlength="4000"></textarea></label>
+              <div class="date-grid">
+                <label>参照URL<input id="business-resource-url" name="url" type="url" maxlength="2000" placeholder="https://..." /></label>
+                <label>ファイルURL<input id="business-resource-file-url" name="fileUrl" type="url" maxlength="2000" placeholder="https://..." /></label>
+              </div>
+              <div class="date-grid">
+                <label>最終確認日<input id="business-resource-last-checked-at" name="lastCheckedAt" type="date" /></label>
+                <label>情報元区分<input id="business-resource-source-type" name="sourceType" type="text" maxlength="80" placeholder="行政庁 / 社内 / 外部資料 など" /></label>
+              </div>
+              <label>情報元名<input id="business-resource-source-name" name="sourceName" type="text" maxlength="200" /></label>
+              <div class="date-grid">
+                <label>関連タスク種別<input id="business-resource-related-task-type" name="relatedTaskType" type="text" maxlength="120" /></label>
+                <label>関連見積項目<input id="business-resource-related-estimate-item" name="relatedEstimateItem" type="text" maxlength="160" /></label>
+              </div>
+              <div class="date-grid">
+                <label>関連経費項目<input id="business-resource-related-expense-item" name="relatedExpenseItem" type="text" maxlength="160" /></label>
+                <label>並び順<input id="business-resource-sort-order" name="sortOrder" type="number" inputmode="numeric" step="1" value="0" /></label>
+              </div>
+              <div class="inline-options">
+                <label><input id="business-resource-required" name="required" type="checkbox" /> 必須資料</label>
+                <label><input id="business-resource-customer-visible" name="customerVisible" type="checkbox" /> 顧客表示可</label>
+                <label><input id="business-resource-is-active" name="isActive" type="checkbox" checked /> 有効</label>
+              </div>
+              <label>メモ<textarea id="business-resource-memo" name="memo" rows="2" maxlength="2000"></textarea></label>
+              <div class="form-actions">
+                <button id="business-resource-submit-btn" type="submit">業務資料を登録</button>
+                <button id="business-resource-reset-btn" type="button" class="secondary-btn">入力をクリア</button>
+              </div>
+            </form>
+
+            <div class="filter-bar business-resource-filters">
+              <label>手続種別
+                <select id="business-resource-filter-procedure">
+                  <option value="all">すべて</option>
+                  <option value="construction_license_new">建設業許可 新規</option>
+                  <option value="construction_license_renewal">建設業許可 更新</option>
+                  <option value="construction_license_add_business">業種追加</option>
+                  <option value="annual_closing_report">決算変更届</option>
+                  <option value="change_notification">変更届</option>
+                  <option value="keishin">経審</option>
+                  <option value="management_analysis">経営状況分析</option>
+                </select>
+              </label>
+              <label>資料分類
+                <select id="business-resource-filter-category">
+                  <option value="all">すべて</option>
+                  <option value="use">使う資料</option>
+                  <option value="collect">回収する資料</option>
+                  <option value="submit">提出する資料</option>
+                </select>
+              </label>
+              <label>有効状態
+                <select id="business-resource-filter-active">
+                  <option value="active">有効のみ</option>
+                  <option value="all">すべて</option>
+                  <option value="inactive">無効のみ</option>
+                </select>
+              </label>
+              <label>キーワード検索<input id="business-resource-search" type="search" placeholder="資料名・説明・情報元・メモ" /></label>
+            </div>
+            <div id="business-resource-templates-empty" class="empty">業務資料はまだありません。</div>
+            <div id="business-resource-templates-wrap" class="table-wrap" hidden>
+              <table class="business-resource-table">
+                <thead>
+                  <tr>
+                    <th>手続種別</th>
+                    <th>資料分類</th>
+                    <th>資料名</th>
+                    <th>必須</th>
+                    <th>顧客表示</th>
+                    <th>最終確認日</th>
+                    <th>情報元</th>
+                    <th>状態</th>
+                    <th>メモ</th>
+                    <th>操作</th>
+                  </tr>
+                </thead>
+                <tbody id="business-resource-templates-body"></tbody>
+              </table>
+            </div>
+          </section>
         </section>
 
         <section id="tab-estimates" class="tab-panel">

--- a/styles.css
+++ b/styles.css
@@ -1200,3 +1200,47 @@ input[type="number"] {
 .card-select-btn { min-width: 2.2rem; font-weight: 700; }
 .item { position: relative; }
 .item > .row-actions { align-self: flex-start; }
+
+.business-resource-form {
+  margin-bottom: 1.5rem;
+}
+
+.inline-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem 1.25rem;
+  align-items: center;
+}
+
+.inline-options label {
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.4rem;
+  align-items: center;
+  font-weight: 600;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filter-bar,
+.business-resource-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+  margin: 1rem 0;
+}
+
+.business-resource-table th,
+.business-resource-table td {
+  vertical-align: top;
+}
+
+.business-resource-table .row-actions {
+  flex-wrap: nowrap;
+}


### PR DESCRIPTION
### Motivation
- Provide a management UI for `business_resource_templates` so construction-permit related materials (use/collect/submit) can be registered, edited, disabled and filtered without changing existing app flows. 

### Description
- Added a new "業務資料ライブラリ" subtab under the existing "業務テンプレート" tab and implemented a registration/edit form covering the specified columns (procedure_type, resource_category, resource_name, description, url, file_url, customer_visible, required, last_checked_at, source_type, source_name, memo, related_task_type, related_estimate_item, related_expense_item, sort_order, is_active). (files: `index.html`, `app.js`, `styles.css`)
- Implemented list rendering with Japanese labels, filtering (`procedure_type`, `resource_category`, `is_active`) and keyword search (resource_name, description, source_name, memo), sort order rules, URL links display, edit flow, and is_active-based disable/reactivate behavior while preferring logical disable over physical delete. (logic: `app.js` functions `fetchBusinessResourceTemplates`, `upsertBusinessResourceTemplate`, `handleBusinessResourceTemplateSubmit`, `renderBusinessResourceTemplates`, `setBusinessResourceTemplateActive`, etc.)
- Kept `file_url` as a URL string only (no upload implemented), ensured saved rows include `user_id`, and wired UI actions into existing `runMutation`/reload/render patterns so changes are reflected immediately.
- Preserved backup/restore configuration (no change to `BACKUP_TABLE_KEYS`, `RESTORE_INSERT_ORDER`, `RESTORE_DELETE_ORDER`, `RESTORE_MUTATION_COLUMNS`) and avoided adding any case-level automatic expansion (no caseDocuments/caseTasks generation or other 第1-C behaviors). 

### Testing
- Ran `node --check app.js` to validate JS syntax and it passed without errors. 
- Ran repository checks (`git diff --check`, targeted `rg` searches) and verified new UI hooks and `business_resource_templates` usage are present and consistent; these checks passed. 
- Performed static code review to confirm: list/register/edit/disable flows, `user_id` injection, `file_url` string-only handling, and no injection of 第1-C expansion logic; review found no issues. 
- Browser/Playwright UI automated checks were not available in this environment (Playwright/chrome not present), so runtime UI interactions (manual click-throughs) remain to be validated after deployment by QA or the user.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18e3f2f7388333aca2e5897b79ccaa)