### PR TITLE
Group built-in Boki2 original questions by trial section

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/originalQuestionGroupBridge.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/components/originalQuestionGroupBridge.ts
@@ -1,0 +1,361 @@
+import type { CpaTrialSectionRef, QuestionItem, ReviewSchedule, AnswerAttempt } from '../originalStudyTypes';
+
+const DB_NAME = 'nissho-boki2-original-study-app';
+const DB_VERSION = 2;
+const BRIDGE_ID = 'boki2-original-question-group-selector';
+const STYLE_ID = 'boki2-original-question-group-selector-style';
+const OPEN_GROUP_KEY = 'boki2-original-question-open-group-ref';
+const SESSION_KEY = 'boki2-original-question-continuous-session';
+
+type BridgeWindow = Window & { __boki2OriginalQuestionGroups?: QuestionItem[]; __boki2OriginalQuestionGroupBridgeInstalled?: boolean };
+type StoredAttempt = Pick<AnswerAttempt, 'studyMode' | 'questionId'>;
+type StoredReview = Pick<ReviewSchedule, 'studyMode' | 'questionId' | 'nextReviewDate' | 'latestRank' | 'isWeak'>;
+type QuestionStatus = '未学習' | '学習済み' | '復習対象';
+type GroupStats = Record<string, { studied: number; due: number; statuses: Record<string, QuestionStatus> }>;
+type ContinuousSession = { groupRef: string; questionIds: string[]; currentIndex: number };
+
+type QuestionGroup = {
+  ref: CpaTrialSectionRef;
+  label: string;
+  subject: string;
+  section: string;
+  topic: string;
+  questions: QuestionItem[];
+};
+
+function sectionNumber(ref: string): string {
+  const match = ref.match(/_(\d+)_(\d+)$/);
+  return match ? `${match[1]}-${match[2]}` : ref;
+}
+
+function groupLabel(question: QuestionItem): string {
+  return `${sectionNumber(question.cpaTrialSectionRef)} ${question.topic}`;
+}
+
+function groupQuestions(questions: QuestionItem[]): QuestionGroup[] {
+  const map = new Map<CpaTrialSectionRef, QuestionGroup>();
+  questions
+    .filter((question) => question.verificationStatus === 'approved')
+    .forEach((question) => {
+      const ref = question.cpaTrialSectionRef;
+      const current = map.get(ref);
+      if (current) {
+        current.questions.push(question);
+        return;
+      }
+      map.set(ref, {
+        ref,
+        label: groupLabel(question),
+        subject: question.subject,
+        section: question.section,
+        topic: question.topic,
+        questions: [question],
+      });
+    });
+  return Array.from(map.values()).sort((a, b) => sectionNumber(a.ref).localeCompare(sectionNumber(b.ref), 'ja', { numeric: true }));
+}
+
+function todayString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function readSession(): ContinuousSession | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ContinuousSession;
+    if (!parsed || !Array.isArray(parsed.questionIds) || !parsed.questionIds.length) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSession(session: ContinuousSession | null): void {
+  if (!session) {
+    sessionStorage.removeItem(SESSION_KEY);
+    return;
+  }
+  sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getAllFromStore<T>(storeName: string): Promise<T[]> {
+  if (!('indexedDB' in window)) return [];
+  try {
+    const db = await openDb();
+    if (!db.objectStoreNames.contains(storeName)) {
+      db.close();
+      return [];
+    }
+    return await new Promise<T[]>((resolve, reject) => {
+      const tx = db.transaction(storeName, 'readonly');
+      const request = tx.objectStore(storeName).getAll();
+      request.onsuccess = () => resolve((request.result ?? []) as T[]);
+      request.onerror = () => reject(request.error);
+      tx.oncomplete = () => db.close();
+      tx.onerror = () => { db.close(); reject(tx.error); };
+    });
+  } catch (error) {
+    console.warn('original question group bridge storage read skipped', error);
+    return [];
+  }
+}
+
+async function loadStats(groups: QuestionGroup[]): Promise<GroupStats> {
+  const [attempts, reviews] = await Promise.all([
+    getAllFromStore<StoredAttempt>('answerAttempts'),
+    getAllFromStore<StoredReview>('reviewSchedules'),
+  ]);
+  const today = todayString();
+  const attemptsByQuestion = new Set(attempts.filter((attempt) => attempt.studyMode === 'built_in_question').map((attempt) => attempt.questionId));
+  const reviewsByQuestion = new Map(reviews.filter((review) => review.studyMode === 'built_in_question').map((review) => [review.questionId, review]));
+  const stats: GroupStats = {};
+  groups.forEach((group) => {
+    const statuses: Record<string, QuestionStatus> = {};
+    let studied = 0;
+    let due = 0;
+    group.questions.forEach((question) => {
+      const review = reviewsByQuestion.get(question.id);
+      const isDue = Boolean(review && (review.isWeak || review.nextReviewDate <= today || review.latestRank === 'B' || review.latestRank === 'C'));
+      if (isDue) {
+        statuses[question.id] = '復習対象';
+        due += 1;
+        studied += 1;
+      } else if (attemptsByQuestion.has(question.id)) {
+        statuses[question.id] = '学習済み';
+        studied += 1;
+      } else {
+        statuses[question.id] = '未学習';
+      }
+    });
+    stats[group.ref] = { studied, due, statuses };
+  });
+  return stats;
+}
+
+function findBuiltInSelect(): HTMLSelectElement | null {
+  const selects = Array.from(document.querySelectorAll<HTMLSelectElement>('section.answer-summary-card select'));
+  return selects.find((select) => select.closest('label')?.textContent?.includes('approved オリジナル短問')) ?? null;
+}
+
+function setNativeSelectValue(select: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+  if (setter) setter.call(select, value);
+  else select.value = value;
+  select.dispatchEvent(new Event('input', { bubbles: true }));
+  select.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function selectQuestionById(id: string): void {
+  const select = findBuiltInSelect();
+  if (!select) return;
+  setNativeSelectValue(select, id);
+  const solveButton = Array.from(document.querySelectorAll<HTMLButtonElement>('.mode-nav button')).find((button) => button.textContent?.trim() === '今すぐ解く');
+  solveButton?.click();
+}
+
+function questionRank(status: QuestionStatus): number {
+  if (status === '未学習') return 0;
+  if (status === '復習対象') return 1;
+  return 2;
+}
+
+function startContinuous(group: QuestionGroup, stats: GroupStats): void {
+  const statuses = stats[group.ref]?.statuses ?? {};
+  const ordered = [...group.questions].sort((a, b) => questionRank(statuses[a.id] ?? '未学習') - questionRank(statuses[b.id] ?? '未学習'));
+  const questionIds = ordered.map((question) => question.id);
+  writeSession({ groupRef: group.ref, questionIds, currentIndex: 0 });
+  sessionStorage.setItem(OPEN_GROUP_KEY, group.ref);
+  selectQuestionById(questionIds[0]);
+}
+
+function advanceContinuousAfterSave(): void {
+  const session = readSession();
+  if (!session) return;
+  const nextIndex = session.currentIndex + 1;
+  if (nextIndex >= session.questionIds.length) {
+    writeSession(null);
+    return;
+  }
+  const nextSession = { ...session, currentIndex: nextIndex };
+  writeSession(nextSession);
+  setTimeout(() => selectQuestionById(nextSession.questionIds[nextIndex]), 150);
+}
+
+function injectStyle(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .original-question-group-selector { display: grid; gap: 12px; }
+    .original-question-group-card { border: 1px solid #d8dee9; border-radius: 14px; padding: 14px; background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,.04); }
+    .original-question-group-card.is-current { border-color: #2563eb; box-shadow: 0 0 0 2px rgba(37,99,235,.12); }
+    .original-question-group-header { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; flex-wrap: wrap; }
+    .original-question-group-title { display: grid; gap: 4px; }
+    .original-question-group-title button { border: 0; background: transparent; padding: 0; text-align: left; font: inherit; cursor: pointer; color: #111827; }
+    .original-question-group-title strong { font-size: 1.05rem; }
+    .original-question-group-title span, .original-question-card-meta { color: #64748b; font-size: .9rem; }
+    .original-question-group-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .original-question-list { display: grid; gap: 8px; margin-top: 12px; padding-top: 12px; border-top: 1px solid #e5e7eb; }
+    .original-question-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; align-items: center; border: 1px solid #edf2f7; border-radius: 10px; padding: 10px; background: #f8fafc; }
+    .original-question-row-title { display: grid; gap: 3px; }
+    .original-question-status { display: inline-flex; align-items: center; width: fit-content; border-radius: 999px; background: #e0f2fe; color: #0369a1; padding: 2px 8px; font-size: .8rem; }
+    .original-question-continuous-banner { display: flex; justify-content: space-between; align-items: center; gap: 10px; border-radius: 12px; padding: 10px 12px; background: #fff7ed; border: 1px solid #fed7aa; }
+    .original-question-group-selector button { cursor: pointer; }
+    @media (max-width: 720px) { .original-question-row { grid-template-columns: 1fr; } .original-question-group-header { display: grid; } }
+  `;
+  document.head.appendChild(style);
+}
+
+function renderGroupSelector(root: HTMLElement, select: HTMLSelectElement, groups: QuestionGroup[], stats: GroupStats): void {
+  const currentId = select.value;
+  const currentGroup = groups.find((group) => group.questions.some((question) => question.id === currentId));
+  const openRef = sessionStorage.getItem(OPEN_GROUP_KEY) as CpaTrialSectionRef | null;
+  const session = readSession();
+  const sessionGroup = session ? groups.find((group) => group.ref === session.groupRef) : null;
+  const sessionIndex = session && session.questionIds.includes(currentId) ? session.questionIds.indexOf(currentId) : session?.currentIndex ?? -1;
+
+  root.innerHTML = `
+    <section class="panel original-question-group-selector" aria-label="教材なしモードの論点グループ選択">
+      <div>
+        <p class="eyebrow">教材なしモード</p>
+        <h2>論点グループから選ぶ</h2>
+        <p class="readable-question-text">問題数が増えても選びやすいよう、1問ずつではなく論点グループ単位で表示しています。</p>
+      </div>
+      ${session && sessionGroup ? `<div class="original-question-continuous-banner"><strong>${sessionGroup.label}　${Math.max(1, sessionIndex + 1)} / ${session.questionIds.length}問目</strong><button type="button" data-end-continuous="true">連続演習を終了</button></div>` : ''}
+      ${groups.map((group) => {
+        const groupStats = stats[group.ref] ?? { studied: 0, due: 0, statuses: {} };
+        const isOpen = openRef === group.ref;
+        const isCurrent = currentGroup?.ref === group.ref;
+        const unstudied = Math.max(0, group.questions.length - groupStats.studied);
+        return `<article class="original-question-group-card ${isCurrent ? 'is-current' : ''}" data-group-ref="${group.ref}">
+          <div class="original-question-group-header">
+            <div class="original-question-group-title">
+              <button type="button" data-toggle-group="${group.ref}"><strong>${group.label}</strong></button>
+              <span>${group.subject} / ${group.section}</span>
+              <span>問題数：${group.questions.length}問 / 学習済み：${groupStats.studied}問 / 未学習：${unstudied}問 / 復習対象：${groupStats.due}問</span>
+            </div>
+            <div class="original-question-group-actions">
+              <button type="button" data-open-list="${group.ref}">1問ずつ選んで解く</button>
+              <button type="button" data-start-continuous="${group.ref}">連続で解く</button>
+            </div>
+          </div>
+          ${isOpen ? `<div class="original-question-list">
+            ${group.questions.map((question) => {
+              const status = groupStats.statuses[question.id] ?? '未学習';
+              return `<div class="original-question-row">
+                <div class="original-question-row-title">
+                  <strong>${question.title}</strong>
+                  <span class="original-question-card-meta">${question.difficulty ?? '標準'} / ${question.maxScore}点 / ${question.estimatedMinutes ?? '-'}分</span>
+                  <span class="original-question-status">${status}</span>
+                </div>
+                <button type="button" data-select-question="${question.id}">解く</button>
+              </div>`;
+            }).join('')}
+          </div>` : ''}
+        </article>`;
+      }).join('')}
+    </section>
+  `;
+
+  root.querySelectorAll<HTMLButtonElement>('[data-toggle-group], [data-open-list]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const ref = button.dataset.toggleGroup || button.dataset.openList;
+      if (!ref) return;
+      sessionStorage.setItem(OPEN_GROUP_KEY, ref);
+      scheduleRender();
+    });
+  });
+  root.querySelectorAll<HTMLButtonElement>('[data-select-question]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const id = button.dataset.selectQuestion;
+      if (!id) return;
+      writeSession(null);
+      selectQuestionById(id);
+      scheduleRender();
+    });
+  });
+  root.querySelectorAll<HTMLButtonElement>('[data-start-continuous]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const ref = button.dataset.startContinuous as CpaTrialSectionRef | undefined;
+      const group = groups.find((candidate) => candidate.ref === ref);
+      if (!group) return;
+      startContinuous(group, stats);
+      scheduleRender();
+    });
+  });
+  root.querySelector<HTMLButtonElement>('[data-end-continuous]')?.addEventListener('click', () => {
+    writeSession(null);
+    scheduleRender();
+  });
+}
+
+let renderScheduled = false;
+function scheduleRender(): void {
+  if (renderScheduled) return;
+  renderScheduled = true;
+  requestAnimationFrame(() => {
+    renderScheduled = false;
+    void renderBridge();
+  });
+}
+
+async function renderBridge(): Promise<void> {
+  const win = window as BridgeWindow;
+  const questions = win.__boki2OriginalQuestionGroups ?? [];
+  if (!questions.length) return;
+  const select = findBuiltInSelect();
+  const sourcePanel = select?.closest<HTMLElement>('section.answer-summary-card');
+  if (!select || !sourcePanel) {
+    document.getElementById(BRIDGE_ID)?.remove();
+    return;
+  }
+  sourcePanel.style.display = 'none';
+  let root = document.getElementById(BRIDGE_ID);
+  if (!root) {
+    root = document.createElement('div');
+    root.id = BRIDGE_ID;
+    sourcePanel.insertAdjacentElement('afterend', root);
+  }
+  const groups = groupQuestions(questions);
+  const stats = await loadStats(groups);
+  renderGroupSelector(root, select, groups, stats);
+}
+
+function handleSaveClick(event: MouseEvent): void {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const button = target.closest('button');
+  if (!button || button.textContent?.trim() !== '保存して次へ') return;
+  const session = readSession();
+  if (!session) return;
+  setTimeout(() => advanceContinuousAfterSave(), 300);
+}
+
+export function installOriginalQuestionGroupSelectorBridge(questions: QuestionItem[]): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  const win = window as BridgeWindow;
+  win.__boki2OriginalQuestionGroups = questions;
+  injectStyle();
+  if (win.__boki2OriginalQuestionGroupBridgeInstalled) {
+    scheduleRender();
+    return;
+  }
+  win.__boki2OriginalQuestionGroupBridgeInstalled = true;
+  const observer = new MutationObserver((mutations) => {
+    const root = document.getElementById(BRIDGE_ID);
+    if (root && mutations.every((mutation) => root.contains(mutation.target as Node))) return;
+    scheduleRender();
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+  document.addEventListener('click', handleSaveClick, true);
+  scheduleRender();
+}

--- a/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts
@@ -1,6 +1,7 @@
 import { cpaTrialSections, findTrialSection } from './cpaTrialSections';
 import type { AnswerLine, CpaTrialSectionRef, QuestionItem, VerificationStatus } from '../originalStudyTypes';
 import { installVisualAidBridge } from '../components/visualAidBridge';
+import { installOriginalQuestionGroupSelectorBridge } from '../components/originalQuestionGroupBridge';
 
 installVisualAidBridge();
 
@@ -109,3 +110,5 @@ const draftQuestions: QuestionItem[] = cpaTrialSections.filter((section) => !app
 export const originalQuestions: QuestionItem[] = [...approvedQuestions, ...draftQuestions];
 export const approvedOriginalQuestions: QuestionItem[] = originalQuestions.filter((question) => question.verificationStatus === 'approved');
 export const draftOriginalQuestions: QuestionItem[] = originalQuestions.filter((question) => question.verificationStatus === 'draft');
+
+installOriginalQuestionGroupSelectorBridge(approvedOriginalQuestions);


### PR DESCRIPTION
## 今回の目的

教材なしモードのオリジナル問題が増えても選びやすいよう、問題選択UIを1問ずつの直列表示から、論点グループ単位の表示へ整理します。

今回のPRは問題選択UIの整理だけです。新規問題の追加、採点ロジック変更、勘定連絡図エディタ変更、削除UX改善は行っていません。

## 実装内容

- 教材なしモードの approved オリジナル短問を `cpaTrialSectionRef` 単位でグループ化
- 初期表示では論点グループのみ表示
- 各グループに問題数、学習済み数、未学習数、復習対象数を表示
- 「1問ずつ選んで解く」でグループ内の問題一覧を展開
- 問題一覧では内部IDではなく日本語タイトルを表示
- 各問題の「解く」ボタンで対象問題を開く
- 「連続で解く」でグループ内問題を順番に解く簡易連続演習を追加
- 連続演習中に `x / n問目` と「連続演習を終了」を表示
- 既存の select はDOM上に残しつつ非表示にし、既存React状態・採点・保存処理を壊さない形で選択UIだけ差し替え

## グルーピング仕様

優先キー：`cpaTrialSectionRef`

例：

- `industrial_4_1` → `4-1 工業簿記 仕訳問題`
- `industrial_4_2` → `4-2 工程別総合原価計算`
- `commercial_1_1` → `1-1 商品、収益認識、現金預金`

これにより、既存の `短問-4-1` と追加済みの `短問-industrial_4_1-*` は同じ `4-1 工業簿記 仕訳問題` グループ内にまとまります。

## 1問ずつ選んで解く

- グループ内の問題一覧を展開
- 各問題を日本語タイトルで表示
- 難易度、満点、想定時間、学習状態を表示
- 「解く」でその問題だけを開く

## 連続で解く

- グループ内の問題を順番に解くモードを追加
- 未学習 → 復習対象 → 学習済みの順に優先
- 採点画面の「保存して次へ」後、次の問題へ進む補助処理を追加
- 連続演習中は進捗表示と「連続演習を終了」を表示

## 内部IDをユーザー表示しない対応

問題一覧では以下のような内部IDを出さず、日本語タイトルを表示します。

- `短問-industrial_4_1-material-consumption` → `材料費の消費`
- `短問-industrial_4_1-labor-consumption` → `賃金の消費`
- `短問-industrial_4_1-factory-overhead-cash` → `工場経費の支払い`
- `短問-industrial_4_1-overhead-applied` → `製造間接費の予定配賦`
- `短問-industrial_4_2-process-transfer` → `工程別総合原価計算の工程間振替`

## 今回新規問題は追加していません

問題文、模範解答、解説、modelAnswer は変更していません。

## 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/src/components/originalQuestionGroupBridge.ts`
- `cpa-boki2-trial-section-answer-manager/src/data/originalQuestions.ts`

## 変更していないもの

- 勘定連絡図エディタ
- React Flow関連
- 削除UX改善
- 自動採点ロジック
- side_multiset採点ロジック
- IME入力処理
- 金額入力処理
- 一時保存ロジックの大幅変更
- もう一度解く
- 既存案件管理アプリ本体
- GitHub PagesトップURL
- ルート index.html / app.js / styles.css

## 既存機能への影響

- 自動採点への影響：ロジック変更なし
- side_multiset採点への影響：ロジック変更なし
- 一時保存への影響：保存処理変更なし
- 勘定連絡図エディタへの影響：変更なし
- 日本語IME入力への影響：変更なし
- 金額入力への影響：変更なし

## npm run build 結果

未確認。GitHub Actionsで確認します。

## GitHub Actions 結果

未確認。PR作成後に確認します。

## Console確認結果

未確認。実URLでの手動確認が必要です。

## 未確認事項

- 実URLでのグループ表示確認
- 4-1グループ内に既存問題と追加問題がまとまること
- 4-2グループ内に工程間振替問題が入ること
- 1問ずつ選んで解く導線
- 連続で解く導線
- 採点後に次の問題へ進む挙動
- 勘定連絡図エディタの実画面確認
- Console赤エラー有無

## 実URLで確認すべき項目

1. 教材なしモードを開く
2. 初期表示で論点グループだけが表示されることを確認
3. 4-1 工業簿記 仕訳問題グループを確認
4. 4-1グループ内に既存問題と追加問題が入っていることを確認
5. 「1問ずつ選んで解く」を押す
6. 材料費の消費、賃金の消費、工場経費の支払い、製造間接費の予定配賦が表示されることを確認
7. 各問題が内部IDではなく日本語タイトルで表示されることを確認
8. 任意の問題の「解く」を押して問題を開く
9. 模範解答どおり入力し、自動採点できることを確認
10. 4-1グループへ戻る
11. 「連続で解く」を押す
12. 1問目から順番に解けることを確認
13. 採点後、次の問題へ進めることを確認
14. 連続演習を終了できることを確認
15. 4-2 工程別総合原価計算グループを開く
16. 工程間振替問題が表示されることを確認
17. 勘定連絡図エディタが引き続き使えることを確認
18. 一時保存、もう一度解く、日本語IME入力が壊れていないことを確認
19. Consoleに赤エラーが出ていないことを確認

## マージについて

ユーザー確認前にはマージしません。