### PR TITLE
緊急修正：estimateFormState 初期化前参照を解消

### DIFF
--- a/app.js
+++ b/app.js
@@ -335,6 +335,17 @@ const state = {
   selectedBusinessResourceTemplateIds: [],
 };
 const editState = { clientId: null, caseId: null, workTemplateId: null, businessResourceTemplateId: null, saleId: null, expenseId: null, fixedExpenseId: null, dailyReportId: null, estimateId: null, caseTaskId: null, caseDocumentId: null };
+const ESTIMATE_DRAFT_STORAGE_KEY = "gyosei_estimate_draft_v1";
+const estimateFormState = {
+  mode: null,
+  currentEstimateId: null,
+  generation: 0,
+  dirty: false,
+  restoring: false,
+};
+let isRestoringEstimateDraft = false;
+let estimateDraftSaveTimer = null;
+let estimateDraftRestoreRunId = 0;
 
 const CLICK_ACTION_HANDLERS = {
   activate_tab: (event, button) => activateTab(button?.dataset?.tab),
@@ -8544,19 +8555,13 @@ function matchesDailyReportDateFilter(entry, filter) {
 }
 
 
-const ESTIMATE_DRAFT_STORAGE_KEY = "gyosei_estimate_draft_v1";
-let isRestoringEstimateDraft = false;
-let estimateDraftSaveTimer = null;
-let estimateDraftRestoreRunId = 0;
-const estimateFormState = {
-  mode: null,
-  currentEstimateId: null,
-  generation: 0,
-  dirty: false,
-};
-
 function normalizeEstimateFormMode(mode) {
   return ["new", "edit", "view"].includes(mode) ? mode : null;
+}
+
+function setEstimateFormRestoring(restoring) {
+  isRestoringEstimateDraft = Boolean(restoring);
+  estimateFormState.restoring = isRestoringEstimateDraft;
 }
 
 function normalizeEstimateFormEstimateId(estimateId) {
@@ -8743,7 +8748,7 @@ function readEstimateFormDraft(context = getEstimateFormContextSnapshot()) {
 function restoreEstimateFormDraft(draft = readEstimateFormDraft(), options = {}) {
   const context = options.context || getEstimateFormContextSnapshot();
   if (!draft || !estimateForm || !isEstimateDraftEligibleContext(context) || !isEstimateFormContextCurrent(context) || !doesEstimateDraftMatchContext(draft, context)) return false;
-  isRestoringEstimateDraft = true;
+  setEstimateFormRestoring(true);
   try {
     const fieldValues = {
       clientId: draft.clientId || "",
@@ -8772,7 +8777,7 @@ function restoreEstimateFormDraft(draft = readEstimateFormDraft(), options = {})
     console.warn("見積下書き復元に失敗", error);
     return false;
   } finally {
-    isRestoringEstimateDraft = false;
+    setEstimateFormRestoring(false);
   }
 }
 
@@ -10049,7 +10054,7 @@ async function startEstimateEdit(estimateId) {
     subtabState.estimates = "create";
     const editContext = setEstimateFormContext("edit", target.id, "startEstimateEdit");
     clearEstimateFormDraft(getEstimateDraftKey(editContext));
-    isRestoringEstimateDraft = true;
+    setEstimateFormRestoring(true);
     activateTab("estimates");
     try {
       if (estimateForm.elements.clientId) estimateForm.elements.clientId.value = target.clientId || "";
@@ -10066,7 +10071,7 @@ async function startEstimateEdit(estimateId) {
       recalcEstimateTotals();
       estimateFormState.dirty = false;
     } finally {
-      isRestoringEstimateDraft = false;
+      setEstimateFormRestoring(false);
     }
     if (estimateSubmitBtn) estimateSubmitBtn.textContent = "見積を更新";
     estimateForm.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -10091,7 +10096,7 @@ function resetEstimateForm(options = {}) {
     return;
   }
 
-  isRestoringEstimateDraft = true;
+  setEstimateFormRestoring(true);
   try {
     estimateForm?.reset();
     if (estimateForm?.elements?.clientId) estimateForm.elements.clientId.value = "";
@@ -10105,7 +10110,7 @@ function resetEstimateForm(options = {}) {
     recalcEstimateTotals();
     estimateFormState.dirty = false;
   } finally {
-    isRestoringEstimateDraft = false;
+    setEstimateFormRestoring(false);
   }
 }
 


### PR DESCRIPTION
### Motivation
- ログイン後の初期化中に `activateTab()` → `saveEstimateDraftBeforeSuspend()` → `getEstimateFormContextSnapshot()` の呼び出しで `estimateFormState` がまだ初期化されておらず `ReferenceError: Cannot access 'estimateFormState' before initialization` が発生してアプリが停止していたため。 
- 問題の本質は `let/const` の TDZ による初期化順序の誤りで、関数側を `typeof` や optional chaining 等で逃がすのではなくトップレベルの初期化順序を直す必要があるため。 

### Description
- 見積下書き関連のグローバル（`ESTIMATE_DRAFT_STORAGE_KEY` / `estimateFormState` / `isRestoringEstimateDraft` / タイマー変数等）をアプリ全体状態定義箇所（`editState` の直後）へ移動し、`initialize()` 実行より前に確実に初期化されるようにした。 
- `estimateFormState` に中立的な初期値を追加し、`mode: null`, `currentEstimateId: null`, `generation: 0`, `dirty: false`, `restoring: false` を設定して初期参照が安全になるようにした。 
- 直接の `isRestoringEstimateDraft = true/false` 操作を `setEstimateFormRestoring()` ヘルパーに置き換え、`isRestoringEstimateDraft` と `estimateFormState.restoring` を同期する形に変更して既存の復元フロー（`restoreEstimateFormDraft` / `startEstimateEdit` / `resetEstimateForm` 等）を維持した。 
- 初期化順序以外の見積フォーム状態管理（`setEstimateFormContext`, `getEstimateFormContextSnapshot`, `bumpEstimateFormGeneration` 等）の既存ロジックは破壊せずそのまま維持した。 

### Testing
- `node --check app.js` を実行して構文チェックを行い問題は検出されませんでした。 
- `git diff --check` を実行して差分チェックを行い問題は検出されませんでした。 
- コード上の初期化前参照箇所を確認し、`getEstimateFormContextSnapshot()` が必ず初期化済みの `estimateFormState` を参照する構造になっていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a936a21488333aeec146543492264)