### PR TITLE
Improve case list card readability (construction module 1‑C)

### DIFF
--- a/app.js
+++ b/app.js
@@ -8753,6 +8753,58 @@ function getCaseDocumentStats(caseId) {
   return { total, received, unreceived, defective };
 }
 
+function getCaseTaskStats(caseRow) {
+  const caseTasks = (Array.isArray(state.caseTasks) ? state.caseTasks : [])
+    .filter((entry) => String(entry.caseId || "") === String(caseRow?.id || ""));
+  if (caseTasks.length) {
+    const completedStatuses = new Set(["完了", "対応済み", "不要"]);
+    const incomplete = caseTasks.filter((entry) => !completedStatuses.has(String(entry.status || "").trim())).length;
+    return { total: caseTasks.length, incomplete };
+  }
+  const legacyTasks = parseTaskList(caseRow?.taskList || "");
+  return { total: legacyTasks.length, incomplete: legacyTasks.filter((entry) => !entry.done).length };
+}
+
+function getConstructionTemplateSummary(caseRow, constructionDetail, docStats, taskStats) {
+  if (!constructionDetail) return "未設定";
+  const procedureType = normalizeConstructionProcedureType(constructionDetail.procedure_type);
+  if (!procedureType) return "手続種別未設定";
+  const hasExpandedItems = (docStats?.total || 0) > 0 || (taskStats?.total || 0) > 0;
+  return hasExpandedItems ? "適用済み相当" : "適用可";
+}
+
+function appendCaseSummaryField(container, label, value) {
+  if (!container) return null;
+  const field = document.createElement("div");
+  field.className = "case-card-field";
+  const labelElement = document.createElement("span");
+  labelElement.className = "case-card-label";
+  labelElement.textContent = label;
+  const valueElement = document.createElement("span");
+  valueElement.className = "case-card-value";
+  valueElement.textContent = value || "未設定";
+  field.append(labelElement, valueElement);
+  container.appendChild(field);
+  return valueElement;
+}
+
+function appendCaseLinkSummaryField(container, links) {
+  const visibleLinks = (Array.isArray(links) ? links : []).filter((entry) => entry?.url);
+  if (!visibleLinks.length) return;
+  const valueElement = appendCaseSummaryField(container, "リンク", "");
+  if (!valueElement) return;
+  valueElement.textContent = "";
+  visibleLinks.forEach((entry, index) => {
+    if (index > 0) valueElement.appendChild(document.createTextNode(" / "));
+    const link = document.createElement("a");
+    link.href = entry.url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = entry.label;
+    valueElement.appendChild(link);
+  });
+}
+
 function getDocumentAlertTargets() {
   const todayTs = getTodayTimestamp();
   return (Array.isArray(state.caseDocuments) ? state.caseDocuments : []).reduce((acc, doc) => {
@@ -8856,7 +8908,8 @@ function renderCases() {
     const node = caseItemTemplate.content.cloneNode(true);
     const item = node.querySelector(".item");
     const title = node.querySelector(".title");
-    const meta = node.querySelector(".meta");
+    const statusBadge = node.querySelector(".case-status-badge");
+    const summaryGrid = node.querySelector(".case-card-summary-grid");
     const caseWorkMeta = node.querySelector(".case-work-meta");
     const profitMeta = node.querySelector(".profit-meta");
     const rowActions = node.querySelector(".row-actions");
@@ -8865,8 +8918,8 @@ function renderCases() {
     const templateName = state.workTemplates.find((template) => template.id === entry.templateId)?.name || "未設定";
     const customerName = entry.customerName || "顧客不明";
     const caseName = entry.caseName || "案件名未設定";
-    const incompleteTasks = getIncompleteTaskCount(entry.taskList);
     const docStats = getCaseDocumentStats(entry.id);
+    const taskStats = getCaseTaskStats(entry);
     const auditAlerts = getCaseAuditAlerts(entry);
     const linkedEstimate = getCaseLinkedEstimate(entry);
     const linkedSales = (Array.isArray(state.sales) ? state.sales : []).filter((sale) => {
@@ -8878,21 +8931,45 @@ function renderCases() {
     const preferredAmount = getCasePreferredInvoiceAmount(entry, linkedEstimate);
     const linkedSaleAmount = Number(linkedSales[0]?.invoiceAmount ?? 0);
     const hasSaleAmountMismatch = hasSaleRegistered && preferredAmount > 0 && linkedSaleAmount !== preferredAmount;
+    const constructionDetail = getConstructionCaseDetailForCase(entry.id);
+    const constructionProcedure = constructionDetail
+      ? getConstructionProcedureLabel(constructionDetail.procedure_type)
+      : "未設定";
+    const constructionTemplateSummary = getConstructionTemplateSummary(entry, constructionDetail, docStats, taskStats);
 
     item.dataset.id = entry.id;
     title.textContent = `${customerName}｜${caseName}`;
-    const urlLinks = [
-      entry.documentUrl ? `<a href="${escapeHtml(entry.documentUrl)}" target="_blank" rel="noopener noreferrer">関連書類を開く</a>` : "",
-      entry.invoiceUrl ? `<a href="${escapeHtml(entry.invoiceUrl)}" target="_blank" rel="noopener noreferrer">請求書を開く</a>` : "",
-      entry.receiptUrl ? `<a href="${escapeHtml(entry.receiptUrl)}" target="_blank" rel="noopener noreferrer">領収書を開く</a>` : "",
-    ].filter(Boolean).join(" / ");
-    const constructionDetail = getConstructionCaseDetailForCase(entry.id);
-    const constructionMeta = constructionDetail
-      ? ` / 建設業許可系: ${escapeHtml(getConstructionProcedureLabel(constructionDetail.procedure_type))} / 許可満了日: ${formatDate(constructionDetail.permit_expiry_date)} / 申請方法: ${escapeHtml(constructionDetail.application_route || "未定")}`
-      : " / 建設業許可系: 未設定";
-    meta.innerHTML = `見積: ${formatCurrency(entry.estimateAmount)} / ステータス: ${escapeHtml(entry.status)} / 受付日: ${formatDate(entry.receivedDate)} / 期限日: ${formatDate(entry.dueDate)} / 次回対応日: ${formatDate(entry.nextActionDate)} / 次回対応内容: ${escapeHtml(entry.nextAction || "未設定")}${constructionMeta}${urlLinks ? ` / ${urlLinks}` : ""}`;
+    if (statusBadge) statusBadge.textContent = entry.status || "ステータス未設定";
+    if (summaryGrid) {
+      summaryGrid.innerHTML = "";
+      appendCaseSummaryField(summaryGrid, "顧客", customerName);
+      appendCaseSummaryField(summaryGrid, "案件名", caseName);
+      appendCaseSummaryField(summaryGrid, "ステータス", entry.status || "未設定");
+      appendCaseSummaryField(summaryGrid, "受付日", formatDate(entry.receivedDate));
+      appendCaseSummaryField(summaryGrid, "期限日", formatDate(entry.dueDate));
+      appendCaseSummaryField(summaryGrid, "次回対応日", formatDate(entry.nextActionDate));
+      appendCaseSummaryField(summaryGrid, "次回対応内容", entry.nextAction || "未設定");
+      appendCaseSummaryField(summaryGrid, "業務テンプレート", templateName);
+      appendCaseSummaryField(summaryGrid, "手続種別", constructionProcedure);
+      if (constructionDetail) {
+        appendCaseSummaryField(summaryGrid, "許可満了日", formatDate(constructionDetail.permit_expiry_date));
+        appendCaseSummaryField(summaryGrid, "決算月", constructionDetail.fiscal_month ? `${constructionDetail.fiscal_month}月` : "未設定");
+        appendCaseSummaryField(summaryGrid, "申請方法", constructionDetail.application_route || "未定");
+      }
+      appendCaseSummaryField(summaryGrid, "建設業許可テンプレート", constructionTemplateSummary);
+      appendCaseSummaryField(summaryGrid, "必要書類", `${docStats.total}件（回収済${docStats.received}件／未回収${docStats.unreceived}件${docStats.defective ? `／不備${docStats.defective}件` : ""}）`);
+      appendCaseSummaryField(summaryGrid, "タスク", `${taskStats.total}件（未完了${taskStats.incomplete}件）`);
+      appendCaseSummaryField(summaryGrid, "見積", formatCurrency(entry.estimateAmount));
+      appendCaseSummaryField(summaryGrid, "売上", hasSaleRegistered ? "売上登録済み" : "売上未登録");
+      appendCaseLinkSummaryField(summaryGrid, [
+        { url: entry.documentUrl, label: "関連書類" },
+        { url: entry.invoiceUrl, label: "請求書" },
+        { url: entry.receiptUrl, label: "領収書" },
+      ]);
+    }
     if (caseWorkMeta) {
-      caseWorkMeta.textContent = `テンプレート: ${templateName} / 必要書類: ${truncateText(entry.requiredDocuments || "未設定", 50)} / 書類管理: 必要書類 ${docStats.total}件 / 回収済 ${docStats.received}件 / 未回収 ${docStats.unreceived}件 / 不備 ${docStats.defective}件 / タスク: ${truncateText(entry.taskList || "未設定", 50)} / 未完了タスク: ${incompleteTasks}件 / 売上: ${hasSaleRegistered ? "売上登録済み" : "売上未登録"}${hasSaleAmountMismatch ? " / ⚠ 金額不一致あり" : ""} / 作業メモ: ${truncateText(sanitizeLegacyEstimateMemo(entry.workMemo) || "未設定", 40)} / 進行監査: ${auditAlerts.length ? auditAlerts.join(" / ") : "問題なし"}`;
+      const auditSummary = auditAlerts.length ? auditAlerts.join(" / ") : "問題なし";
+      caseWorkMeta.textContent = `進行監査: ${auditSummary}${hasSaleAmountMismatch ? " / ⚠ 金額不一致あり" : ""}`;
       caseWorkMeta.classList.remove("next-action-overdue", "next-action-within3", "next-action-within7");
       if (nextActionInfo) safeAddClass(caseWorkMeta, nextActionInfo.urgencyClass);
     }

--- a/index.html
+++ b/index.html
@@ -1598,14 +1598,17 @@
     </div>
 
     <template id="case-item-template">
-      <li class="item">
-        <div>
-          <p class="title"></p>
-          <p class="meta"></p>
-          <p class="meta case-work-meta"></p>
-          <p class="meta profit-meta"></p>
+      <li class="item case-card">
+        <div class="case-card-main">
+          <div class="case-card-header">
+            <p class="title case-card-title"></p>
+            <span class="case-status-badge"></span>
+          </div>
+          <div class="case-card-summary-grid"></div>
+          <p class="meta case-work-meta case-card-detail-summary"></p>
+          <p class="meta profit-meta case-card-profit"></p>
         </div>
-        <div class="row-actions"><button type="button" class="edit-btn secondary-btn" data-action="edit_case" data-list-action="edit_case">編集</button><button type="button" class="danger-btn delete-btn" data-action="delete_case" data-list-action="delete_case">削除</button></div>
+        <div class="row-actions case-card-actions"><button type="button" class="edit-btn secondary-btn" data-action="edit_case" data-list-action="edit_case">編集</button><button type="button" class="danger-btn delete-btn" data-action="delete_case" data-list-action="delete_case">削除</button></div>
       </li>
     </template>
     <template id="expense-item-template">

--- a/styles.css
+++ b/styles.css
@@ -1287,3 +1287,112 @@ button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
 }
+
+.case-card {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.case-card-main {
+  min-width: 0;
+  width: 100%;
+}
+
+.case-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.case-card-title {
+  margin: 0;
+  min-width: min(100%, 16rem);
+  overflow-wrap: anywhere;
+  word-break: keep-all;
+}
+
+.case-status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0.18rem 0.65rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.84rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.case-card-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(18rem, 1fr));
+  gap: 0.38rem 1rem;
+}
+
+.case-card-field {
+  display: grid;
+  grid-template-columns: minmax(7.2rem, max-content) minmax(0, 1fr);
+  gap: 0.35rem;
+  align-items: baseline;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.case-card-label {
+  color: #374151;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.case-card-label::after {
+  content: "：";
+}
+
+.case-card-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: keep-all;
+}
+
+.case-card-detail-summary,
+.case-card-profit {
+  margin-top: 0.45rem;
+  overflow-wrap: anywhere;
+  word-break: keep-all;
+}
+
+.case-card-actions {
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--border);
+}
+
+.case-card-actions button {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 760px) {
+  .case-card-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .case-card-field {
+    grid-template-columns: minmax(6.5rem, max-content) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 430px) {
+  .case-card-field {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
+  }
+}


### PR DESCRIPTION
### Motivation

- 案件一覧のカード表示が第1-Cマージ後に本文幅が圧迫され、ラベルが1〜2文字単位で縦に折り返される等の可読性崩れを修正するため。 
- 案件カードは一覧性に必要な最小情報のみを表示し、詳細や長文は詳細画面へ委ねる方針を実装するため。 
- 第1-Cで追加した建設業許可テンプレートの展開ロジック（書類・タスク生成や重複防止等）は維持するため。

### Description

- 変更ファイルは `app.js` / `index.html` / `styles.css` で、案件一覧（`#case-list`）の既存構造は維持しつつカードテンプレートを再構成しました。 
- 案件カードを `header / summary grid / detail summary / profit / actions` の専用構成に分離し、`必要書類` と `タスク` は全文表示から件数サマリー表示へ切替えました（例: `書類: 5件（回収済0件／未回収5件）`）。 
- 表示ロジック補助として `getCaseTaskStats` / `getConstructionTemplateSummary` / `appendCaseSummaryField` 等のヘルパーを追加し、既存の `getCaseDocumentStats` や `applyConstructionCaseTemplate` 等の第1-C関連関数は変更していません。 
- CSSは案件カード専用クラス（`.case-card` 等）を追加してラベルの縦割れを防ぎ、アクションボタン群を本文下部に分離して `flex-wrap` で折り返すようにして本文幅の圧迫を解消しました。

### Testing

- `node --check app.js` を実行して構文チェックを行い、問題は検出されませんでした（成功）。
- `git diff --check` および差分の静的確認を行い、衝突するスタイルや構文エラーは検出されませんでした（成功）。
- 変更箇所周辺のキー関数（`applyConstructionCaseTemplate`, `createCaseDocumentsFromBusinessResourceTemplates`, `createCaseInitialTasksForConstructionProcedure`, `getApplicableBusinessResourceTemplates`, `getConstructionCaseDetailForCase` 等）を検索・確認し、展開ロジックや `is_active=false` / `collect`/`submit` 判定・重複生成防止の振る舞いは維持されていることを確認しました（成功）。
- ブラウザでの実画面自動テスト（Playwright 等）は環境に未導入のため実行できませんでした（失敗／未実施）、よって実画面確認はユーザー側でのマージ後検証をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18fc1255288333af05e9903ad4cc46)