### PR TITLE
Fix estimate PDF memo precedence

### DIFF
--- a/app.js
+++ b/app.js
@@ -11551,8 +11551,10 @@ function buildEstimateDocumentFromEstimate(estimate) {
 
   const estimateDate = estimate.estimateDate || toDateString(new Date());
   const expenseNotice = "実費・法定費用は申請先確認後に別途精算";
+  const customEstimateMemo = asTrimmedText(estimate?.memo || "");
   const noteLines = [getCustomerFacingEstimateNotice(), asTrimmedText(appSettings.estimateNote || "") || ""];
   if (expenseTotal + advanceTotal <= 0) noteLines.push(expenseNotice);
+  const defaultEstimateNote = noteLines.filter(Boolean).join("\n");
   return {
     customerName: estimate.customerName || "顧客名未設定",
     subject: estimate.estimateTitle || "見積内容",
@@ -11570,7 +11572,8 @@ function buildEstimateDocumentFromEstimate(estimate) {
     total: estimate.total ?? 0,
     paymentTerms: `お支払い条件：請求書受領後${getDefaultInvoiceDueDays()}日以内に銀行振込`,
     taxRate: getCurrentTaxRate(),
-    note: noteLines.filter(Boolean).join("\n"),
+    note: customEstimateMemo || defaultEstimateNote,
+    hasCustomEstimateMemo: Boolean(customEstimateMemo),
   };
 }
 
@@ -12002,7 +12005,7 @@ body {
       ${receiptMetaHtml}
       <section class="info-section">
         <h3>${isInvoice ? "備考" : "備考"}</h3>
-        <div class="note-box">${escapeHtml(isInvoice ? (documentData.note || "") : `${documentData.note || ""}\n${documentData.paymentTerms || "支払条件: 記載なし"}\n有効期限: ${documentData.validUntil || "記載なし"}`.trim())}</div>
+        <div class="note-box">${escapeHtml(isInvoice || documentData.hasCustomEstimateMemo ? (documentData.note || "") : `${documentData.note || ""}\n${documentData.paymentTerms || "支払条件: 記載なし"}\n有効期限: ${documentData.validUntil || "記載なし"}`.trim())}</div>
       </section>
     </section>
 </main>


### PR DESCRIPTION
## Summary
- 見積書PDF出力時、保存済みの見積書備考 `estimate.memo` がある場合は入力備考のみを優先表示するよう修正しました。
- 入力備考が空欄の場合のみ、従来の既定備考を使用します。
- 見積書備考がある場合は、支払条件や有効期限の自動追記で入力備考が埋もれないようにしました。

## Scope
- 備考欄 textarea: `id="estimate-memo"` / `name="memo"`
- 保存キー: `estimates.memo` / `estimate.memo`
- PDF参照キー: `estimate.memo`
- 入力ありの場合: 入力備考のみ優先表示
- 空欄の場合: 既定備考を使用
- 変更ファイル: `app.js`

## Validation
- `git status`
- `git diff -- app.js`
- `node --check app.js`
- `git diff --check`
- GitHub compare: `main...codex/fix-estimate-memo-pdf` が `app.js` 1ファイルのみであることを確認

## Notes
- `index.html` / `styles.css` / 第2-E / `item_type` / 明細 / 金額計算 / 請求書 / 請求Excel の差分はこのPRに含めていません。