### PR TITLE
第2-D補修：建設業許可見積候補プレビューUIと表示条件を改善

### DIFF
--- a/app.js
+++ b/app.js
@@ -3506,11 +3506,25 @@ function getConstructionEstimateTemplateSummary(procedureType) {
 const CONSTRUCTION_ESTIMATE_PREVIEW_ITEM_TYPE_ORDER = ["reward", "advance", "expense", "discount"];
 
 function getCaseProcedureType(caseItem) {
+  const constructionDetail = getConstructionCaseDetailForCase(caseItem?.id);
   const detailProcedureType = normalizeConstructionProcedureType(
-    getConstructionCaseDetailForCase(caseItem?.id)?.procedure_type
+    constructionDetail?.procedure_type ?? constructionDetail?.procedureType
   );
   if (detailProcedureType) return detailProcedureType;
-  return normalizeConstructionProcedureType(caseItem?.procedureType ?? caseItem?.procedure_type);
+
+  return normalizeConstructionProcedureType(
+    caseItem?.procedureType
+      ?? caseItem?.procedure_type
+      ?? caseItem?.constructionProcedureType
+      ?? caseItem?.construction_procedure_type
+  );
+}
+
+function isConstructionEstimatePreviewAvailable(caseItem) {
+  const procedureType = getCaseProcedureType(caseItem);
+  if (!procedureType) return false;
+  if (!CONSTRUCTION_PROCEDURE_TYPE_LABELS[procedureType]) return false;
+  return getConstructionEstimateTemplates(procedureType).length > 0;
 }
 
 function getConstructionEstimatePreviewItems(caseItem) {
@@ -3557,80 +3571,63 @@ function calculateEstimatePreviewTotal(items) {
 
 function renderConstructionEstimatePreview(caseItem) {
   const preview = getConstructionEstimatePreviewItems(caseItem);
-  if (!preview.procedureType) {
-    return `
-      <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
-        <div class="construction-estimate-preview-header">
-          <h3>見積候補プレビュー</h3>
-          <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
-        </div>
-        <p class="meta">この案件には手続種別が設定されていないため、見積候補を表示できません。</p>
-      </section>
-    `;
-  }
-  if (!preview.items.length) {
-    return `
-      <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
-        <div class="construction-estimate-preview-header">
-          <h3>見積候補プレビュー</h3>
-          <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
-        </div>
-        <p class="meta">対象手続：${escapeHtml(preview.procedureLabel)}</p>
-        <p class="meta">この手続種別に対応する見積候補は登録されていません。</p>
-      </section>
-    `;
-  }
+  if (!preview.procedureType || !preview.items.length) return "";
 
   const hasUnsetUnitPrice = preview.items.some((item) => item.defaultUnitPrice === null || item.defaultUnitPrice === undefined || item.defaultUnitPrice === "");
-  const hasPricedItems = preview.items.some((item) => item.defaultUnitPrice !== null && item.defaultUnitPrice !== undefined && item.defaultUnitPrice !== "" && Number.isFinite(Number(item.defaultUnitPrice)));
-  const previewTotal = calculateEstimatePreviewTotal(preview.items);
-  const previewTotalLabel = hasPricedItems
-    ? `単価設定済み分合計：${formatCurrency(previewTotal)}${hasUnsetUnitPrice ? "（金額未設定の候補があります）" : ""}`
-    : "単価未設定のため合計は未計算です（金額未設定の候補があります）";
-  const groupedSections = groupEstimatePreviewItemsByType(preview.items).map(({ itemType, items }) => `
-    <section class="construction-estimate-preview-group">
-      <h4>${escapeHtml(getEstimateItemTypeLabel(itemType))}</h4>
-      <div class="construction-estimate-preview-table-wrap">
-        <table class="construction-estimate-preview-table">
-          <thead>
-            <tr>
-              <th>区分</th>
-              <th>項目名</th>
-              <th>初期数量</th>
-              <th>初期単価</th>
-              <th>任意項目</th>
-              <th>説明</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${items.map((item) => `
+  const groupedSections = groupEstimatePreviewItemsByType(preview.items).map(({ itemType, items }) => {
+    const itemTypeLabel = getEstimateItemTypeLabel(itemType);
+    return `
+      <details class="construction-estimate-preview-group"${itemType === "reward" ? " open" : ""}>
+        <summary>
+          <span>${escapeHtml(itemTypeLabel)}</span>
+          <span class="meta">${items.length}件</span>
+        </summary>
+        <div class="construction-estimate-preview-table-wrap">
+          <table class="construction-estimate-preview-table">
+            <thead>
               <tr>
-                <td>${escapeHtml(getEstimateItemTypeLabel(item.itemType))}</td>
-                <td>${escapeHtml(item.itemName)}</td>
-                <td>${escapeHtml(String(item.defaultQuantity ?? 1))}</td>
-                <td>${escapeHtml(formatEstimatePreviewUnitPrice(item.defaultUnitPrice))}</td>
-                <td>${item.optional ? "任意" : "標準"}</td>
-                <td>${escapeHtml(item.description || "-")}</td>
+                <th>区分</th>
+                <th>項目名</th>
+                <th>初期数量</th>
+                <th>初期単価</th>
+                <th>任意項目</th>
+                <th>説明</th>
               </tr>
-            `).join("")}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  `).join("");
+            </thead>
+            <tbody>
+              ${items.map((item) => `
+                <tr>
+                  <td>${escapeHtml(itemTypeLabel)}</td>
+                  <td>${escapeHtml(item.itemName)}</td>
+                  <td>${escapeHtml(String(item.defaultQuantity ?? 1))}</td>
+                  <td>${escapeHtml(formatEstimatePreviewUnitPrice(item.defaultUnitPrice))}</td>
+                  <td>${item.optional ? "任意" : "標準"}</td>
+                  <td>${escapeHtml(item.description || "-")}</td>
+                </tr>
+              `).join("")}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    `;
+  }).join("");
 
   return `
     <section class="construction-estimate-preview" aria-label="見積候補プレビュー">
       <div class="construction-estimate-preview-header">
         <div>
           <h3>見積候補プレビュー</h3>
-          <p class="meta">${escapeHtml(preview.customerName)}｜${escapeHtml(preview.caseName)}</p>
+          <p class="meta">対象手続：${escapeHtml(preview.procedureLabel)} / 候補数：${preview.items.length}件</p>
+          ${hasUnsetUnitPrice ? '<p class="meta warning-text">単価未設定の候補があります</p>' : ""}
         </div>
         <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
       </div>
-      <p class="meta">対象手続：${escapeHtml(preview.procedureLabel)} / 候補数：${preview.items.length}件</p>
-      <p class="meta">プレビュー合計：${escapeHtml(previewTotalLabel)}</p>
-      ${groupedSections}
+      <div class="construction-estimate-preview-groups">
+        ${groupedSections}
+      </div>
+      <div class="construction-estimate-preview-footer">
+        <button type="button" class="secondary-btn" data-action="close_construction_estimate_preview" data-list-action="close_construction_estimate_preview" data-case-id="${escapeHtml(preview.caseId)}">閉じる</button>
+      </div>
     </section>
   `;
 }
@@ -3642,6 +3639,19 @@ function setConstructionEstimatePreviewVisibility(caseId, visible) {
   if (!previewWrap || !targetCase) {
     showAppMessage("見積候補プレビュー対象の案件が見つかりません。", true);
     return;
+  }
+  if (visible && !isConstructionEstimatePreviewAvailable(targetCase)) {
+    previewWrap.hidden = true;
+    previewWrap.innerHTML = "";
+    showAppMessage("この案件には表示できる建設業許可の見積候補がありません。", true);
+    return;
+  }
+  if (visible) {
+    caseList?.querySelectorAll(".construction-estimate-preview-wrap").forEach((wrap) => {
+      if (wrap === previewWrap) return;
+      wrap.hidden = true;
+      wrap.innerHTML = "";
+    });
   }
   previewWrap.hidden = !visible;
   previewWrap.innerHTML = visible ? renderConstructionEstimatePreview(targetCase) : "";
@@ -10292,7 +10302,7 @@ function renderCases() {
       btn.textContent = config.label;
       rowActions.appendChild(btn);
     });
-    if (rowActions && !rowActions.querySelector(".case-estimate-preview-btn")) {
+    if (rowActions && isConstructionEstimatePreviewAvailable(entry) && !rowActions.querySelector(".case-estimate-preview-btn")) {
       const estimatePreviewBtn = document.createElement("button");
       estimatePreviewBtn.type = "button";
       estimatePreviewBtn.className = "secondary-btn case-estimate-preview-btn";

--- a/styles.css
+++ b/styles.css
@@ -1411,6 +1411,8 @@ button:disabled {
   padding: 0.85rem;
   display: grid;
   gap: 0.65rem;
+  max-height: 420px;
+  overflow-y: auto;
 }
 
 .construction-estimate-preview-header {
@@ -1419,6 +1421,13 @@ button:disabled {
   align-items: flex-start;
   gap: 0.75rem;
   flex-wrap: wrap;
+  position: sticky;
+  top: -0.85rem;
+  z-index: 1;
+  margin: -0.85rem -0.85rem 0;
+  padding: 0.85rem;
+  background: #f8fbff;
+  border-bottom: 1px solid #dbeafe;
 }
 
 .construction-estimate-preview-header h3,
@@ -1426,13 +1435,45 @@ button:disabled {
   margin: 0;
 }
 
-.construction-estimate-preview-group {
+.construction-estimate-preview-groups {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.5rem;
+}
+
+.construction-estimate-preview-group {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.construction-estimate-preview-group summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.7rem;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.construction-estimate-preview-group[open] summary {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.construction-estimate-preview-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.2rem;
+}
+
+.warning-text {
+  color: #b45309;
+  font-weight: 700;
 }
 
 .construction-estimate-preview-table-wrap {
   overflow-x: auto;
+  padding: 0.7rem;
 }
 
 .construction-estimate-preview-table {


### PR DESCRIPTION
### Motivation
- 案件一覧での建設業許可見積候補プレビューが画面を占有したり対象外案件にもボタンが表示される問題を解消するためのUI/表示条件補修です。
- プレビューの同時展開や閉じ操作の使い勝手を改善して一覧の一覧性を維持することを目的としています。

### Description
- `getCaseProcedureType` を整理し、優先順位を `construction_case_details` の `procedure_type` → cases 側の `procedureType` / `procedure_type` / `constructionProcedureType` / `construction_procedure_type` の順に統一しました。関数名はそのまま再利用しています。 (変更箇所: `app.js`)
- 表示可否判定として `isConstructionEstimatePreviewAvailable(caseItem)` を追加し、対象手続が建設業許可7種でテンプレートが存在する案件だけに `見積候補を表示` ボタンを生成するようにしました（非対象はボタン自体を出さない）。 (変更箇所: `app.js`)
- プレビュー表示をコンパクト化し、全体に `max-height: 420px` と `overflow-y: auto` を設定、区分ごとに折りたたみ（`<details>`）表示し初期は `reward` を開いた状態に変更、ヘッダーを sticky にして下部にも閉じボタンを追加しました（同時展開は新しいプレビューを開くと既存を自動で閉じる）。 (変更箇所: `app.js`, `styles.css`)
- `defaultUnitPrice` が `null` / 空 / 不正値の場合は `0円` ではなく `未設定` を表示する既存のフォーマットを維持しました（表示内容は対象手続・候補数・区分・項目名・初期数量・初期単価・任意項目・説明 に絞る）。 (変更箇所: `app.js`)
- 見積フォームや `estimate_items` への保存、Supabase SQL、`sessionStorage` / `visibilitychange` / `pagehide` / `blur` / `focus` 周辺などは禁止対象は一切変更していません。変更ファイルは `app.js` と `styles.css` のみです.

### Testing
- `node --check app.js` は成功しました。
- `git diff --check` は問題ありませんでした（差分の静的チェックを実行済み）。
- コード上で `getCaseProcedureType` / `isConstructionEstimatePreviewAvailable` / `getConstructionEstimateTemplates` / `renderConstructionEstimatePreview` / `setConstructionEstimatePreviewVisibility` のロジックと、`case-estimate-preview-btn` の生成条件、`max-height: 420px` / `overflow-y: auto` などの CSS が適用されるように変更を確認しました（検索確認に `rg` を使用）。
- UI の振る舞い（上部・下部の閉じるボタン、区分折りたたみ、同時展開1件制御、テンプレート未存在時にボタンを出さない等）はコード上で実装済みですが、実ブラウザでの視覚チェックはこの環境で実行していないため「コード上確認済み／実画面確認はユーザー側で必要」です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae621fa34833397837fecf8b924eb)