### PR TITLE
第2-D: 建設業許可案件の見積候補プレビューを追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -433,6 +433,8 @@ const CLICK_ACTION_HANDLERS = {
     const caseId = button.dataset.caseId;
     return openCaseBusinessDocumentPrintPreview(caseId, "acceptance_certificate");
   },
+  show_construction_estimate_preview: handleCaseListAction,
+  close_construction_estimate_preview: handleCaseListAction,
   export_estimate_excel: handleEstimateListAction,
   export_invoice_excel_from_estimate: handleEstimateListAction,
   edit_sale: handleSalesListAction,
@@ -3431,6 +3433,150 @@ function getConstructionEstimateTemplateSummary(procedureType) {
   };
 }
 
+const CONSTRUCTION_ESTIMATE_PREVIEW_ITEM_TYPE_ORDER = ["reward", "advance", "expense", "discount"];
+
+function getCaseProcedureType(caseItem) {
+  const detailProcedureType = normalizeConstructionProcedureType(
+    getConstructionCaseDetailForCase(caseItem?.id)?.procedure_type
+  );
+  if (detailProcedureType) return detailProcedureType;
+  return normalizeConstructionProcedureType(caseItem?.procedureType ?? caseItem?.procedure_type);
+}
+
+function getConstructionEstimatePreviewItems(caseItem) {
+  const procedureType = getCaseProcedureType(caseItem);
+  const templates = getConstructionEstimateTemplates(procedureType);
+  return {
+    caseId: caseItem?.id || "",
+    customerName: caseItem?.customerName || caseItem?.customer_name || "顧客不明",
+    caseName: caseItem?.caseName || caseItem?.case_name || "案件名未設定",
+    procedureType,
+    procedureLabel: procedureType ? getConstructionProcedureLabel(procedureType) : "手続種別未設定",
+    items: templates.map((item) => ({ ...item })),
+  };
+}
+
+function groupEstimatePreviewItemsByType(items) {
+  const grouped = new Map(CONSTRUCTION_ESTIMATE_PREVIEW_ITEM_TYPE_ORDER.map((itemType) => [itemType, []]));
+  (Array.isArray(items) ? items : []).forEach((item) => {
+    const itemType = normalizeEstimateItemType(item?.itemType ?? item?.item_type);
+    if (!grouped.has(itemType)) grouped.set(itemType, []);
+    grouped.get(itemType).push({ ...item, itemType });
+  });
+  return Array.from(grouped.entries())
+    .filter(([, groupItems]) => groupItems.length > 0)
+    .map(([itemType, groupItems]) => ({ itemType, items: groupItems }));
+}
+
+function formatEstimatePreviewUnitPrice(value) {
+  if (value === null || value === undefined || value === "") return "未設定";
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return "未設定";
+  return formatCurrency(amount);
+}
+
+function calculateEstimatePreviewTotal(items) {
+  return (Array.isArray(items) ? items : []).reduce((total, item) => {
+    if (item?.defaultUnitPrice === null || item?.defaultUnitPrice === undefined || item?.defaultUnitPrice === "") return total;
+    const unitPrice = Number(item.defaultUnitPrice);
+    const quantity = Number(item?.defaultQuantity ?? 1);
+    if (!Number.isFinite(unitPrice) || !Number.isFinite(quantity)) return total;
+    return total + (unitPrice * quantity);
+  }, 0);
+}
+
+function renderConstructionEstimatePreview(caseItem) {
+  const preview = getConstructionEstimatePreviewItems(caseItem);
+  if (!preview.procedureType) {
+    return `
+      <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
+        <div class="construction-estimate-preview-header">
+          <h3>見積候補プレビュー</h3>
+          <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
+        </div>
+        <p class="meta">この案件には手続種別が設定されていないため、見積候補を表示できません。</p>
+      </section>
+    `;
+  }
+  if (!preview.items.length) {
+    return `
+      <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
+        <div class="construction-estimate-preview-header">
+          <h3>見積候補プレビュー</h3>
+          <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
+        </div>
+        <p class="meta">対象手続：${escapeHtml(preview.procedureLabel)}</p>
+        <p class="meta">この手続種別に対応する見積候補は登録されていません。</p>
+      </section>
+    `;
+  }
+
+  const hasUnsetUnitPrice = preview.items.some((item) => item.defaultUnitPrice === null || item.defaultUnitPrice === undefined || item.defaultUnitPrice === "");
+  const hasPricedItems = preview.items.some((item) => item.defaultUnitPrice !== null && item.defaultUnitPrice !== undefined && item.defaultUnitPrice !== "" && Number.isFinite(Number(item.defaultUnitPrice)));
+  const previewTotal = calculateEstimatePreviewTotal(preview.items);
+  const previewTotalLabel = hasPricedItems
+    ? `単価設定済み分合計：${formatCurrency(previewTotal)}${hasUnsetUnitPrice ? "（金額未設定の候補があります）" : ""}`
+    : "単価未設定のため合計は未計算です（金額未設定の候補があります）";
+  const groupedSections = groupEstimatePreviewItemsByType(preview.items).map(({ itemType, items }) => `
+    <section class="construction-estimate-preview-group">
+      <h4>${escapeHtml(getEstimateItemTypeLabel(itemType))}</h4>
+      <div class="construction-estimate-preview-table-wrap">
+        <table class="construction-estimate-preview-table">
+          <thead>
+            <tr>
+              <th>区分</th>
+              <th>項目名</th>
+              <th>初期数量</th>
+              <th>初期単価</th>
+              <th>任意項目</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map((item) => `
+              <tr>
+                <td>${escapeHtml(getEstimateItemTypeLabel(item.itemType))}</td>
+                <td>${escapeHtml(item.itemName)}</td>
+                <td>${escapeHtml(String(item.defaultQuantity ?? 1))}</td>
+                <td>${escapeHtml(formatEstimatePreviewUnitPrice(item.defaultUnitPrice))}</td>
+                <td>${item.optional ? "任意" : "標準"}</td>
+                <td>${escapeHtml(item.description || "-")}</td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `).join("");
+
+  return `
+    <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
+      <div class="construction-estimate-preview-header">
+        <div>
+          <h3>見積候補プレビュー</h3>
+          <p class="meta">${escapeHtml(preview.customerName)}｜${escapeHtml(preview.caseName)}</p>
+        </div>
+        <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
+      </div>
+      <p class="meta">対象手続：${escapeHtml(preview.procedureLabel)} / 候補数：${preview.items.length}件</p>
+      <p class="meta">プレビュー合計：${escapeHtml(previewTotalLabel)}</p>
+      ${groupedSections}
+    </section>
+  `;
+}
+
+function setConstructionEstimatePreviewVisibility(caseId, visible) {
+  const item = caseList?.querySelector(`.case-card[data-id="${CSS.escape(String(caseId || ""))}"]`);
+  const previewWrap = item?.querySelector(".construction-estimate-preview-wrap");
+  const targetCase = state.cases.find((entry) => String(entry.id) === String(caseId));
+  if (!previewWrap || !targetCase) {
+    showAppMessage("見積候補プレビュー対象の案件が見つかりません。", true);
+    return;
+  }
+  previewWrap.hidden = !visible;
+  previewWrap.innerHTML = visible ? renderConstructionEstimatePreview(targetCase) : "";
+}
+
 function getBusinessResourceSortOrder(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -4149,6 +4295,14 @@ async function handleCaseListAction(event) {
   }
   if (listAction === "apply_construction_case_template") {
     await applyConstructionCaseTemplate(id);
+    return;
+  }
+  if (listAction === "show_construction_estimate_preview") {
+    setConstructionEstimatePreviewVisibility(id, true);
+    return;
+  }
+  if (listAction === "close_construction_estimate_preview") {
+    setConstructionEstimatePreviewVisibility(id, false);
     return;
   }
   if (listAction === "print_case_delivery_note") return openCaseBusinessDocumentPrintPreview(id, "delivery_note");
@@ -9718,6 +9872,7 @@ function renderCases() {
     const title = node.querySelector(".title");
     const statusBadge = node.querySelector(".case-status-badge");
     const summaryGrid = node.querySelector(".case-card-summary-grid");
+    const previewWrap = node.querySelector(".construction-estimate-preview-wrap");
     const caseWorkMeta = node.querySelector(".case-work-meta");
     const profitMeta = node.querySelector(".profit-meta");
     const rowActions = node.querySelector(".row-actions");
@@ -9775,6 +9930,10 @@ function renderCases() {
         { url: entry.receiptUrl, label: "領収書" },
       ]);
     }
+    if (previewWrap) {
+      previewWrap.hidden = true;
+      previewWrap.innerHTML = "";
+    }
     if (caseWorkMeta) {
       const auditSummary = auditAlerts.length ? auditAlerts.join(" / ") : "問題なし";
       caseWorkMeta.textContent = `進行監査: ${auditSummary}${hasSaleAmountMismatch ? " / ⚠ 金額不一致あり" : ""}`;
@@ -9825,6 +9984,16 @@ function renderCases() {
       btn.textContent = config.label;
       rowActions.appendChild(btn);
     });
+    if (rowActions && !rowActions.querySelector(".case-estimate-preview-btn")) {
+      const estimatePreviewBtn = document.createElement("button");
+      estimatePreviewBtn.type = "button";
+      estimatePreviewBtn.className = "secondary-btn case-estimate-preview-btn";
+      estimatePreviewBtn.dataset.action = "show_construction_estimate_preview";
+      estimatePreviewBtn.dataset.listAction = "show_construction_estimate_preview";
+      estimatePreviewBtn.dataset.caseId = entry.id;
+      estimatePreviewBtn.textContent = "見積候補を表示";
+      rowActions.appendChild(estimatePreviewBtn);
+    }
     if (rowActions && !rowActions.querySelector(".case-construction-template-btn")) {
       const constructionTemplateBtn = document.createElement("button");
       constructionTemplateBtn.type = "button";

--- a/index.html
+++ b/index.html
@@ -1605,6 +1605,7 @@
             <span class="case-status-badge"></span>
           </div>
           <div class="case-card-summary-grid"></div>
+          <div class="construction-estimate-preview-wrap" hidden></div>
           <p class="meta case-work-meta case-card-detail-summary"></p>
           <p class="meta profit-meta case-card-profit"></p>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1399,3 +1399,60 @@ button:disabled {
     gap: 0.1rem;
   }
 }
+
+.construction-estimate-preview-wrap {
+  margin-top: 0.75rem;
+}
+
+.construction-estimate-preview {
+  border: 1px solid #bfdbfe;
+  border-radius: 12px;
+  background: #f8fbff;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.construction-estimate-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.construction-estimate-preview-header h3,
+.construction-estimate-preview-group h4 {
+  margin: 0;
+}
+
+.construction-estimate-preview-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.construction-estimate-preview-table-wrap {
+  overflow-x: auto;
+}
+
+.construction-estimate-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+  background: #fff;
+}
+
+.construction-estimate-preview-table th,
+.construction-estimate-preview-table td {
+  border: 1px solid var(--border);
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+  vertical-align: top;
+  font-size: 0.88rem;
+}
+
+.construction-estimate-preview-table th {
+  background: #eef4ff;
+  color: #1f2937;
+  white-space: nowrap;
+}


### PR DESCRIPTION
### Motivation
- 案件の `procedure_type` に応じて第2-Cの `CONSTRUCTION_ESTIMATE_ITEM_TEMPLATES` から標準見積候補を取得し、画面上でプレビュー表示できるようにするため。今回の範囲はあくまでプレビュー表示までとする。 

### Description
- 案件一覧カード内にプレビュー領域を追加し、カード右側の操作ボタン群に「見積候補を表示」ボタンを追加して同カード内で開閉するUIを実装した（変更ファイル: `index.html`, `styles.css`, `app.js`）。
- `getCaseProcedureType(caseItem)` を追加して `construction_case_details` の `procedure_type` を優先し、案件本体の `procedureType / procedure_type` をフォールバックで参照するようにした。 
- `getConstructionEstimatePreviewItems(caseItem)`, `groupEstimatePreviewItemsByType(items)`, `formatEstimatePreviewUnitPrice(value)`, `calculateEstimatePreviewTotal(items)`, `renderConstructionEstimatePreview(caseItem)`, `setConstructionEstimatePreviewVisibility(caseId, visible)` を追加し、テンプレート取得・区分（報酬→立替金→実費→値引き）でのグループ化・プレビュー描画を行うようにした。 
- `defaultUnitPrice` が `null`/`undefined`/空文字のときは単価を「未設定」と表示し、0円と表示しないようにし、合計は単価が設定されている項目のみで計算して、単価未設定のみの場合は「単価未設定のため合計は未計算です」の文言を出す挙動にした。 
- 表示は既存UIに合わせたカード＋テーブル形式で実装し、プレビューから見積フォームへの自動反映や `estimate_items` への保存、Supabase SQL / 新規DBテーブル追加、`estimateFormState` / `sessionStorage` / `visibilitychange` 周辺の変更は行っていない。 

### Testing
- `node --check app.js` を実行し構文チェックは通過した（成功）。
- `git diff --check` を実行し差分チェックは問題なし（成功）。
- 変更差分を確認し、`estimate_items` への挿入、見積フォーム自動挿入、Supabase SQL の追加、新規DBテーブル追加、`estimateFormState` / `sessionStorage` / `visibilitychange` 周辺の変更が行われていないことを `rg` / `git diff` ベースで確認した（成功）。
- プレビュー表示ロジックについて `CONSTRUCTION_ESTIMATE_ITEM_TEMPLATES` から procedure_type ごとに候補を取得できること、`defaultUnitPrice: null` を 0円表示にしていないこと、区分ラベル（報酬・立替金・実費・値引き）で表示することをコードレビューで確認した（成功）。

(実ブラウザによる表示・Console の完全確認はこの環境で行えていないため、ユーザー側で案内した手順に従い動作確認をお願いします。)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1acc739c208333bba7852e987132fa)