### PR TITLE
Add WIP box visual aid for Boki2 industrial 4-2 and 4-4

### DIFF
--- a/cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx
+++ b/cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { IndustrialAccountFlowData, PracticeItem, VisualAidType } from '../originalStudyTypes';
+import type { IndustrialAccountFlowData, PracticeItem, VisualAidType, WipBoxData } from '../originalStudyTypes';
 import './visualAids.css';
 
 function renderIndustrialAccountFlow(data: IndustrialAccountFlowData) {
@@ -36,6 +36,26 @@ function renderIndustrialAccountFlow(data: IndustrialAccountFlowData) {
   );
 }
 
+function renderWipBox(data: WipBoxData) {
+  return (
+    <div className="visual-aid-diagram wip-box-diagram" aria-label="仕掛品BOX">
+      <div className="wip-box-title">{data.title}</div>
+      <div className="wip-box-frame">
+        <div className="wip-box-side wip-box-left" aria-label="投入側">
+          {data.rows.map((row) => <div className="wip-box-entry" key={`left-${row.leftLabel}`}>{row.leftLabel}</div>)}
+        </div>
+        <div className="wip-box-center" aria-hidden="true">仕掛品</div>
+        <div className="wip-box-side wip-box-right" aria-label="完成・月末側">
+          {data.rows.map((row) => <div className="wip-box-entry" key={`right-${row.rightLabel}`}>{row.rightLabel}</div>)}
+        </div>
+      </div>
+      <div className="wip-box-notes" aria-label="確認ポイント">
+        {data.notes.map((note) => <span key={note}>{note}</span>)}
+      </div>
+    </div>
+  );
+}
+
 function hasVisualAid(item: PracticeItem): boolean {
   return Array.isArray(item.visualAidTypes) && item.visualAidTypes.length > 0;
 }
@@ -44,6 +64,8 @@ export function VisualAidPanel({ item }: { item: PracticeItem }) {
   const [open, setOpen] = useState(false);
   const firstType = item.visualAidTypes?.[0] as VisualAidType | undefined;
   const accountFlow = item.visualAidData?.industrial_account_flow;
+  const wipBox = item.visualAidData?.wip_box;
+  const title = firstType === 'wip_box' ? wipBox?.title : accountFlow?.title;
 
   if (!hasVisualAid(item) || !firstType) return null;
 
@@ -52,7 +74,7 @@ export function VisualAidPanel({ item }: { item: PracticeItem }) {
       <div className="visual-aid-header">
         <div>
           <p className="eyebrow">図表で確認</p>
-          <h2>{accountFlow?.title ?? '図表'}</h2>
+          <h2>{title ?? '図表'}</h2>
         </div>
         <button type="button" className="secondary" onClick={() => setOpen((value) => !value)}>
           {open ? '図表を閉じる' : '図表で確認'}
@@ -64,6 +86,14 @@ export function VisualAidPanel({ item }: { item: PracticeItem }) {
             {accountFlow.description ?? '材料・賃金・経費が製造活動を通じて仕掛品、製品、売上原価へ流れる関係を確認する図です。'}
           </p>
           {renderIndustrialAccountFlow(accountFlow)}
+        </div>
+      )}
+      {open && firstType === 'wip_box' && wipBox && (
+        <div className="visual-aid-body">
+          <p className="visual-aid-description">
+            {wipBox.description ?? '仕掛品BOXは、月初仕掛品と当月投入が、完成品と月末仕掛品へ分かれる関係を整理するための図です。'}
+          </p>
+          {renderWipBox(wipBox)}
         </div>
       )}
     </section>

--- a/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts
@@ -69,6 +69,60 @@ const VISUAL_AID_STYLE = `
     color: #31543d;
     font-size: 0.9rem;
   }
+  .wip-box-title {
+    text-align: center;
+    font-weight: 800;
+    color: #173a22;
+    margin-bottom: 10px;
+  }
+  .wip-box-frame {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) minmax(120px, 0.8fr) minmax(150px, 1fr);
+    border: 2px solid #4c9b61;
+    border-radius: 12px;
+    overflow: hidden;
+    min-width: 520px;
+  }
+  .wip-box-side {
+    display: grid;
+    gap: 8px;
+    padding: 12px;
+    background: #fbfefd;
+  }
+  .wip-box-left { border-right: 1px solid #d9eadf; }
+  .wip-box-right { border-left: 1px solid #d9eadf; }
+  .wip-box-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #dff2e4;
+    color: #173a22;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  }
+  .wip-box-entry {
+    border: 1px solid #8fc39e;
+    border-radius: 10px;
+    background: #eef8f0;
+    padding: 10px;
+    text-align: center;
+    font-weight: 700;
+    color: #173a22;
+  }
+  .wip-box-notes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .wip-box-notes span {
+    background: #f1f6f3;
+    border: 1px solid #d8e8dd;
+    border-radius: 999px;
+    color: #31543d;
+    padding: 5px 10px;
+    font-size: 0.9rem;
+  }
   @media (max-width: 760px) {
     .visual-aid-header { align-items: flex-start; flex-direction: column; }
     .flow-row {
@@ -78,6 +132,13 @@ const VISUAL_AID_STYLE = `
     }
     .flow-arrow { transform: rotate(90deg); align-self: center; }
     .flow-node { width: 100%; box-sizing: border-box; }
