### PR TITLE
日報一覧の期間UIと件数表示を添付デザインに調整

### DIFF
--- a/app.js
+++ b/app.js
@@ -546,7 +546,6 @@ const CLICK_ACTION_HANDLERS = {
   select_all_fixed_expenses: ()=>{ setAllSelections('selectedFixedExpenseIds', state.fixedExpenses||[], true); renderFixedExpenses(); },
   clear_all_fixed_expenses: ()=>{ setAllSelections('selectedFixedExpenseIds', state.fixedExpenses||[], false); renderFixedExpenses(); },
   bulk_delete_fixed_expenses: ()=>handleGenericBulkDelete({label:'固定費', table:'fixed_expenses', stateKey:'fixedExpenses', selectionKey:'selectedFixedExpenseIds', render:renderFixedExpenses}),
-  set_daily_report_view_mode: (event, button) => setDailyReportViewMode(button?.dataset?.viewMode),
   move_daily_report_period: (event, button) => moveDailyReportPeriod(Number(button?.dataset?.periodStep || 0)),
   reset_daily_report_period: resetDailyReportPeriod,
   change_daily_report_page: (event, button) => changeDailyReportPage(Number(button?.dataset?.pageStep || 0)),
@@ -950,9 +949,14 @@ const dailyReportAlertListWrap = document.getElementById("daily-report-alert-lis
 const dailyReportSummaryList = document.getElementById("daily-report-summary-list");
 const dailyReportSearchInput = document.getElementById("daily-report-search-input");
 const dailyReportFilterClearBtn = document.getElementById("daily-report-filter-clear-btn");
-const dailyReportFilterCount = document.getElementById("daily-report-filter-count");
+const dailyReportViewModeInputs = document.querySelectorAll("[data-daily-report-view-mode]");
+const dailyReportPeriodField = document.getElementById("daily-report-period-field");
 const dailyReportPeriodNav = document.getElementById("daily-report-period-nav");
 const dailyReportPeriodLabel = document.getElementById("daily-report-period-label");
+const dailyReportMatchedCount = document.getElementById("daily-report-matched-count");
+const dailyReportVisibleRange = document.getElementById("daily-report-visible-range");
+const dailyReportTotalCount = document.getElementById("daily-report-total-count");
+const dailyReportSelectedCount = document.getElementById("daily-report-selected-count");
 const dailyReportPeriodPrevBtn = document.getElementById("daily-report-period-prev");
 const dailyReportPeriodCurrentBtn = document.getElementById("daily-report-period-current");
 const dailyReportPeriodNextBtn = document.getElementById("daily-report-period-next");
@@ -1204,6 +1208,9 @@ function bindEvents() {
   expensesSearchInput?.addEventListener("input", handleExpensesSearchInput);
   if (expensesFilterClearBtn) expensesFilterClearBtn.dataset.action = "clear_expenses_search";
   dailyReportSearchInput?.addEventListener("input", handleDailyReportSearchInput);
+  dailyReportViewModeInputs.forEach((input) => {
+    input.addEventListener("change", handleDailyReportViewModeChange);
+  });
   if (dailyReportFilterClearBtn) dailyReportFilterClearBtn.dataset.action = "clear_daily_report_filters";
   window.addEventListener("resize", updateDailyReportTextToggleVisibility);
   permitHearingSearchInput?.addEventListener("input", handlePermitHearingSearchInput);
@@ -2420,6 +2427,11 @@ function handleDailyReportSearchInput(event) {
   state.dailyReportSearchQuery = String(event?.target?.value ?? "").trim().toLowerCase();
   state.dailyReportCurrentPage = 1;
   safeRender("dailyReports", renderDailyReports);
+}
+
+function handleDailyReportViewModeChange(event) {
+  if (!event?.target?.checked) return;
+  setDailyReportViewMode(event.target.value);
 }
 
 function handlePermitHearingSearchInput(event) {
@@ -9326,20 +9338,20 @@ function renderDailyReports() {
     dailyReportsEmpty.textContent = "条件に一致する日報はありません。";
   }
 
+  const range = hasPageRows ? `${view.rangeStart}～${view.rangeEnd}件` : "0件";
   if (dailyReportPeriodLabel) dailyReportPeriodLabel.textContent = `${view.period.label}：${view.periodRows.length}件`;
-  if (dailyReportFilterCount) {
-    const range = hasPageRows ? `${view.rangeStart}～${view.rangeEnd}件` : "0件";
-    dailyReportFilterCount.textContent = `表示中 ${range} / 条件一致${view.filteredRows.length}件 / 全${view.sortedRows.length}件 / 選択${selectedIds.size}件`;
-  }
+  if (dailyReportMatchedCount) dailyReportMatchedCount.textContent = `${view.filteredRows.length}件`;
+  if (dailyReportVisibleRange) dailyReportVisibleRange.textContent = range;
+  if (dailyReportTotalCount) dailyReportTotalCount.textContent = `${view.sortedRows.length}件`;
+  if (dailyReportSelectedCount) dailyReportSelectedCount.textContent = `${selectedIds.size}件`;
 
-  document.querySelectorAll("[data-daily-report-view-mode]").forEach((button) => {
-    const isActive = button.dataset.viewMode === state.dailyReportViewMode;
-    button.classList.toggle("is-active", isActive);
-    button.setAttribute("aria-pressed", String(isActive));
+  dailyReportViewModeInputs.forEach((input) => {
+    input.checked = input.value === state.dailyReportViewMode;
   });
 
   const isAllPeriod = state.dailyReportViewMode === "all";
   const isWeekPeriod = state.dailyReportViewMode === "week";
+  if (dailyReportPeriodField) dailyReportPeriodField.hidden = isAllPeriod;
   if (dailyReportPeriodNav) dailyReportPeriodNav.hidden = isAllPeriod;
   if (dailyReportPeriodPrevBtn) dailyReportPeriodPrevBtn.textContent = isWeekPeriod ? "前週" : "前月";
   if (dailyReportPeriodCurrentBtn) dailyReportPeriodCurrentBtn.textContent = isWeekPeriod ? "今週" : "今月";

--- a/index.html
+++ b/index.html
@@ -1524,29 +1524,59 @@
             <section class="panel report-list-panel subtab-panel" data-parent-tab="daily-reports" data-subtab="list" hidden>
               <h2>日報一覧</h2>
               <div class="search-filter-bar daily-report-filter-bar">
-                <label class="inline-field" for="daily-report-search-input">
+                <fieldset class="daily-report-view-mode-field">
+                  <legend>表示単位</legend>
+                  <div class="daily-report-view-mode-options">
+                    <label class="daily-report-view-mode-option">
+                      <input type="radio" name="daily-report-view-mode" value="all" data-daily-report-view-mode />
+                      全期間
+                    </label>
+                    <label class="daily-report-view-mode-option">
+                      <input type="radio" name="daily-report-view-mode" value="month" data-daily-report-view-mode checked />
+                      月別
+                    </label>
+                    <label class="daily-report-view-mode-option">
+                      <input type="radio" name="daily-report-view-mode" value="week" data-daily-report-view-mode />
+                      週別
+                    </label>
+                  </div>
+                </fieldset>
+                <div id="daily-report-period-field" class="daily-report-period-field">
+                  <span class="daily-report-period-field-label">対象期間</span>
+                  <div id="daily-report-period-nav" class="daily-report-period-nav" aria-label="表示期間の移動">
+                    <button id="daily-report-period-prev" type="button" class="secondary-btn" data-action="move_daily_report_period" data-period-step="-1">前月</button>
+                    <button id="daily-report-period-current" type="button" class="secondary-btn" data-action="reset_daily_report_period">今月</button>
+                    <button id="daily-report-period-next" type="button" class="secondary-btn" data-action="move_daily_report_period" data-period-step="1">次月</button>
+                  </div>
+                </div>
+                <label class="inline-field daily-report-search-field" for="daily-report-search-input">
                   キーワード検索
                   <input id="daily-report-search-input" type="search" placeholder="案件名・作業内容・次回対応・メモで検索" />
                 </label>
-                <div class="inline-field daily-report-view-mode-field">
-                  <span>期間表示</span>
-                  <div class="daily-report-view-mode-options" role="group" aria-label="日報の期間表示">
-                    <button type="button" class="secondary-btn daily-report-view-mode-btn is-active" data-action="set_daily_report_view_mode" data-daily-report-view-mode data-view-mode="month" aria-pressed="true">月別</button>
-                    <button type="button" class="secondary-btn daily-report-view-mode-btn" data-action="set_daily_report_view_mode" data-daily-report-view-mode data-view-mode="week" aria-pressed="false">週別</button>
-                    <button type="button" class="secondary-btn daily-report-view-mode-btn" data-action="set_daily_report_view_mode" data-daily-report-view-mode data-view-mode="all" aria-pressed="false">全期間</button>
-                  </div>
-                </div>
                 <button id="daily-report-filter-clear-btn" type="button" class="secondary-btn">条件クリア</button>
               </div>
-              <div class="daily-report-period-toolbar">
-                <div id="daily-report-period-nav" class="daily-report-period-nav" aria-label="表示期間の移動">
-                  <button id="daily-report-period-prev" type="button" class="secondary-btn" data-action="move_daily_report_period" data-period-step="-1">前月</button>
-                  <button id="daily-report-period-current" type="button" class="secondary-btn" data-action="reset_daily_report_period">今月</button>
-                  <button id="daily-report-period-next" type="button" class="secondary-btn" data-action="move_daily_report_period" data-period-step="1">次月</button>
+              <div class="daily-report-filter-summary" aria-live="polite">
+                <div class="daily-report-filter-summary-card">
+                  <span>対象期間</span>
+                  <strong id="daily-report-period-label">今月：0件</strong>
                 </div>
-                <p id="daily-report-period-label" class="daily-report-period-label">今月：0件</p>
+                <div class="daily-report-filter-summary-card">
+                  <span>条件一致</span>
+                  <strong id="daily-report-matched-count">0件</strong>
+                </div>
+                <div class="daily-report-filter-summary-card">
+                  <span>表示範囲</span>
+                  <strong id="daily-report-visible-range">0件</strong>
+                </div>
+                <div class="daily-report-filter-summary-card">
+                  <span>全日報</span>
+                  <strong id="daily-report-total-count">0件</strong>
+                </div>
+                <div class="daily-report-filter-summary-card">
+                  <span>選択</span>
+                  <strong id="daily-report-selected-count">0件</strong>
+                </div>
               </div>
-              <p id="daily-report-filter-count" class="filter-count">表示中 0件 / 条件一致0件 / 全0件 / 選択0件</p>
               <div class="inline-actions">
                 <button type="button" class="secondary-btn" data-action="select_all_daily_reports">現在ページを全選択</button>
                 <button type="button" class="secondary-btn" data-action="clear_all_daily_reports">全解除</button>

--- a/styles.css
+++ b/styles.css
@@ -991,7 +991,10 @@ tbody tr:last-child td {
 
 
 .daily-report-filter-bar {
-  grid-template-columns: minmax(260px, 2fr) minmax(280px, 1.4fr) auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .daily-report-filter-bar button {
@@ -999,42 +1002,95 @@ tbody tr:last-child td {
 }
 
 .daily-report-view-mode-field {
-  display: grid;
-  gap: 0.4rem;
+  flex: 0 0 auto;
+  min-width: max-content;
+  margin: 0;
+  padding: 0.35rem 0.75rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.daily-report-view-mode-field legend {
+  padding: 0 0.2rem;
+  color: var(--muted);
+  font-size: 0.86rem;
 }
 
 .daily-report-view-mode-options,
 .daily-report-period-nav {
   display: flex;
-  gap: 0.4rem;
+  align-items: center;
+  gap: 0.7rem;
   flex-wrap: wrap;
 }
 
-.daily-report-view-mode-options button {
-  flex: 1 1 auto;
-}
-
-.daily-report-view-mode-btn.is-active {
-  background: var(--primary);
-  box-shadow: inset 0 0 0 2px #fff;
-}
-
-.daily-report-period-toolbar {
-  display: flex;
+.daily-report-view-mode-option {
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  margin: 0.7rem 0 0.45rem;
-  padding: 0.65rem;
+  gap: 0.35rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.daily-report-view-mode-option input {
+  width: auto;
+  margin: 0;
+}
+
+.daily-report-period-field {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 0.4rem;
+}
+
+.daily-report-period-field[hidden] {
+  display: none;
+}
+
+.daily-report-period-field-label {
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.daily-report-period-nav {
+  gap: 0.4rem;
+}
+
+.daily-report-period-nav button {
+  padding: 0.65rem 0.75rem;
+}
+
+.daily-report-search-field {
+  flex: 1 1 300px;
+  min-width: 240px;
+}
+
+.daily-report-filter-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.6rem;
+  margin: 0.75rem 0;
+}
+
+.daily-report-filter-summary-card {
+  min-width: 0;
+  padding: 0.7rem;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: #f8faff;
 }
 
-.daily-report-period-label {
-  flex: 1;
-  margin: 0;
-  text-align: center;
-  font-weight: 700;
+.daily-report-filter-summary-card span {
+  display: block;
+  margin-bottom: 0.3rem;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.daily-report-filter-summary-card strong {
+  display: block;
+  overflow-wrap: anywhere;
   font-size: 1rem;
 }
 
@@ -1155,12 +1211,13 @@ tbody tr:last-child td {
 
 @media (max-width: 820px) {
   .daily-report-filter-bar {
-    grid-template-columns: 1fr;
-  }
-
-  .daily-report-period-toolbar {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .daily-report-filter-bar > * {
+    width: 100%;
+    box-sizing: border-box;
   }
 
   .daily-report-period-nav button {
@@ -1268,8 +1325,7 @@ input[type="number"] {
   .daily-report-card-header { flex-direction: column; }
   .daily-report-card-actions { width: 100%; justify-content: flex-start; }
   .daily-report-card-actions button { flex: 1 1 auto; }
-  .daily-report-view-mode-options { flex-direction: column; }
-  .daily-report-period-nav { flex-direction: column; }
+  .daily-report-view-mode-options { gap: 0.8rem; }
   .daily-report-pagination { gap: 0.4rem; }
   .daily-report-pagination button { flex: 1 1 0; }
 }


### PR DESCRIPTION
## 概要

マージ済みの #284 を基点に、日報一覧の期間選択と件数表示を添付画像の構成へ寄せました。

## 変更内容

- 月別・週別・全期間の切替を、コンパクトなラジオボタン形式へ変更
- 前月／今月／次月、前週／今週／次週を「対象期間」欄へ集約
- 対象期間、条件一致、表示範囲、全日報、選択件数を5枚の集計カードで表示
- デスクトップでは横並び、820px以下では縦並びになるレスポンシブCSSを追加
- 既存の検索、ページ分割、長文省略、全選択・一括削除ロジックは維持

## 影響範囲

日報一覧の期間・件数UIのみです。Supabase、日報保存形式、登録・編集フォーム、他画面は変更していません。

## 確認

- `node --check app.js` 成功
- `git diff --check` 成功
- ローカルブラウザで月別・週別・全期間の切替を確認
- 条件クリアで当月表示へ戻ることを確認
- 390px幅で横はみ出しがないことを確認
- Consoleエラー 0件