### PR TITLE
日報一覧で対象月を直接選択できるようにする

### DIFF
--- a/app.js
+++ b/app.js
@@ -951,6 +951,9 @@ const dailyReportSearchInput = document.getElementById("daily-report-search-inpu
 const dailyReportFilterClearBtn = document.getElementById("daily-report-filter-clear-btn");
 const dailyReportViewModeInputs = document.querySelectorAll("[data-daily-report-view-mode]");
 const dailyReportPeriodField = document.getElementById("daily-report-period-field");
+const dailyReportMonthPickerField = document.getElementById("daily-report-month-picker-field");
+const dailyReportMonthPicker = document.getElementById("daily-report-month-picker");
+const dailyReportWeekPeriodLabel = document.getElementById("daily-report-week-period-label");
 const dailyReportPeriodNav = document.getElementById("daily-report-period-nav");
 const dailyReportPeriodLabel = document.getElementById("daily-report-period-label");
 const dailyReportMatchedCount = document.getElementById("daily-report-matched-count");
@@ -1211,6 +1214,7 @@ function bindEvents() {
   dailyReportViewModeInputs.forEach((input) => {
     input.addEventListener("change", handleDailyReportViewModeChange);
   });
+  dailyReportMonthPicker?.addEventListener("input", handleDailyReportMonthChange);
   if (dailyReportFilterClearBtn) dailyReportFilterClearBtn.dataset.action = "clear_daily_report_filters";
   window.addEventListener("resize", updateDailyReportTextToggleVisibility);
   permitHearingSearchInput?.addEventListener("input", handlePermitHearingSearchInput);
@@ -2432,6 +2436,18 @@ function handleDailyReportSearchInput(event) {
 function handleDailyReportViewModeChange(event) {
   if (!event?.target?.checked) return;
   setDailyReportViewMode(event.target.value);
+}
+
+function handleDailyReportMonthChange(event) {
+  const value = String(event?.target?.value || "");
+  const match = value.match(/^(\d{4})-(\d{2})$/);
+  if (!match) return;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (!Number.isInteger(year) || month < 1 || month > 12) return;
+  state.dailyReportAnchorDate = toDateString(new Date(year, month - 1, 1));
+  state.dailyReportCurrentPage = 1;
+  safeRender("dailyReports", renderDailyReports);
 }
 
 function handlePermitHearingSearchInput(event) {
@@ -9351,7 +9367,14 @@ function renderDailyReports() {
 
   const isAllPeriod = state.dailyReportViewMode === "all";
   const isWeekPeriod = state.dailyReportViewMode === "week";
+  const isMonthPeriod = state.dailyReportViewMode === "month";
+  const anchorDate = getDailyReportAnchorDate();
   if (dailyReportPeriodField) dailyReportPeriodField.hidden = isAllPeriod;
+  if (dailyReportMonthPickerField) dailyReportMonthPickerField.hidden = !isMonthPeriod;
+  if (dailyReportMonthPicker) {
+    dailyReportMonthPicker.value = `${anchorDate.getFullYear()}-${String(anchorDate.getMonth() + 1).padStart(2, "0")}`;
+  }
+  if (dailyReportWeekPeriodLabel) dailyReportWeekPeriodLabel.hidden = !isWeekPeriod;
   if (dailyReportPeriodNav) dailyReportPeriodNav.hidden = isAllPeriod;
   if (dailyReportPeriodPrevBtn) dailyReportPeriodPrevBtn.textContent = isWeekPeriod ? "前週" : "前月";
   if (dailyReportPeriodCurrentBtn) dailyReportPeriodCurrentBtn.textContent = isWeekPeriod ? "今週" : "今月";

--- a/index.html
+++ b/index.html
@@ -1542,7 +1542,13 @@
                   </div>
                 </fieldset>
                 <div id="daily-report-period-field" class="daily-report-period-field">
-                  <span class="daily-report-period-field-label">対象期間</span>
+                  <div class="daily-report-period-picker">
+                    <label id="daily-report-month-picker-field" class="inline-field daily-report-month-picker-field" for="daily-report-month-picker">
+                      対象月
+                      <input id="daily-report-month-picker" type="month" aria-label="対象月" />
+                    </label>
+                    <span id="daily-report-week-period-label" class="daily-report-period-field-label" hidden>対象週</span>
+                  </div>
                   <div id="daily-report-period-nav" class="daily-report-period-nav" aria-label="表示期間の移動">
                     <button id="daily-report-period-prev" type="button" class="secondary-btn" data-action="move_daily_report_period" data-period-step="-1">前月</button>
                     <button id="daily-report-period-current" type="button" class="secondary-btn" data-action="reset_daily_report_period">今月</button>

--- a/styles.css
+++ b/styles.css
@@ -1039,16 +1039,37 @@ tbody tr:last-child td {
 }
 
 .daily-report-period-field {
-  display: grid;
+  display: flex;
+  align-items: flex-end;
   flex: 0 0 auto;
-  gap: 0.4rem;
+  gap: 0.5rem;
 }
 
 .daily-report-period-field[hidden] {
   display: none;
 }
 
+.daily-report-period-picker {
+  display: grid;
+  align-self: stretch;
+}
+
+.daily-report-month-picker-field {
+  min-width: 145px;
+}
+
+.daily-report-month-picker-field input {
+  min-width: 145px;
+}
+
+.daily-report-month-picker-field[hidden],
+.daily-report-week-period-label[hidden] {
+  display: none;
+}
+
 .daily-report-period-field-label {
+  align-self: end;
+  padding-bottom: 0.7rem;
   color: var(--muted);
   font-size: 0.86rem;
 }
@@ -1216,6 +1237,17 @@ tbody tr:last-child td {
   }
 
   .daily-report-filter-bar > * {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .daily-report-period-field {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .daily-report-month-picker-field,
+  .daily-report-month-picker-field input {
     width: 100%;
     box-sizing: border-box;
   }


### PR DESCRIPTION
## 概要

日報一覧の月別表示に、添付画像と同じネイティブの月選択欄を追加しました。

## 変更内容

- 月別モードで「対象月」の `input type="month"` を表示
- カレンダーアイコンから年・月を直接選択可能
- 選択した `YYYY-MM` をローカル年月として処理し、タイムゾーンによる日付ずれを回避
- 月変更時に一覧・対象期間件数を更新し、ページを1ページ目へ戻す
- 週別では月入力を隠して前週／今週／次週を表示
- 全期間では対象期間操作を非表示
- 既存の前月／今月／次月操作も維持
- 390px幅では月入力と期間ボタンを縦配置し、横はみ出しを防止

## 影響範囲

日報一覧の対象期間UIのみです。Supabase、日報保存形式、登録・編集・削除、検索、ページ分割、複数選択、長文省略は変更していません。

## 確認

- `node --check app.js` 成功
- `git diff --check` 成功
- ローカルブラウザで月入力が `2026-07` を表示することを確認
- `2026-05` へ直接変更し、対象期間が `2026年5月` へ即時更新されることを確認
- 月別→週別で月入力が非表示になることを確認
- 390px幅で横はみ出しなし
- Consoleエラー 0件