+    .wip-box-frame {
+      grid-template-columns: 1fr;
+      min-width: 0;
+    }
+    .wip-box-left,
+    .wip-box-right { border: 0; }
+    .wip-box-center { padding: 12px; border-top: 1px solid #d9eadf; border-bottom: 1px solid #d9eadf; }
   }
 `;
 
@@ -120,6 +181,38 @@ const INDUSTRIAL_ACCOUNT_FLOW_HTML = `
   </section>
 `;
 
+const WIP_BOX_HTML = `
+  <section class="panel visual-aid-panel" aria-label="図表で確認">
+    <div class="visual-aid-header">
+      <div>
+        <p class="eyebrow">図表で確認</p>
+        <h2>仕掛品BOX</h2>
+      </div>
+      <button type="button" class="secondary" data-visual-aid-toggle>図表で確認</button>
+    </div>
+    <div class="visual-aid-body" data-visual-aid-body hidden>
+      <p class="visual-aid-description">仕掛品BOXは、月初仕掛品と当月投入が、完成品と月末仕掛品へ分かれる関係を整理するための図です。</p>
+      <div class="visual-aid-diagram wip-box-diagram" aria-label="仕掛品BOX">
+        <div class="wip-box-title">仕掛品BOX</div>
+        <div class="wip-box-frame">
+          <div class="wip-box-side wip-box-left" aria-label="投入側">
+            <div class="wip-box-entry">月初仕掛品</div>
+            <div class="wip-box-entry">当月投入</div>
+          </div>
+          <div class="wip-box-center" aria-hidden="true">仕掛品</div>
+          <div class="wip-box-side wip-box-right" aria-label="完成・月末側">
+            <div class="wip-box-entry">完成品</div>
+            <div class="wip-box-entry">月末仕掛品</div>
+          </div>
+        </div>
+        <div class="wip-box-notes" aria-label="確認ポイント">
+          <span>材料費</span><span>加工費</span><span>換算量</span><span>完成品換算量</span>
+        </div>
+      </div>
+    </div>
+  </section>
+`;
+
 function ensureVisualAidStyle() {
   if (document.getElementById(VISUAL_AID_STYLE_ID)) return;
   const style = document.createElement('style');
@@ -128,10 +221,13 @@ function ensureVisualAidStyle() {
   document.head.appendChild(style);
 }
 
-function currentQuestionHasIndustrial41(): boolean {
+function getCurrentVisualAidKind(): 'industrial_account_flow' | 'wip_box' | null {
   const questionCard = document.querySelector('.question-reference-card');
   const text = questionCard?.textContent ?? '';
-  return text.includes('教材なしモード') && text.includes('industrial_4_1');
+  if (!text.includes('教材なしモード')) return null;
+  if (text.includes('industrial_4_1')) return 'industrial_account_flow';
+  if (text.includes('industrial_4_2') || text.includes('industrial_4_4')) return 'wip_box';
+  return null;
 }
 
 function unmountEditor() {
@@ -146,7 +242,7 @@ function unmountEditor() {
 
 function removeVisualAidIfNeeded() {
   const root = document.getElementById(VISUAL_AID_ROOT_ID);
-  if (root && !currentQuestionHasIndustrial41()) {
+  if (root && !getCurrentVisualAidKind()) {
     unmountEditor();
     root.remove();
   }
@@ -201,15 +297,22 @@ function ensureVisualAid() {
   ensureVisualAidStyle();
   const answerArea = document.querySelector('.focused-answer-area.answer-only-main');
   if (!answerArea) return;
-  if (!currentQuestionHasIndustrial41()) {
+  const visualAidKind = getCurrentVisualAidKind();
+  if (!visualAidKind) {
     removeVisualAidIfNeeded();
     return;
   }
-  if (document.getElementById(VISUAL_AID_ROOT_ID)) return;
+  const existingRoot = document.getElementById(VISUAL_AID_ROOT_ID);
+  if (existingRoot?.dataset.visualAidKind === visualAidKind) return;
+  if (existingRoot) {
+    unmountEditor();
+    existingRoot.remove();
+  }
 
   const root = document.createElement('div');
   root.id = VISUAL_AID_ROOT_ID;
-  root.innerHTML = INDUSTRIAL_ACCOUNT_FLOW_HTML;
+  root.dataset.visualAidKind = visualAidKind;
+  root.innerHTML = visualAidKind === 'industrial_account_flow' ? INDUSTRIAL_ACCOUNT_FLOW_HTML : WIP_BOX_HTML;
   answerArea.parentElement?.insertBefore(root, answerArea);
   wireVisualAidControls(root);
 }

--- a/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
+++ b/cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts
@@ -32,7 +32,7 @@ export type AnswerTemplateId = 'journal' | 'numeric' | 'statementTable' | 'accou
 export type GradeMark = '未採点' | '正解' | '不正解' | '要確認' | '○' | '△' | '×';
 export type ReviewRank = '' | 'A' | 'B' | 'C';
 export type MissReason = '論点理解不足' | '仕訳ミス' | '借方貸方逆' | '金額ミス' | '集計ミス' | '転記ミス' | '表の入力位置ミス' | '下書き不足' | '時間不足' | '解答形式の誤認' | '問題文読み落とし' | 'その他';
-export type VisualAidType = 'industrial_account_flow';
+export type VisualAidType = 'industrial_account_flow' | 'wip_box';
 
 export interface QualityCheck {
   scopeChecked: boolean;
@@ -55,8 +55,21 @@ export interface IndustrialAccountFlowData {
   edges: [string, string][];
 }
 
+export interface WipBoxRow {
+  leftLabel: string;
+  rightLabel: string;
+}
+
+export interface WipBoxData {
+  title: string;
+  description?: string;
+  rows: WipBoxRow[];
+  notes: string[];
+}
+
 export interface VisualAidDataMap {
   industrial_account_flow?: IndustrialAccountFlowData;
+  wip_box?: WipBoxData;
 }
 
 export interface AnswerLine {


### PR DESCRIPTION
## 今回の目的

工業簿記 4-2 / 4-4 で、問題文の下・答案入力欄の上に「仕掛品BOX図」を確認用テンプレートとして表示できるようにします。

今回のPRでは、問題追加・採点ロジック変更・勘定連絡図エディタ変更は行っていません。

## 実装内容

- 4-2 工程別総合原価計算で「図表で確認」から仕掛品BOX図を表示します。
- 4-4 財務諸表作成で「図表で確認」から仕掛品BOX図を表示します。
- 4-1 工業簿記仕訳問題では、既存の勘定連絡図・勘定連絡図エディタを維持します。
- 商業簿記、5-1 / 5-2 / 5-3 では仕掛品BOX図を表示しない条件にしています。

## 図表の生成方法

- 画像・スクリーンショットは使っていません。
- CPA教材、日商サンプル問題、他サイト画像、市販教材図表は使用していません。
- HTML/CSSで自前生成しています。

## 仕掛品BOX図の内容

表示要素：

- 左側：月初仕掛品 / 当月投入
- 中央：仕掛品
- 右側：完成品 / 月末仕掛品
- 補助表示：材料費 / 加工費 / 換算量 / 完成品換算量

説明文：

> 仕掛品BOXは、月初仕掛品と当月投入が、完成品と月末仕掛品へ分かれる関係を整理するための図です。

## 今回実装していないこと

- 仕掛品BOX図上での直接入力
- 仕掛品BOX図の自動採点
- 完成品換算量の自動計算
- 月末仕掛品原価の自動計算
- 先入先出法 / 平均法の完全計算機能
- 図表から答案欄への自動転記
- 勘定連絡図エディタの変更
- T勘定
- 連結タイムテーブル
- B/S、P/L
- シュラッター図
- 新規問題追加
- 問題文、模範解答、解説の変更
- 自動採点ロジックの変更
- side_multiset採点ロジックの変更
- 一時保存ロジックの大幅変更

## 変更ファイル一覧

- `cpa-boki2-trial-section-answer-manager/src/components/VisualAidPanel.tsx`
- `cpa-boki2-trial-section-answer-manager/src/components/visualAidBridge.ts`
- `cpa-boki2-trial-section-answer-manager/src/originalStudyTypes.ts`

## 既存機能への影響

- 自動採点への影響：採点ロジックは変更していません。
- side_multiset採点への影響：変更していません。
- 勘定連絡図エディタへの影響：4-1用の既存エディタの表示分岐は維持しています。
- 問題選択UIへの影響：変更していません。
- 一時保存への影響：保存ロジックは変更していません。
- IME入力・金額入力への影響：入力処理は変更していません。
- もう一度解くへの影響：変更していません。
- 既存案件管理アプリ本体への影響：対象外です。

## npm run build 結果

未実施です。GitHub Actionsで確認します。

## GitHub Actions 結果

PR作成後に確認します。

## Console確認結果

未確認です。実URLでの手動確認が必要です。

## 未確認事項

- 実URLで4-2に仕掛品BOX図が表示されること
- 実URLで4-4に仕掛品BOX図が表示されること
- 4-1の勘定連絡図・勘定連絡図エディタが壊れていないこと
- 商業簿記や5-1 / 5-2 / 5-3に誤表示されないこと
- 図表開閉後も答案入力が消えないこと
- Console赤エラー有無

## 実URLで確認すべき項目

1. 教材なしモードを開く
2. 4-2 工程別総合原価計算グループを開く
3. 任意の4-2問題を開く
4. 図表で確認を押す
5. 仕掛品BOX図が表示されることを確認
6. 答案入力欄が壊れていないことを確認
7. 4-4 財務諸表作成グループを開く
8. 4-4問題で仕掛品BOX図が表示されることを確認
9. 4-1 工業簿記仕訳問題を開く
10. 既存の勘定連絡図が壊れていないことを確認
11. 4-1の勘定連絡図エディタが壊れていないことを確認
12. 商業簿記1-1などを開き、仕掛品BOX図が誤表示されないことを確認
13. 自動採点、一時保存、もう一度解くが壊れていないことを確認
14. 日本語IME入力と金額入力が壊れていないことを確認
15. Consoleに赤エラーが出ないことを確認

## マージについて

ユーザー確認前にはマージしません。