### PR TITLE
見積明細：単価欄の初期値を空欄に変更（UX改善）

### DIFF
--- a/app.js
+++ b/app.js
@@ -8481,16 +8481,25 @@ function preserveEstimateFormDuring(operation, options = {}) {
   return result;
 }
 
+function getEstimateItemInputInitialValue(item, camelKey, snakeKey, fallback = "") {
+  if (!item || typeof item !== "object") return fallback;
+  if (Object.prototype.hasOwnProperty.call(item, camelKey) && item[camelKey] !== null && item[camelKey] !== undefined) return item[camelKey];
+  if (Object.prototype.hasOwnProperty.call(item, snakeKey) && item[snakeKey] !== null && item[snakeKey] !== undefined) return item[snakeKey];
+  return fallback;
+}
+
 function addEstimateItemRow(defaultItem = {}) {
   if (!estimateItemsWrap) return;
   const row = document.createElement("div");
   const itemType = normalizeEstimateItemType(defaultItem.itemType ?? defaultItem.item_type);
+  const quantityValue = getEstimateItemInputInitialValue(defaultItem, "quantity", "quantity", 1);
+  const unitPriceValue = getEstimateItemInputInitialValue(defaultItem, "unitPrice", "unit_price", "");
   row.className = "estimate-item-row";
   row.innerHTML = `
     <select data-key="itemType" aria-label="区分" title="区分">${createEstimateItemTypeOptions(itemType)}</select>
     <input type="text" data-key="itemName" placeholder="項目名" value="${escapeHtml(defaultItem.itemName || defaultItem.item_name || "")}" />
-    <input type="text" inputmode="decimal" pattern="[0-9.,]*" data-key="quantity" placeholder="数量" value="${defaultItem.quantity ?? 1}" />
-    <input type="text" inputmode="numeric" pattern="-?[0-9,]*" data-key="unitPrice" data-allow-negative="true" placeholder="単価" value="${defaultItem.unitPrice ?? defaultItem.unit_price ?? 0}" />
+    <input type="text" inputmode="decimal" pattern="[0-9.,]*" data-key="quantity" placeholder="数量" value="${escapeHtml(String(quantityValue))}" />
+    <input type="text" inputmode="numeric" pattern="-?[0-9,]*" data-key="unitPrice" data-allow-negative="true" placeholder="単価" value="${escapeHtml(String(unitPriceValue))}" />
     <p class="meta item-amount">${formatCurrency(defaultItem.amount ?? 0)}</p>
     <button type="button" class="danger-btn estimate-item-remove-btn" data-action="remove_estimate_item_row">削除</button>
   `;
@@ -8501,7 +8510,7 @@ function addEstimateItemRow(defaultItem = {}) {
 }
 
 function addEstimateDiscountRow() {
-  addEstimateItemRow({ itemName: "値引き", itemType: "discount", quantity: 1, unitPrice: -5000, amount: -5000 });
+  addEstimateItemRow({ itemName: "値引き", itemType: "discount", quantity: 1 });
 }
 
 function handleEstimateItemsInput() {


### PR DESCRIPTION
### Motivation
- 新規作成や明細追加時に単価入力欄が初期で `0` 表示されていたため、連続入力時に毎回消す必要があり入力効率が悪かったため、表示上の初期値を空欄化して UX を改善します。
- 値引き行の追加で固定値（例: `-5000`）が事前表示される問題を解消し、ユーザーが金額を入力してから計算されるようにします。

### Description
- `getEstimateItemInputInitialValue()` ヘルパーを追加して、明示的に渡された保存済み値のみを表示し、未指定のフィールドは空文字で初期化するようにしました。`
- `addEstimateItemRow()` を修正し、`unitPrice` の初期表示を空文字に変更し、`quantity` は既存の方針どおり `1` を保持するようにしました。`
- `addEstimateDiscountRow()` の固定初期 `unitPrice: -5000` / `amount: -5000` を廃止して、値引き行は `itemType: "discount"` と `quantity: 1` のみを初期化するようにしました。`
- 表示上は空欄に変更しますが、内部の計算は既存の `parseNumberInput()` により空文字を `0` 扱いにしているため、`recalcEstimateTotals()` / `getEstimateItemsFromForm()` / `isMeaningfulEstimateItem()` 等の計算・保存・下書き復元ロジックは維持されています。`

### Testing
- `node --check app.js` による構文チェックは成功しました。`
- `git diff --check` とリポジトリ内の静的パターンチェック（`rg`）および小スクリプトによる確認で、単価入力の `0` 初期値削除と値引き固定金額削除、空欄単価が計算時に `0` として扱われることを確認しました。`
- ブラウザでの実動作（Playwright / Puppeteer）による画面確認は、この環境に該当ツールがないため未実施です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198a75daf483339ab75bc913932409)