### PR TITLE
業務資料ライブラリ：複数選択と一括操作（有効化/無効化/削除）を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,6 +125,7 @@ const state = {
   selectedExpenseIds: [],
   selectedDailyReportIds: [],
   selectedFixedExpenseIds: [],
+  selectedBusinessResourceTemplateIds: [],
 };
 const editState = { clientId: null, caseId: null, workTemplateId: null, businessResourceTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null, caseDocumentId: null };
 
@@ -181,6 +182,12 @@ const CLICK_ACTION_HANDLERS = {
   edit_business_resource_template: handleBusinessResourceTemplateListAction,
   disable_business_resource_template: handleBusinessResourceTemplateListAction,
   reactivate_business_resource_template: handleBusinessResourceTemplateListAction,
+  delete_business_resource_template: handleBusinessResourceTemplateListAction,
+  select_all_business_resource_templates: () => setAllBusinessResourceTemplateSelections(true),
+  clear_all_business_resource_templates: () => setAllBusinessResourceTemplateSelections(false),
+  bulk_activate_business_resource_templates: () => handleBulkBusinessResourceTemplateActiveUpdate(true),
+  bulk_deactivate_business_resource_templates: () => handleBulkBusinessResourceTemplateActiveUpdate(false),
+  bulk_delete_business_resource_templates: handleBulkDeleteBusinessResourceTemplates,
   edit_estimate: handleEstimateListAction,
   delete_estimate: handleEstimateListAction,
   create_case_from_estimate: handleEstimateListAction,
@@ -653,6 +660,12 @@ const businessResourceSearchInput = document.getElementById("business-resource-s
 const businessResourceTemplatesEmpty = document.getElementById("business-resource-templates-empty");
 const businessResourceTemplatesWrap = document.getElementById("business-resource-templates-wrap");
 const businessResourceTemplatesBody = document.getElementById("business-resource-templates-body");
+const businessResourceSelectionCount = document.getElementById("business-resource-selection-count");
+const businessResourceSelectAllBtn = document.getElementById("business-resource-select-all-btn");
+const businessResourceClearSelectionBtn = document.getElementById("business-resource-clear-selection-btn");
+const businessResourceBulkActivateBtn = document.getElementById("business-resource-bulk-activate-btn");
+const businessResourceBulkDeactivateBtn = document.getElementById("business-resource-bulk-deactivate-btn");
+const businessResourceBulkDeleteBtn = document.getElementById("business-resource-bulk-delete-btn");
 const expenseItemTemplate = document.getElementById("expense-item-template");
 const fixedExpenseItemTemplate = document.getElementById("fixed-expense-item-template");
 const estimateForm = document.getElementById("estimate-form");
@@ -821,6 +834,7 @@ function bindEvents() {
   businessResourceFilterCategory?.addEventListener("change", handleBusinessResourceFilterChange);
   businessResourceFilterActive?.addEventListener("change", handleBusinessResourceFilterChange);
   businessResourceSearchInput?.addEventListener("input", handleBusinessResourceFilterChange);
+  businessResourceTemplatesBody?.addEventListener("change", handleBusinessResourceTemplateSelectionChange);
   debugLog("SALE FORM FOUND", !!saleForm);
   debugLog("EXPENSE FORM FOUND", !!expenseForm);
   debugLog("DAILY REPORT FORM FOUND", !!dailyReportForm);
@@ -2434,7 +2448,7 @@ async function upsertBusinessResourceTemplate(template) {
   return runMutation("業務資料テンプレートの保存", mutation, { successMessage: "業務資料テンプレートを保存しました。" });
 }
 
-async function deleteBusinessResourceTemplate(id) {
+async function deleteBusinessResourceTemplate(id, options = {}) {
   if (!currentUser) {
     showAppMessage("ログイン状態を確認できません。", true);
     return null;
@@ -2443,7 +2457,26 @@ async function deleteBusinessResourceTemplate(id) {
     showAppMessage("業務資料テンプレートの削除対象IDを取得できませんでした。", true);
     return null;
   }
-  return setBusinessResourceTemplateActive(id, false);
+  if (!options.skipConfirm && !window.confirm("この資料を完全に削除します。この操作は元に戻せません。実行しますか？")) return null;
+  return runMutation("業務資料テンプレートの削除", async () => {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", currentUser.id)
+      .select("id")
+      .single();
+    if (error) throw error;
+    return data;
+  }, {
+    successMessage: "業務資料テンプレートを削除しました。",
+    afterSuccess: () => {
+      state.selectedBusinessResourceTemplateIds = getSelectedIdsByKey("selectedBusinessResourceTemplateIds").filter((selectedId) => selectedId !== String(id));
+      if (String(editState.businessResourceTemplateId) === String(id)) resetBusinessResourceTemplateForm();
+      subtabState["work-templates"] = "resource-library";
+      renderBusinessResourceTemplates();
+    },
+  });
 }
 
 async function loadPermitHearings() {
@@ -3022,7 +3055,90 @@ function handleBusinessResourceFilterChange() {
   state.businessResourceCategoryFilter = businessResourceFilterCategory?.value || "all";
   state.businessResourceActiveFilter = businessResourceFilterActive?.value || "active";
   state.businessResourceSearchQuery = asTrimmedText(businessResourceSearchInput?.value).toLowerCase();
+  state.selectedBusinessResourceTemplateIds = [];
   renderBusinessResourceTemplates();
+}
+
+function getVisibleBusinessResourceTemplateIds() {
+  return getFilteredBusinessResourceTemplates().map((entry) => String(entry.id)).filter(Boolean);
+}
+
+function getSelectedVisibleBusinessResourceTemplateIds() {
+  const visibleIds = new Set(getVisibleBusinessResourceTemplateIds());
+  return getSelectedIdsByKey("selectedBusinessResourceTemplateIds").filter((id) => visibleIds.has(String(id)));
+}
+
+function setAllBusinessResourceTemplateSelections(checked) {
+  state.selectedBusinessResourceTemplateIds = checked ? getVisibleBusinessResourceTemplateIds() : [];
+  renderBusinessResourceTemplates();
+}
+
+function handleBusinessResourceTemplateSelectionChange(event) {
+  const checkbox = event.target;
+  if (!(checkbox instanceof HTMLInputElement) || checkbox.type !== "checkbox" || checkbox.dataset.action !== "select_business_resource_template") return;
+  const id = checkbox.dataset.id;
+  if (!id) return;
+  const selected = new Set(getSelectedIdsByKey("selectedBusinessResourceTemplateIds"));
+  if (checkbox.checked) selected.add(String(id)); else selected.delete(String(id));
+  state.selectedBusinessResourceTemplateIds = Array.from(selected);
+  renderBusinessResourceTemplates();
+}
+
+async function handleBulkBusinessResourceTemplateActiveUpdate(isActive) {
+  if (!currentUser) return;
+  const ids = getSelectedVisibleBusinessResourceTemplateIds();
+  if (!ids.length) {
+    showAppMessage("対象の業務資料を選択してください。", true);
+    renderBusinessResourceTemplates();
+    return;
+  }
+  await runMutation(isActive ? "業務資料一括有効化" : "業務資料一括無効化", async () => {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .update({ is_active: Boolean(isActive), user_id: currentUser.id })
+      .in("id", ids)
+      .eq("user_id", currentUser.id)
+      .select("id,is_active");
+    if (error) throw error;
+    return data;
+  }, {
+    successMessage: isActive ? "選択した業務資料を有効化しました。" : "選択した業務資料を無効化しました。",
+    afterSuccess: () => {
+      if (ids.some((id) => String(editState.businessResourceTemplateId) === String(id))) resetBusinessResourceTemplateForm();
+      state.selectedBusinessResourceTemplateIds = [];
+      subtabState["work-templates"] = "resource-library";
+      renderBusinessResourceTemplates();
+    },
+  });
+}
+
+async function handleBulkDeleteBusinessResourceTemplates() {
+  if (!currentUser) return;
+  const ids = getSelectedVisibleBusinessResourceTemplateIds();
+  if (!ids.length) {
+    showAppMessage("削除する業務資料を選択してください。", true);
+    renderBusinessResourceTemplates();
+    return;
+  }
+  if (!window.confirm("選択した資料を完全に削除します。この操作は元に戻せません。実行しますか？")) return;
+  await runMutation("業務資料一括削除", async () => {
+    const { data, error } = await sbClient
+      .from("business_resource_templates")
+      .delete()
+      .in("id", ids)
+      .eq("user_id", currentUser.id)
+      .select("id");
+    if (error) throw error;
+    return data;
+  }, {
+    successMessage: "選択した業務資料を削除しました。",
+    afterSuccess: () => {
+      if (ids.some((id) => String(editState.businessResourceTemplateId) === String(id))) resetBusinessResourceTemplateForm();
+      state.selectedBusinessResourceTemplateIds = [];
+      subtabState["work-templates"] = "resource-library";
+      renderBusinessResourceTemplates();
+    },
+  });
 }
 
 async function createCaseTasksFromTemplate(caseRow, templateId) {
@@ -3705,6 +3821,10 @@ async function handleBusinessResourceTemplateListAction(event) {
   }
   if (listAction === "reactivate_business_resource_template") {
     await setBusinessResourceTemplateActive(id, true);
+    return;
+  }
+  if (listAction === "delete_business_resource_template") {
+    await deleteBusinessResourceTemplate(id);
   }
 }
 
@@ -7655,16 +7775,28 @@ function renderBusinessResourceTemplates() {
   }
 
   const filtered = getFilteredBusinessResourceTemplates();
+  const filteredIds = new Set(filtered.map((entry) => String(entry.id)));
+  state.selectedBusinessResourceTemplateIds = getSelectedIdsByKey("selectedBusinessResourceTemplateIds").filter((id) => filteredIds.has(String(id)));
+  const selectedIds = new Set(state.selectedBusinessResourceTemplateIds);
+  const selectedCount = selectedIds.size;
+  if (businessResourceSelectionCount) businessResourceSelectionCount.textContent = `${selectedCount}件選択中`;
+  if (businessResourceSelectAllBtn) businessResourceSelectAllBtn.disabled = filtered.length === 0;
+  if (businessResourceClearSelectionBtn) businessResourceClearSelectionBtn.disabled = selectedCount === 0;
+  if (businessResourceBulkActivateBtn) businessResourceBulkActivateBtn.disabled = selectedCount === 0;
+  if (businessResourceBulkDeactivateBtn) businessResourceBulkDeactivateBtn.disabled = selectedCount === 0;
+  if (businessResourceBulkDeleteBtn) businessResourceBulkDeleteBtn.disabled = selectedCount === 0;
   businessResourceTemplatesBody.innerHTML = "";
   filtered.forEach((entry) => {
     const tr = document.createElement("tr");
     tr.dataset.id = entry.id;
     const isActive = getBusinessResourceActiveValue(entry);
+    const isSelected = selectedIds.has(String(entry.id));
     const urlLinks = [
       entry.url ? `<a href="${escapeHtml(entry.url)}" target="_blank" rel="noopener noreferrer">参照URL</a>` : "",
       entry.file_url ? `<a href="${escapeHtml(entry.file_url)}" target="_blank" rel="noopener noreferrer">ファイルURL</a>` : "",
     ].filter(Boolean).join(" / ");
     tr.innerHTML = `
+      <td class="selection-cell"><input type="checkbox" aria-label="${escapeHtml(entry.resource_name || "業務資料")}を選択" data-action="select_business_resource_template" data-id="${escapeHtml(entry.id)}" ${isSelected ? "checked" : ""} /></td>
       <td>${escapeHtml(getBusinessResourceProcedureLabel(entry.procedure_type))}</td>
       <td>${escapeHtml(getBusinessResourceCategoryLabel(entry.resource_category))}</td>
       <td>
@@ -7682,6 +7814,7 @@ function renderBusinessResourceTemplates() {
         <div class="row-actions">
           <button type="button" class="secondary-btn" data-action="edit_business_resource_template" data-list-action="edit_business_resource_template" data-id="${escapeHtml(entry.id)}">編集</button>
           <button type="button" class="${isActive ? "danger-btn" : "secondary-btn"}" data-action="${isActive ? "disable_business_resource_template" : "reactivate_business_resource_template"}" data-list-action="${isActive ? "disable_business_resource_template" : "reactivate_business_resource_template"}" data-id="${escapeHtml(entry.id)}">${isActive ? "無効化" : "有効化"}</button>
+          <button type="button" class="danger-btn" data-action="delete_business_resource_template" data-list-action="delete_business_resource_template" data-id="${escapeHtml(entry.id)}">削除</button>
         </div>
       </td>
     `;

--- a/index.html
+++ b/index.html
@@ -1051,11 +1051,20 @@
               </label>
               <label>キーワード検索<input id="business-resource-search" type="search" placeholder="資料名・説明・情報元・メモ" /></label>
             </div>
+            <div class="bulk-actions business-resource-bulk-actions" aria-label="業務資料ライブラリ一括操作">
+              <button id="business-resource-select-all-btn" type="button" class="secondary-btn" data-action="select_all_business_resource_templates">全選択</button>
+              <button id="business-resource-clear-selection-btn" type="button" class="secondary-btn" data-action="clear_all_business_resource_templates" disabled>全解除</button>
+              <span id="business-resource-selection-count" class="bulk-selection-count">0件選択中</span>
+              <button id="business-resource-bulk-activate-btn" type="button" class="secondary-btn" data-action="bulk_activate_business_resource_templates" disabled>選択を有効化</button>
+              <button id="business-resource-bulk-deactivate-btn" type="button" class="secondary-btn" data-action="bulk_deactivate_business_resource_templates" disabled>選択を無効化</button>
+              <button id="business-resource-bulk-delete-btn" type="button" class="danger-btn" data-action="bulk_delete_business_resource_templates" disabled>選択を削除</button>
+            </div>
             <div id="business-resource-templates-empty" class="empty">業務資料はまだありません。</div>
             <div id="business-resource-templates-wrap" class="table-wrap" hidden>
               <table class="business-resource-table">
                 <thead>
                   <tr>
+                    <th>選択</th>
                     <th>手続種別</th>
                     <th>資料分類</th>
                     <th>資料名</th>

--- a/styles.css
+++ b/styles.css
@@ -1244,3 +1244,33 @@ input[type="number"] {
 .business-resource-table .row-actions {
   flex-wrap: nowrap;
 }
+
+.bulk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0.75rem 0;
+}
+
+.bulk-selection-count {
+  font-weight: 700;
+  color: var(--text);
+  margin-right: 0.25rem;
+}
+
+.business-resource-table .selection-cell {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.business-resource-table .selection-cell input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}


### PR DESCRIPTION
### Motivation
- 業務資料ライブラリの一覧操作性を改善し、複数選択と一括操作（有効化／無効化／削除）を可能にして実務での管理を効率化するため。\n- 表示中の行のみを対象にすることで誤操作を防ぎ、第1-C へ進む前の安全な基盤を作るため。\n
### Description
- UI 追加・変更: `index.html` に一括操作エリア（全選択/全解除/選択件数/選択有効化/選択無効化/選択削除）と一覧ヘッダの「選択」列を追加し、行にチェックボックスと行単位削除ボタンを追加しました。\n- ロジック追加: `app.js` に選択状態管理用の `state.selectedBusinessResourceTemplateIds` を追加し、`handleBusinessResourceTemplateSelectionChange`、`setAllBusinessResourceTemplateSelections`、`getVisibleBusinessResourceTemplateIds`、`getSelectedVisibleBusinessResourceTemplateIds`、`handleBulkBusinessResourceTemplateActiveUpdate`、`handleBulkDeleteBusinessResourceTemplates` を実装しました。\n- DB 操作と安全性: 一括有効化/無効化は `sbClient.from('business_resource_templates').update(...).in('id', ids).eq('user_id', currentUser.id)`、一括削除は `delete().in('id', ids).eq('user_id', currentUser.id)`、行単位削除は確認ダイアログ後に物理削除を行う `deleteBusinessResourceTemplate` を追加し、`user_id` 条件（RLS 前提）を保持しています。\n- 表示整合性: フィルタ変更時に選択状態をクリアし、レンダリング時は「現在表示中の行」のみを選択対象に絞り、選択件数表示と一括操作ボタンの `disabled` を同期する実装にしました。\n- スタイル追加: `styles.css` に一括操作領域と選択用チェックボックスのスタイル、および `button:disabled` の見た目を追加しました。\n- 変更ファイル: `app.js`, `index.html`, `styles.css`。\n
### Testing
- `node --check app.js` を実行して構文チェックを行い正常終了しました。\n- `git diff --check` およびリポジトリ内の `rg` によるパターン検索で一括処理・削除処理・`selectedBusinessResourceTemplateIds`・`disabled` 制御・対象テーブルが正しく追加されていることを確認しました。\n- 自動ブラウザ／E2E（Playwright 等）は環境に存在しなかったため未実行で、実画面での視覚確認はユーザー側でのマージ後確認を推奨します（確認手順は UI の短いチェックリストに従ってください）。\n- すべての自動チェックは成功していますが、実ブラウザでの動作確認（チェックボックスの操作、確認ダイアログ、一覧の即時反映、フィルタ変更時の選択クリア等）は必須です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ec5a66d08333b624c538e9347a48)